### PR TITLE
fix folder tree component

### DIFF
--- a/src/Livewire/FolderTree.php
+++ b/src/Livewire/FolderTree.php
@@ -79,12 +79,6 @@ class FolderTree extends Component
         }
     }
 
-    public function mount(?string $modelType = null, ?int $modelId = null): void
-    {
-        $this->modelType = $modelType;
-        $this->modelId = $modelId;
-    }
-
     public function render(): View|Factory|Application
     {
         return view('flux::livewire.folder-tree');


### PR DESCRIPTION
remove mount method as the public properties have already the same name