### PR TITLE
implement mass pruning for failed jobs, logs, notifications, queue monitor, and tokens

### DIFF
--- a/src/Console/Commands/PruneCommand.php
+++ b/src/Console/Commands/PruneCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FluxErp\Console\Commands;
+
+use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class PruneCommand extends BasePruneCommand
+{
+    protected function models()
+    {
+        $projectModels = parent::models();
+
+        if (! empty($this->option('model'))) {
+            return $projectModels;
+        }
+
+        return collect(Relation::morphMap())
+            ->values()
+            ->merge($projectModels)
+            ->unique()
+            ->values();
+    }
+}

--- a/src/Console/Commands/PruneCommand.php
+++ b/src/Console/Commands/PruneCommand.php
@@ -9,15 +9,15 @@ class PruneCommand extends BasePruneCommand
 {
     protected function models()
     {
-        $projectModels = parent::models();
+        $models = parent::models();
 
         if (! empty($this->option('model'))) {
-            return $projectModels;
+            return $models;
         }
 
         return collect(Relation::morphMap())
             ->values()
-            ->merge($projectModels)
+            ->merge($models)
             ->unique()
             ->values();
     }

--- a/src/Console/Commands/PruneCommand.php
+++ b/src/Console/Commands/PruneCommand.php
@@ -4,10 +4,11 @@ namespace FluxErp\Console\Commands;
 
 use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
 
 class PruneCommand extends BasePruneCommand
 {
-    protected function models()
+    protected function models(): Collection
     {
         $models = parent::models();
 

--- a/src/Livewire/Widgets/Settings/System/Database.php
+++ b/src/Livewire/Widgets/Settings/System/Database.php
@@ -117,7 +117,7 @@ class Database extends Component
         $result = Artisan::call(PruneCommand::class, [], $output = new BufferedOutput());
 
         collect(explode("\n", $output->fetch()))
-            ->filter(fn (string $line) => ! blank(trim($line))
+            ->filter(fn (string $line) => ! blank($line)
                 && ! str_contains($line, 'No prunable ')
                 && ! str_contains($line, 'INFO  Pruning')
             )

--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -2,8 +2,13 @@
 
 namespace FluxErp\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\MassPrunable;
+
 class FailedJob extends FluxModel
 {
+    use MassPrunable;
+
     protected $guarded = [
         'id',
         'uuid',
@@ -15,5 +20,15 @@ class FailedJob extends FluxModel
             'payload' => 'array',
             'failed_at' => 'datetime',
         ];
+    }
+
+    public function prunable(): Builder
+    {
+        return static::query()
+            ->where(
+                static::getCreatedAtColumn(),
+                '<',
+                now()->subDays(30)
+            );
     }
 }

--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -26,7 +26,7 @@ class FailedJob extends FluxModel
     {
         return static::query()
             ->where(
-                static::getCreatedAtColumn(),
+                'failed_at',
                 '<',
                 now()->subDays(30)
             );

--- a/src/Models/Log.php
+++ b/src/Models/Log.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\MassPrunable;
 
 class Log extends FluxModel
@@ -15,8 +16,13 @@ class Log extends FluxModel
         ];
     }
 
-    public function prunable(): void
+    public function prunable(): Builder
     {
-        static::where('created_at', '<', now()->subDays(config('logging.channels.database.days')));
+        return static::query()
+            ->where(
+                static::getCreatedAtColumn(),
+                '<',
+                now()->subDays(config('logging.channels.database.days') ?? 1)
+            );
     }
 }

--- a/src/Models/Log.php
+++ b/src/Models/Log.php
@@ -22,7 +22,7 @@ class Log extends FluxModel
             ->where(
                 static::getCreatedAtColumn(),
                 '<',
-                now()->subDays(config('logging.channels.database.days') ?? 1)
+                now()->subDays(config('logging.channels.database.days', 30))
             );
     }
 }

--- a/src/Models/Notification.php
+++ b/src/Models/Notification.php
@@ -5,6 +5,7 @@ namespace FluxErp\Models;
 use FluxErp\Enums\ToastType;
 use FluxErp\Support\TallstackUI\Interactions\Toast;
 use FluxErp\Traits\ResolvesRelationsThroughContainer;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Notifications\DatabaseNotification;
 use Livewire\Component;
@@ -13,9 +14,15 @@ class Notification extends DatabaseNotification
 {
     use MassPrunable, ResolvesRelationsThroughContainer;
 
-    public function prunable(): mixed
+    public function prunable(): Builder
     {
-        return static::where('created_at', '<', now()->subDays(30))->whereNotNull('read_at');
+        return static::query()
+            ->where(
+                static::getCreatedAtColumn(),
+                '<',
+                now()->subDays(30)
+            )
+            ->whereNotNull('read_at');
     }
 
     public function toast(?Component $component = null): Toast

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -223,7 +223,12 @@ class QueueMonitor extends FluxModel
 
     public function prunable(): Builder
     {
-        return $this->where('finished_at', '<', now()->subDays(30));
+        return static::query()
+            ->where(
+                'finished_at',
+                '<',
+                now()->subDays(30)
+            );
     }
 
     public function queueMonitorables(): HasMany

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -65,7 +65,7 @@ class Token extends FluxAuthenticatable
             && parse_url(request()->url(), PHP_URL_PATH) === parse_url($this->url, PHP_URL_PATH);
     }
 
-    public function prunable()
+    public function prunable(): Builder
     {
         return static::query()->invalid();
     }

--- a/src/Providers/MorphMapServiceProvider.php
+++ b/src/Providers/MorphMapServiceProvider.php
@@ -6,6 +6,7 @@ use FluxErp\Models\Activity;
 use FluxErp\Models\AdditionalColumn;
 use FluxErp\Models\Address;
 use FluxErp\Models\AddressType;
+use FluxErp\Models\AttributeTranslation;
 use FluxErp\Models\BankConnection;
 use FluxErp\Models\Calendar;
 use FluxErp\Models\CalendarEvent;
@@ -28,12 +29,14 @@ use FluxErp\Models\Currency;
 use FluxErp\Models\Discount;
 use FluxErp\Models\DiscountGroup;
 use FluxErp\Models\EventSubscription;
+use FluxErp\Models\FailedJob;
 use FluxErp\Models\Favorite;
 use FluxErp\Models\FormBuilderField;
 use FluxErp\Models\FormBuilderFieldResponse;
 use FluxErp\Models\FormBuilderForm;
 use FluxErp\Models\FormBuilderResponse;
 use FluxErp\Models\FormBuilderSection;
+use FluxErp\Models\Industry;
 use FluxErp\Models\JobBatch;
 use FluxErp\Models\Language;
 use FluxErp\Models\LanguageLine;
@@ -117,6 +120,7 @@ class MorphMapServiceProvider extends ServiceProvider
             'additional_column' => AdditionalColumn::class,
             'address' => Address::class,
             'address_type' => AddressType::class,
+            'attribute_translation' => AttributeTranslation::class,
             'bank_connection' => BankConnection::class,
             'calendar' => Calendar::class,
             'calendar_event' => CalendarEvent::class,
@@ -139,12 +143,14 @@ class MorphMapServiceProvider extends ServiceProvider
             'discount' => Discount::class,
             'discount_group' => DiscountGroup::class,
             'event_subscription' => EventSubscription::class,
+            'failed_job' => FailedJob::class,
             'favorite' => Favorite::class,
             'form_builder_field' => FormBuilderField::class,
             'form_builder_field_response' => FormBuilderFieldResponse::class,
             'form_builder_form' => FormBuilderForm::class,
             'form_builder_response' => FormBuilderResponse::class,
             'form_builder_section' => FormBuilderSection::class,
+            'industry' => Industry::class,
             'job_batch' => JobBatch::class,
             'language' => Language::class,
             'language_line' => LanguageLine::class,


### PR DESCRIPTION
## Summary by Sourcery

Implement mass pruning across various models and streamline pruning operations by introducing a custom prune command, updating morph mappings, adding detailed toast notifications, and caching console command discovery for performance.

New Features:
- Implement MassPrunable on FailedJob, Notification, Log, QueueMonitor, and Token models with 30-day retention rules (or invalid criteria for tokens).
- Add a custom PruneCommand that merges morph-mapped models into Laravel’s base pruning command.
- Enhance the Livewire database settings widget to parse prune output and display detailed persistent success/error toasts.

Enhancements:
- Cache console command discovery in FluxServiceProvider using a new findCommands method to improve performance.
- Register new models (AttributeTranslation, FailedJob, Industry) in the MorphMapServiceProvider for polymorphic relations.