### PR TITLE
add morphed_model helper

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -519,10 +519,7 @@ if (! function_exists('morphed_model')) {
             return null;
         }
 
-        return resolve_static(
-            $class,
-            'class'
-        );
+        return resolve_static($class, 'class');
     }
 }
 

--- a/helpers.php
+++ b/helpers.php
@@ -530,7 +530,7 @@ if (! function_exists('class_to_broadcast_channel')) {
 }
 
 if (! function_exists('morphed_model')) {
-    function morphed_model(string $alias): ?Illuminate\Database\Eloquent\Model
+    function morphed_model(string $alias): string
     {
         return resolve_static(
             \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($alias),

--- a/helpers.php
+++ b/helpers.php
@@ -494,47 +494,52 @@ if (! function_exists('class_to_broadcast_channel')) {
         return str_replace('\\', '.', $class)
             . ($withParam ? '.{' . \Illuminate\Support\Str::camel(class_basename($class)) . '}' : '');
     }
+}
 
-    if (! function_exists('morph_alias')) {
-        function morph_alias(string $class): string
-        {
-            $class = resolve_static($class, 'class');
+if (! function_exists('morph_alias')) {
+    function morph_alias(string $class): string
+    {
+        $class = resolve_static($class, 'class');
 
-            if (in_array(\FluxErp\Traits\HasParentMorphClass::class, class_uses_recursive($class))) {
-                /** @var \FluxErp\Traits\HasParentMorphClass $class */
-                $class = morphed_model($class::getParentMorphClass());
-            }
-
-            /** @var \Illuminate\Database\Eloquent\Model $class */
-            return \Illuminate\Database\Eloquent\Relations\Relation::getMorphAlias($class);
+        if (in_array(\FluxErp\Traits\HasParentMorphClass::class, class_uses_recursive($class))) {
+            return $class::getParentMorphClass();
         }
-    }
 
-    if (! function_exists('morph_to')) {
-        function morph_to(string $type, ?int $id = null): ?Illuminate\Database\Eloquent\Model
-        {
-            if (is_null($id) && str_contains($type, ':')) {
-                [$type, $id] = explode(':', $type);
-            }
-
-            if (is_null($id)) {
-                return null;
-            }
-
-            /** @var \Illuminate\Database\Eloquent\Model $model */
-            $model = morphed_model($type);
-
-            return $model::query()->whereKey($id)->first();
-        }
+        /** @var \Illuminate\Database\Eloquent\Model $class */
+        return \Illuminate\Database\Eloquent\Relations\Relation::getMorphAlias($class);
     }
 }
 
 if (! function_exists('morphed_model')) {
-    function morphed_model(string $alias): string
+    function morphed_model(string $alias): ?string
     {
+        $class = \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($alias);
+
+        if (is_null($class)) {
+            return null;
+        }
+
         return resolve_static(
-            \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($alias),
+            $class,
             'class'
         );
+    }
+}
+
+if (! function_exists('morph_to')) {
+    function morph_to(string $type, ?int $id = null): ?Illuminate\Database\Eloquent\Model
+    {
+        if (is_null($id) && str_contains($type, ':')) {
+            [$type, $id] = explode(':', $type);
+        }
+
+        if (is_null($id)) {
+            return null;
+        }
+
+        /** @var \Illuminate\Database\Eloquent\Model $model */
+        $model = morphed_model($type);
+
+        return $model::query()->whereKey($id)->first();
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -502,7 +502,7 @@ if (! function_exists('class_to_broadcast_channel')) {
 
             if (in_array(\FluxErp\Traits\HasParentMorphClass::class, class_uses_recursive($class))) {
                 /** @var \FluxErp\Traits\HasParentMorphClass $class */
-                $class = \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($class::getParentMorphClass());
+                $class = morphed_model($class::getParentMorphClass());
             }
 
             /** @var \Illuminate\Database\Eloquent\Model $class */
@@ -522,42 +522,19 @@ if (! function_exists('class_to_broadcast_channel')) {
             }
 
             /** @var \Illuminate\Database\Eloquent\Model $model */
-            $model = \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($type);
+            $model = morphed_model($type);
 
             return $model::query()->whereKey($id)->first();
         }
     }
 }
 
-if (! function_exists('morph_alias')) {
-    function morph_alias(string $class): string
+if (! function_exists('morphed_model')) {
+    function morphed_model(string $alias): ?Illuminate\Database\Eloquent\Model
     {
-        $class = resolve_static($class, 'class');
-
-        if (in_array(\FluxErp\Traits\HasParentMorphClass::class, class_uses_recursive($class))) {
-            /** @var \FluxErp\Traits\HasParentMorphClass $class */
-            $class = \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($class::getParentMorphClass());
-        }
-
-        /** @var \Illuminate\Database\Eloquent\Model $class */
-        return \Illuminate\Database\Eloquent\Relations\Relation::getMorphAlias($class);
-    }
-}
-
-if (! function_exists('morph_to')) {
-    function morph_to(string $type, ?int $id = null): ?Illuminate\Database\Eloquent\Model
-    {
-        if (is_null($id) && str_contains($type, ':')) {
-            [$type, $id] = explode(':', $type);
-        }
-
-        if (is_null($id)) {
-            return null;
-        }
-
-        /** @var \Illuminate\Database\Eloquent\Model $model */
-        $model = \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($type);
-
-        return $model::query()->whereKey($id)->first();
+        return resolve_static(
+            \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($alias),
+            'class'
+        );
     }
 }

--- a/resources/views/livewire/portal/ticket/ticket.blade.php
+++ b/resources/views/livewire/portal/ticket/ticket.blade.php
@@ -10,7 +10,7 @@
                     <x-input wire:model="ticket.title" :disabled="true"/>
                     <x-textarea wire:model="ticket.description" :disabled="true"/>
                     @if($ticket['model_type']
-                        && $widgetComponent = resolve_static(\Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($ticket['model_type']), 'getLivewireComponentWidget')
+                        && $widgetComponent = resolve_static(morphed_model($ticket['model_type']), 'getLivewireComponentWidget')
                     )
                         <x-card>
                             <livewire:is :component="$widgetComponent" :modelId="$ticket['model_id']" />

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -79,7 +79,7 @@
                             </div>
                             @section('content.widget')
                                 @if($ticket['model_type']
-                                    && $widgetComponent = resolve_static(\Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($ticket['model_type']), 'getLivewireComponentWidget')
+                                    && $widgetComponent = resolve_static(morphed_model($ticket['model_type']), 'getLivewireComponentWidget')
                                 )
                                     <x-card>
                                         <livewire:is :component="$widgetComponent" :modelId="$ticket['model_id']" />
@@ -181,8 +181,8 @@
                                     ]"
                                     :async-data="[
                                         'api' => route('search', $ticket['authenticatable_type'] ?
-                                            \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($ticket['authenticatable_type']) :
-                                            \FluxErp\Models\Address::class
+                                            morphed_model($ticket['authenticatable_type']) :
+                                            resolve_static(\FluxErp\Models\Address::class, 'class')
                                         ),
                                         'method' => 'POST',
                                         'params' => [

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -34,7 +34,7 @@ foreach (Relation::morphMap() as $class) {
 }
 
 Broadcast::channel(
-    class_to_broadcast_channel(Relation::getMorphedModel('user')),
+    class_to_broadcast_channel(morphed_model('user')),
     function ($user, $id) {
         return (int) $user->id === (int) $id;
     }

--- a/src/Actions/Media/UploadMedia.php
+++ b/src/Actions/Media/UploadMedia.php
@@ -26,7 +26,7 @@ class UploadMedia extends FluxAction
 
     public function performAction(): Model
     {
-        $modelInstance = app(morphed_model($this->data['model_type']))->query()
+        $modelInstance = morphed_model($this->data['model_type'])::query()
             ->whereKey($this->data['model_id'])
             ->first();
 

--- a/src/Actions/Media/UploadMedia.php
+++ b/src/Actions/Media/UploadMedia.php
@@ -6,7 +6,6 @@ use FluxErp\Actions\FluxAction;
 use FluxErp\Models\Media;
 use FluxErp\Rulesets\Media\UploadMediaRuleset;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -27,7 +26,7 @@ class UploadMedia extends FluxAction
 
     public function performAction(): Model
     {
-        $modelInstance = app(Relation::getMorphedModel($this->data['model_type']))->query()
+        $modelInstance = app(morphed_model($this->data['model_type']))->query()
             ->whereKey($this->data['model_id'])
             ->first();
 

--- a/src/Actions/Printing.php
+++ b/src/Actions/Printing.php
@@ -6,7 +6,6 @@ use FluxErp\Printing\Printable;
 use FluxErp\Rulesets\Printing\PrintingRuleset;
 use FluxErp\View\Printing\PrintableView;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
 
@@ -22,7 +21,7 @@ class Printing extends FluxAction
         $this->rules = resolve_static(PrintingRuleset::class, 'getRules');
 
         $this->validate();
-        $this->model = app(Relation::getMorphedModel($this->data['model_type']))->query()
+        $this->model = app(morphed_model($this->data['model_type']))->query()
             ->whereKey($this->data['model_id'])
             ->first();
     }

--- a/src/Actions/Printing.php
+++ b/src/Actions/Printing.php
@@ -21,7 +21,7 @@ class Printing extends FluxAction
         $this->rules = resolve_static(PrintingRuleset::class, 'getRules');
 
         $this->validate();
-        $this->model = app(morphed_model($this->data['model_type']))->query()
+        $this->model = morphed_model($this->data['model_type'])::query()
             ->whereKey($this->data['model_id'])
             ->first();
     }

--- a/src/Http/Controllers/PrintController.php
+++ b/src/Http/Controllers/PrintController.php
@@ -7,7 +7,6 @@ use FluxErp\Helpers\ResponseHelper;
 use FluxErp\Http\Requests\GetPrintViewsRequest;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -18,7 +17,7 @@ class PrintController extends Controller
     {
         $validated = $request->validated();
 
-        $modelType = Relation::getMorphedModel($validated['model_type']);
+        $modelType = morphed_model($validated['model_type']);
         if ($validated['model_id'] ?? false) {
             $views = array_keys(
                 app($modelType)->query()

--- a/src/Http/Middleware/SetJobAuthenticatedUserMiddleware.php
+++ b/src/Http/Middleware/SetJobAuthenticatedUserMiddleware.php
@@ -3,7 +3,6 @@
 namespace FluxErp\Http\Middleware;
 
 use Closure;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
 
@@ -13,7 +12,7 @@ class SetJobAuthenticatedUserMiddleware
     {
         if (! auth()->check() && $context = Context::get('user')) {
             $context = explode(':', $context);
-            Auth::setUser(Relation::getMorphedModel($context[0])::query()->whereKey($context[1])->first());
+            Auth::setUser(morphed_model($context[0])::query()->whereKey($context[1])->first());
         }
 
         return $next($job);

--- a/src/Listeners/MessageSendingEventSubscriber.php
+++ b/src/Listeners/MessageSendingEventSubscriber.php
@@ -47,7 +47,7 @@ class MessageSendingEventSubscriber
 
         $communication = app(Communication::class)->query()->whereKey($communicationForm->id)->first();
 
-        $communicatable = Relation::getMorphedModel($communicationForm->communicatable_type)::query()
+        $communicatable = morphed_model($communicationForm->communicatable_type)::query()
             ->whereKey($communicationForm->communicatable_id)
             ->first();
 

--- a/src/Livewire/Features/Calendar/FluxCalendar.php
+++ b/src/Livewire/Features/Calendar/FluxCalendar.php
@@ -12,7 +12,6 @@ use FluxErp\Models\CalendarEvent;
 use FluxErp\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
@@ -48,7 +47,7 @@ class FluxCalendar extends CalendarComponent
     public function getEvents(array $info, array $calendarAttributes): array
     {
         if ($calendarAttributes['model_type'] ?? false) {
-            return Relation::getMorphedModel($calendarAttributes['model_type'])::query()
+            return morphed_model($calendarAttributes['model_type'])::query()
                 ->get()
                 ->map(fn (Model $model) => $model->toCalendarEvent())
                 ->toArray();
@@ -127,7 +126,7 @@ class FluxCalendar extends CalendarComponent
                 return false;
             }
 
-            $modelClass = Relation::getMorphedModel($attributes['calendar_type']);
+            $modelClass = morphed_model($attributes['calendar_type']);
 
             try {
                 $result = $action['class']::make(resolve_static($modelClass, 'fromCalendarEvent', [$attributes]))
@@ -212,7 +211,7 @@ class FluxCalendar extends CalendarComponent
                 return false;
             }
 
-            $modelClass = Relation::getMorphedModel($attributes['calendar_type']);
+            $modelClass = morphed_model($attributes['calendar_type']);
 
             try {
                 $action['class']::make(resolve_static($modelClass, 'fromCalendarEvent', [$attributes]))

--- a/src/Livewire/Forms/CommunicationForm.php
+++ b/src/Livewire/Forms/CommunicationForm.php
@@ -7,7 +7,6 @@ use FluxErp\Actions\Communication\DeleteCommunication;
 use FluxErp\Actions\Communication\UpdateCommunication;
 use FluxErp\Models\Communication;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Livewire\Attributes\Locked;
 
 class CommunicationForm extends FluxForm
@@ -97,7 +96,7 @@ class CommunicationForm extends FluxForm
     public function communicatable(): ?Model
     {
         return $this->communicatable_type && $this->communicatable_id
-            ? Relation::getMorphedModel($this->communicatable_type)::query()
+            ? morphed_model($this->communicatable_type)::query()
                 ->whereKey($this->communicatable_id)
                 ->first()
             : null;

--- a/src/Livewire/Settings/Clients.php
+++ b/src/Livewire/Settings/Clients.php
@@ -84,7 +84,7 @@ class Clients extends ClientList
                 ->color('primary')
                 ->icon('user')
                 ->attributes([
-                    'wire:click' => 'showCustomerPortal(record)',
+                    'wire:click' => 'showCustomerPortal(record.id)',
                 ])
                 ->when(resolve_static(UpdateClient::class, 'canPerformAction', [false])),
         ];

--- a/src/Livewire/WorkTime.php
+++ b/src/Livewire/WorkTime.php
@@ -8,7 +8,6 @@ use FluxErp\Models\WorkTimeType;
 use FluxErp\Traits\Trackable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -78,7 +77,7 @@ class WorkTime extends Component
     public function start(?array $data): void
     {
         if ($trackableType = data_get($data, 'trackable_type')) {
-            $data['trackable_type'] = app(Relation::getMorphedModel($trackableType) ?? $trackableType)->getMorphClass();
+            $data['trackable_type'] = app(morphed_model($trackableType) ?? $trackableType)->getMorphClass();
         }
 
         $this->workTime->fill($data ?? []);

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use Spatie\EloquentSortable\Sortable;
@@ -102,7 +101,7 @@ class Category extends Model implements InteractsWithDataTables, Sortable
     public function model(): MorphToMany
     {
         return $this->model_type
-            ? $this->morphedByMany(Relation::getMorphedModel($this->model_type), 'categorizable')
+            ? $this->morphedByMany(morphed_model($this->model_type), 'categorizable')
             : new MorphToMany(
                 static::query(),
                 $this,

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -57,7 +57,9 @@ class QueueMonitor extends Model
             $user = auth()->user();
             if (! $user && $context = Context::get('user')) {
                 $context = explode(':', $context);
-                $user = morphed_model($context[0])->whereKey($context[1])->first();
+                $user = morphed_model($context[0])::query()
+                    ->whereKey($context[1])
+                    ->first();
             }
 
             if ($user && array_key_exists(MonitorsQueue::class, class_uses_recursive($user))) {

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -20,7 +20,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Context;
@@ -58,7 +57,7 @@ class QueueMonitor extends Model
             $user = auth()->user();
             if (! $user && $context = Context::get('user')) {
                 $context = explode(':', $context);
-                $user = Relation::getMorphedModel($context[0])->whereKey($context[1])->first();
+                $user = morphed_model($context[0])->whereKey($context[1])->first();
             }
 
             if ($user && array_key_exists(MonitorsQueue::class, class_uses_recursive($user))) {

--- a/src/Models/SerialNumberRange.php
+++ b/src/Models/SerialNumberRange.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use TeamNiftyGmbH\DataTable\Helpers\ModelInfo;
 
@@ -77,7 +76,7 @@ class SerialNumberRange extends Model
         }
 
         $modelAttributes = array_fill_keys(
-            ModelInfo::forModel(Relation::getMorphedModel($this->model_type))->attributes->pluck('name')->toArray(),
+            ModelInfo::forModel(morphed_model($this->model_type))->attributes->pluck('name')->toArray(),
             null
         );
 

--- a/src/Rules/MediaUploadType.php
+++ b/src/Rules/MediaUploadType.php
@@ -4,7 +4,6 @@ namespace FluxErp\Rules;
 
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\InvokableRule;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
 
@@ -31,7 +30,7 @@ class MediaUploadType implements DataAwareRule, InvokableRule
             return;
         }
 
-        $modelClass = Relation::getMorphedModel($model);
+        $modelClass = morphed_model($model);
         if ($modelClass
             && $value
             && ! method_exists(app($modelClass), $method)

--- a/src/Rules/MorphClassExists.php
+++ b/src/Rules/MorphClassExists.php
@@ -4,7 +4,6 @@ namespace FluxErp\Rules;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class MorphClassExists extends ClassExists
 {
@@ -15,7 +14,7 @@ class MorphClassExists extends ClassExists
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! $morphClass = Relation::getMorphedModel($value)) {
+        if (! $morphClass = morphed_model($value)) {
             $fail(sprintf('%s is not a valid morph class.', $value))->translate();
         }
 

--- a/src/Rules/MorphExists.php
+++ b/src/Rules/MorphExists.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class MorphExists implements DataAwareRule, ValidationRule
 {
@@ -31,7 +30,7 @@ class MorphExists implements DataAwareRule, ValidationRule
             return;
         }
 
-        $morphClass = Relation::getMorphedModel($model);
+        $morphClass = morphed_model($model);
         if (! $morphClass && (! class_exists($model) || ! app($model) instanceof Model)) {
             $fail(sprintf('%s is not a valid model.', $model))->translate();
 

--- a/src/Support/Bus/MonitorablePendingBatch.php
+++ b/src/Support/Bus/MonitorablePendingBatch.php
@@ -27,7 +27,9 @@ class MonitorablePendingBatch extends PendingBatch
             $user = auth()->user();
             if (! $user && $context = Context::get('user')) {
                 $context = explode(':', $context);
-                $user = morphed_model($context[0])::query()->whereKey($context[1])->first();
+                $user = morphed_model($context[0])::query()
+                    ->whereKey($context[1])
+                    ->first();
             }
 
             if ($user && array_key_exists(MonitorsQueue::class, class_uses_recursive($user))) {

--- a/src/Support/Bus/MonitorablePendingBatch.php
+++ b/src/Support/Bus/MonitorablePendingBatch.php
@@ -10,7 +10,6 @@ use FluxErp\Traits\MonitorsQueue;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Log;
@@ -28,7 +27,7 @@ class MonitorablePendingBatch extends PendingBatch
             $user = auth()->user();
             if (! $user && $context = Context::get('user')) {
                 $context = explode(':', $context);
-                $user = Relation::getMorphedModel($context[0])::query()->whereKey($context[1])->first();
+                $user = morphed_model($context[0])::query()->whereKey($context[1])->first();
             }
 
             if ($user && array_key_exists(MonitorsQueue::class, class_uses_recursive($user))) {

--- a/src/Traits/HasParentMorphClass.php
+++ b/src/Traits/HasParentMorphClass.php
@@ -28,6 +28,10 @@ trait HasParentMorphClass
             return array_search($parentClass, $morphMap, true);
         }
 
-        throw new ClassMorphViolationException(static::class);
+        if (Relation::requiresMorphMap()) {
+            throw new ClassMorphViolationException(new $parentClass);
+        }
+
+        return $parentClass;
     }
 }

--- a/src/Traits/HasRelatedModel.php
+++ b/src/Traits/HasRelatedModel.php
@@ -159,7 +159,7 @@ trait HasRelatedModel
         // First, we will need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we will make the query
         // instances, as well as the relationship instances we need for these.
-        $instance = $this->newRelatedInstance(Relation::getMorphedModel($related) ?? $related);
+        $instance = $this->newRelatedInstance(morphed_model($related) ?? $related);
 
         $foreignPivotKey = $foreignPivotKey ?: $name . '_id';
 


### PR DESCRIPTION
when using Relation::getMorphedModel($alias) the returned class is not resoved through the container. When rebinding a class in the container the getMorphedModel still returns the old class because the morph map wasnt updated to the new one