### PR TITLE
Add helpers to is time frame aware widget trait

### DIFF
--- a/resources/views/components/dashboard/edit-dashboard.blade.php
+++ b/resources/views/components/dashboard/edit-dashboard.blade.php
@@ -4,14 +4,16 @@
         <div
             x-cloak
             x-show="!editGrid"
-            class="flex flex-col items-center gap-2 text-sm md:flex-row"
+            class="flex flex-col items-center gap-2 text-sm md:flex-row md:min-w-96"
         >
-            <x-select.styled
-                class="p-2"
-                wire:model.live="params.timeFrame"
-                required
-                :options="TimeFrameEnum::valuesLocalized()"
-            />
+            <div class="grow w-full">
+                <x-select.styled
+                    class="p-2"
+                    wire:model.live="params.timeFrame"
+                    required
+                    :options="TimeFrameEnum::valuesLocalized()"
+                />
+            </div>
             <div
                 class="flex min-w-96 flex-col items-center gap-2 md:flex-row"
                 x-cloak

--- a/resources/views/components/dashboard/edit-dashboard.blade.php
+++ b/resources/views/components/dashboard/edit-dashboard.blade.php
@@ -4,9 +4,9 @@
         <div
             x-cloak
             x-show="!editGrid"
-            class="flex flex-col items-center gap-2 text-sm md:flex-row md:min-w-96"
+            class="flex flex-col items-center gap-2 text-sm md:min-w-96 md:flex-row"
         >
-            <div class="grow w-full">
+            <div class="w-full grow">
                 <x-select.styled
                     class="p-2"
                     wire:model.live="params.timeFrame"

--- a/resources/views/livewire/support/widgets/value-list.blade.php
+++ b/resources/views/livewire/support/widgets/value-list.blade.php
@@ -31,7 +31,7 @@
                                             x-cloak
                                             x-show="item.growthRate > 0"
                                             class="w-full"
-                                            color:emerald
+                                            color="emerald"
                                         >
                                             <x-slot:left>
                                                 <i class="ph ph-caret-up"></i>

--- a/src/Livewire/Widgets/AverageOrderValue.php
+++ b/src/Livewire/Widgets/AverageOrderValue.php
@@ -40,18 +40,18 @@ class AverageOrderValue extends LineChart
         $metric = Line::make($query)
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay());
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart());
         $previousMetric = Trend::make($query)
             ->setDateColumn('invoice_date')
-            ->setEndingDate($metric->previousRange()[1])
-            ->setStartingDate($metric->previousRange()[0])
+            ->setEndingDate($this->getEndPrevious())
+            ->setStartingDate($this->getStartPrevious())
             ->setRange(TimeFrameEnum::Custom);
 
         $growth = Value::make($query)
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setDateColumn('invoice_date')
             ->withGrowthRate()
             ->avg('total_net_price');

--- a/src/Livewire/Widgets/MyWorkTimes.php
+++ b/src/Livewire/Widgets/MyWorkTimes.php
@@ -2,8 +2,6 @@
 
 namespace FluxErp\Livewire\Widgets;
 
-use Carbon\Carbon;
-use FluxErp\Enums\TimeFrameEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
 use FluxErp\Models\WorkTime;
@@ -66,12 +64,7 @@ class MyWorkTimes extends BarChart
         $baseQuery = resolve_static(WorkTime::class, 'query')
             ->where('user_id', $this->userId)
             ->where('is_locked', true)
-            ->when($this->timeFrame === TimeFrameEnum::Custom && $this->start, function ($query): void {
-                $query->where('started_at', '>=', Carbon::parse($this->start));
-            })
-            ->when($this->timeFrame === TimeFrameEnum::Custom && $this->end, function ($query): void {
-                $query->where('started_at', '<=', Carbon::parse($this->end)->endOfDay());
-            });
+            ->whereBetween('started_at', [$this->getStart(), $this->getEnd()]);
 
         $workDays = Bar::make(
             $baseQuery
@@ -81,8 +74,8 @@ class MyWorkTimes extends BarChart
         )
             ->setDateColumn('started_at')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->sum('total_time_ms');
 
         $pause = Bar::make(
@@ -93,8 +86,8 @@ class MyWorkTimes extends BarChart
         )
             ->setDateColumn('started_at')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->sum('total_time_ms');
 
         $data = [
@@ -148,8 +141,8 @@ class MyWorkTimes extends BarChart
             )
                 ->setDateColumn('started_at')
                 ->setRange($this->timeFrame)
-                ->setEndingDate($this->end?->endOfDay())
-                ->setStartingDate($this->start?->startOfDay())
+                ->setEndingDate($this->getEnd())
+                ->setStartingDate($this->getStart())
                 ->sum('total_time_ms');
 
             if (array_sum($typeData->getData()) > 0) {

--- a/src/Livewire/Widgets/Outstanding.php
+++ b/src/Livewire/Widgets/Outstanding.php
@@ -9,6 +9,7 @@ use FluxErp\Livewire\Order\OrderList;
 use FluxErp\Livewire\Support\Widgets\ValueBox;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
 use FluxErp\States\Order\PaymentState\Paid;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Number;
@@ -28,26 +29,18 @@ class Outstanding extends ValueBox implements HasWidgetOptions
     #[Renderless]
     public function calculateSum(): void
     {
-        $metric = resolve_static(Order::class, 'query')
-            ->whereNotNull('invoice_date')
-            ->whereNotNull('invoice_number')
-            ->whereNotState('payment_state', Paid::class)
-            ->revenue()
-            ->sum('balance');
-
-        $overDueQuery = resolve_static(Order::class, 'query')
-            ->whereNotNull('invoice_date')
-            ->whereNotNull('invoice_number')
-            ->whereNotState('payment_state', Paid::class)
-            ->where('payment_reminder_next_date', '<=', now()->toDate())
-            ->revenue();
-
         $symbol = resolve_static(Currency::class, 'default')->symbol;
         $this->subValue = '<span class="text-red-600">'
-            . Number::abbreviate($overDueQuery->sum('balance'), 2)
+            . Number::abbreviate(
+                $this->getOverdueQuery(resolve_static(Order::class, 'query'))->sum('balance'),
+                2
+            )
             . ' ' . $symbol . ' ' . __('Overdue')
             . '</span>';
-        $this->sum = Number::abbreviate($metric, 2) . ' ' . $symbol;
+        $this->sum = Number::abbreviate(
+            $this->getOutstandingQuery(resolve_static(Order::class, 'query'))->sum('balance'),
+            2
+        ) . ' ' . $symbol;
     }
 
     public function options(): array
@@ -69,10 +62,7 @@ class Outstanding extends ValueBox implements HasWidgetOptions
     {
         SessionFilter::make(
             Livewire::new(resolve_static(OrderList::class, 'class'))->getCacheKey(),
-            fn (Builder $query) => $query->whereNotNull('invoice_date')
-                ->whereNotNull('invoice_number')
-                ->whereNotState('payment_state', Paid::class)
-                ->revenue(),
+            fn (Builder $query) => $this->getOutstandingQuery($query),
             __($this->title()),
         )
             ->store();
@@ -85,11 +75,7 @@ class Outstanding extends ValueBox implements HasWidgetOptions
     {
         SessionFilter::make(
             Livewire::new(resolve_static(PaymentReminder::class, 'class'))->getCacheKey(),
-            fn (Builder $query) => $query->whereNotNull('invoice_date')
-                ->whereNotNull('invoice_number')
-                ->whereNotState('payment_state', Paid::class)
-                ->where('payment_reminder_next_date', '<=', now()->toDate())
-                ->revenue(),
+            fn (Builder $query) => $this->getOverdueQuery($query),
             __('Overdue'),
         )
             ->store();
@@ -103,5 +89,34 @@ class Outstanding extends ValueBox implements HasWidgetOptions
             'echo-private:' . resolve_static(Order::class, 'getBroadcastChannel')
                 . ',.OrderLocked' => 'calculateSum',
         ];
+    }
+
+    protected function getOutstandingQuery(Builder $builder): Builder
+    {
+        return $builder
+            ->whereNotNull('invoice_date')
+            ->whereNotNull('invoice_number')
+            ->whereNotState('payment_state', Paid::class)
+            ->revenue();
+    }
+
+    protected function getOverdueQuery(Builder $builder): Builder
+    {
+        return $builder
+            ->whereRelation('paymentType', 'is_direct_debit', false)
+            ->where('balance', '>', 0)
+            ->whereNotState('payment_state', Paid::class)
+            ->whereNotNull('invoice_number')
+            ->whereDate('payment_reminder_next_date', '<=', now()->endOfDay()->toDate())
+            ->whereIntegerInRaw(
+                'order_type_id',
+                resolve_static(OrderType::class, 'query')
+                    ->where('is_active', true)
+                    ->get(['id', 'order_type_enum'])
+                    ->filter(fn (OrderType $orderType) => ! $orderType->order_type_enum->isPurchase()
+                        && $orderType->order_type_enum->multiplier() > 0
+                    )
+                    ->pluck('id')
+            );
     }
 }

--- a/src/Livewire/Widgets/Outstanding.php
+++ b/src/Livewire/Widgets/Outstanding.php
@@ -38,7 +38,8 @@ class Outstanding extends ValueBox implements HasWidgetOptions
             ->filter(fn (OrderType $orderType) => ! $orderType->order_type_enum->isPurchase()
                 && $orderType->order_type_enum->multiplier() > 0
             )
-            ->pluck('id');
+            ->pluck('id')
+            ->toArray();
 
         parent::mount();
     }

--- a/src/Livewire/Widgets/Purchase.php
+++ b/src/Livewire/Widgets/Purchase.php
@@ -32,8 +32,8 @@ class Purchase extends ValueBox
                 ->purchase()
         )
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setDateColumn('invoice_date')
             ->withGrowthRate()
             ->sum('total_net_price');

--- a/src/Livewire/Widgets/Revenue.php
+++ b/src/Livewire/Widgets/Revenue.php
@@ -30,8 +30,8 @@ class Revenue extends ValueBox
                 ->revenue()
         )
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setDateColumn('invoice_date')
             ->withGrowthRate()
             ->sum('total_net_price');

--- a/src/Livewire/Widgets/RevenueBySalesRepresentative.php
+++ b/src/Livewire/Widgets/RevenueBySalesRepresentative.php
@@ -44,8 +44,8 @@ class RevenueBySalesRepresentative extends CircleChart
         )
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setLabelKey('agent.name')
             ->sum('total_net_price', 'agent_id');
 

--- a/src/Livewire/Widgets/RevenueByTopCustomers.php
+++ b/src/Livewire/Widgets/RevenueByTopCustomers.php
@@ -47,8 +47,8 @@ class RevenueByTopCustomers extends CircleChart
         )
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setLabelKey('addressInvoice.name')
             ->sum('total_net_price', 'address_invoice_id');
 

--- a/src/Livewire/Widgets/RevenuePurchasesProfitChart.php
+++ b/src/Livewire/Widgets/RevenuePurchasesProfitChart.php
@@ -37,15 +37,15 @@ class RevenuePurchasesProfitChart extends LineChart
         $revenue = Line::make($baseQuery->clone()->revenue())
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->sum('total_net_price');
 
         $purchases = Line::make($baseQuery->clone()->purchase())
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->sum('total_net_price');
 
         $purchasesData = $purchases->getCombinedData();

--- a/src/Livewire/Widgets/TopProductsByRevenue.php
+++ b/src/Livewire/Widgets/TopProductsByRevenue.php
@@ -3,7 +3,6 @@
 namespace FluxErp\Livewire\Widgets;
 
 use FluxErp\Enums\GrowthRateTypeEnum;
-use FluxErp\Enums\TimeFrameEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\Support\Widgets\ValueList;
 use FluxErp\Models\Currency;

--- a/src/Livewire/Widgets/TopProductsByRevenue.php
+++ b/src/Livewire/Widgets/TopProductsByRevenue.php
@@ -40,21 +40,7 @@ class TopProductsByRevenue extends ValueList
             ->whereHas(
                 'order',
                 fn (Builder $query) => $query
-                    ->when(
-                        $this->timeFrame === TimeFrameEnum::Custom && $this->end,
-                        function (Builder $query) {
-                            $diff = $this->end->diffInDays($this->start);
-
-                            return $query->whereBetween(
-                                'invoice_date',
-                                [$this->start->subDays($diff), $this->end->subDays($diff)]
-                            );
-                        },
-                        fn (Builder $query) => $query->whereBetween(
-                            'invoice_date',
-                            $this->timeFrame->getPreviousRange()
-                        )
-                    )
+                    ->whereBetween('invoice_date', [$this->getStartPrevious(), $this->getEndPrevious()])
                     ->revenue()
             )
             ->limit($this->limit)
@@ -107,11 +93,7 @@ class TopProductsByRevenue extends ValueList
             ->whereHas(
                 'order',
                 fn (Builder $query) => $query
-                    ->when(
-                        $this->timeFrame === TimeFrameEnum::Custom,
-                        fn (Builder $query) => $query->whereBetween('invoice_date', [$this->start, $this->end]),
-                        fn (Builder $query) => $query->whereBetween('invoice_date', $this->timeFrame->getRange())
-                    )
+                    ->whereBetween('invoice_date', [$this->getStart(), $this->getEnd()])
                     ->revenue()
             )
             ->whereHas('product');

--- a/src/Livewire/Widgets/TopProductsByUnitSold.php
+++ b/src/Livewire/Widgets/TopProductsByUnitSold.php
@@ -3,7 +3,6 @@
 namespace FluxErp\Livewire\Widgets;
 
 use FluxErp\Enums\GrowthRateTypeEnum;
-use FluxErp\Enums\TimeFrameEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\Support\Widgets\ValueList;
 use FluxErp\Models\Order;

--- a/src/Livewire/Widgets/TopProductsByUnitSold.php
+++ b/src/Livewire/Widgets/TopProductsByUnitSold.php
@@ -38,21 +38,7 @@ class TopProductsByUnitSold extends ValueList
             ->whereHas(
                 'order',
                 fn (Builder $query) => $query
-                    ->when(
-                        $this->timeFrame === TimeFrameEnum::Custom && $this->end,
-                        function (Builder $query) {
-                            $diff = $this->end->diffInDays($this->start);
-
-                            return $query->whereBetween(
-                                'invoice_date',
-                                [$this->start->subDays($diff), $this->end->subDays($diff)]
-                            );
-                        },
-                        fn (Builder $query) => $query->whereBetween(
-                            'invoice_date',
-                            $this->timeFrame->getPreviousRange()
-                        )
-                    )
+                    ->whereBetween('invoice_date', [$this->getStartPrevious(), $this->getEndPrevious()])
                     ->revenue()
             )
             ->limit($this->limit)
@@ -104,11 +90,7 @@ class TopProductsByUnitSold extends ValueList
             ->whereHas(
                 'order',
                 fn (Builder $query) => $query
-                    ->when(
-                        $this->timeFrame === TimeFrameEnum::Custom,
-                        fn (Builder $query) => $query->whereBetween('invoice_date', [$this->start, $this->end]),
-                        fn (Builder $query) => $query->whereBetween('invoice_date', $this->timeFrame->getRange())
-                    )
+                    ->whereBetween('invoice_date', [$this->getStart(), $this->getEnd()])
                     ->revenue()
             )
             ->whereHas('product');

--- a/src/Livewire/Widgets/TotalOrdersCount.php
+++ b/src/Livewire/Widgets/TotalOrdersCount.php
@@ -39,18 +39,19 @@ class TotalOrdersCount extends LineChart
         $metric = Line::make($query)
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay());
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart());
+
         $previousMetric = Line::make($query)
             ->setDateColumn('invoice_date')
-            ->setEndingDate($metric->previousRange()[1])
-            ->setStartingDate($metric->previousRange()[0])
+            ->setEndingDate($this->getEndPrevious())
+            ->setStartingDate($this->getStartPrevious())
             ->setRange(TimeFrameEnum::Custom);
 
         $growth = Value::make($query)
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setDateColumn('invoice_date')
             ->withGrowthRate()
             ->count('total_net_price');

--- a/src/Livewire/Widgets/TotalRevenue.php
+++ b/src/Livewire/Widgets/TotalRevenue.php
@@ -41,18 +41,18 @@ class TotalRevenue extends LineChart
         $metric = Line::make($query)
             ->setDateColumn('invoice_date')
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay());
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart());
         $previousMetric = Line::make($query)
             ->setDateColumn('invoice_date')
-            ->setEndingDate($metric->previousRange()[1])
-            ->setStartingDate($metric->previousRange()[0])
+            ->setEndingDate($this->getEndPrevious())
+            ->setStartingDate($this->getStartPrevious())
             ->setRange(TimeFrameEnum::Custom);
 
         $growth = Value::make($query)
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end?->endOfDay())
-            ->setStartingDate($this->start?->startOfDay())
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
             ->setDateColumn('invoice_date')
             ->withGrowthRate()
             ->sum('total_net_price');

--- a/src/Livewire/Widgets/UnassignedTickets.php
+++ b/src/Livewire/Widgets/UnassignedTickets.php
@@ -32,6 +32,7 @@ class UnassignedTickets extends MyTickets
     protected function getTickets(): Collection
     {
         return $this->tickets ?? resolve_static(Ticket::class, 'query')
+            ->latest()
             ->whereDoesntHave('users')
             ->with('authenticatable:id,name')
             ->whereNotIn(

--- a/src/Support/Metrics/Trend.php
+++ b/src/Support/Metrics/Trend.php
@@ -188,8 +188,8 @@ class Trend extends Metric
             $diff = $this->startingDate?->diffInDays($this->endingDate ?? now()->addCenturies(2));
 
             $unit = match (true) {
-                $diff < 30 => 'day',
-                $diff < 365 => 'month',
+                $diff <= 31 => 'day',
+                $diff <= 365 => 'month',
                 default => 'year',
             };
         }

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -55,9 +55,14 @@ trait IsTimeFrameAwareWidget
     {
         if ($this->timeFrame === TimeFrameEnum::Custom) {
             return match (true) {
-                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()->subMonthNoOverflow()->endOfMonth()->endOfDay(),
-                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()->subYear()->endOfYear(),
-                default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())))
+                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()
+                    ->subMonthNoOverflow()
+                    ->endOfMonth()
+                    ->endOfDay(),
+                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()
+                    ->subYear()
+                    ->endOfYear(),
+                default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())) ?: 1)
             };
         }
 
@@ -75,9 +80,14 @@ trait IsTimeFrameAwareWidget
     {
         if ($this->timeFrame === TimeFrameEnum::Custom) {
             return match (true) {
-                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()->subMonthNoOverflow()->startOfMonth()->startOfDay(),
-                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()->subYear()->startOfYear(),
-                default => $this->getStart()->subDays(round($this->getStart()->diffInDays($this->getEnd())))
+                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()
+                    ->subMonthNoOverflow()
+                    ->startOfMonth()
+                    ->startOfDay(),
+                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()
+                    ->subYear()
+                    ->startOfYear(),
+                default => $this->getStart()->subDays(round($this->getStart()->diffInDays($this->getEnd())) ?: 1)
             };
         }
 

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -55,11 +55,11 @@ trait IsTimeFrameAwareWidget
     {
         if ($this->timeFrame === TimeFrameEnum::Custom) {
             return match (true) {
-                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()
+                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getEnd()
                     ->subMonthNoOverflow()
                     ->endOfMonth()
                     ->endOfDay(),
-                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfYear() => $this->getStart()
+                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfYear() => $this->getEnd()
                     ->subYear()
                     ->endOfYear(),
                 default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())) ?: 1)

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -59,7 +59,7 @@ trait IsTimeFrameAwareWidget
                     ->subMonthNoOverflow()
                     ->endOfMonth()
                     ->endOfDay(),
-                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfYear() => $this->getEnd()
+                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getEnd()
                     ->subYear()
                     ->endOfYear(),
                 default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())) ?: 1)

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -12,9 +12,9 @@ trait IsTimeFrameAwareWidget
 {
     use Widgetable;
 
-    public ?Carbon $end = null;
+    public ?string $end = null;
 
-    public ?Carbon $start = null;
+    public ?string $start = null;
 
     public TimeFrameEnum $timeFrame = TimeFrameEnum::ThisMonth;
 
@@ -31,10 +31,10 @@ trait IsTimeFrameAwareWidget
             ? TimeFrameEnum::tryFrom($timeFrame)
             : $timeFrame;
         $this->start = $this->timeFrame === TimeFrameEnum::Custom
-            ? Carbon::parse(data_get($this->timeParams, 'start'))
+            ? Carbon::parse(data_get($this->timeParams, 'start'))->toDateString()
             : null;
         $this->end = $this->timeFrame === TimeFrameEnum::Custom
-            ? Carbon::parse(data_get($this->timeParams, 'end'))
+            ? Carbon::parse(data_get($this->timeParams, 'end'))->toDateString()
             : null;
 
         if ($this->timeFrame === TimeFrameEnum::Custom && ($this->start === null || $this->end === null)) {

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -48,18 +48,18 @@ trait IsTimeFrameAwareWidget
     {
         return $this->timeFrame === TimeFrameEnum::Custom && $this->end
             ? Carbon::parse($this->end)
-            : data_get($this->timeFrame->getRange(), 1)->endOfDay();
+            : data_get($this->timeFrame->getRange(), 1)?->endOfDay();
     }
 
     protected function getEndPrevious(): Carbon|CarbonImmutable|null
     {
         if ($this->timeFrame === TimeFrameEnum::Custom) {
             return match (true) {
-                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()
+                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()
                     ->subMonthNoOverflow()
                     ->endOfMonth()
                     ->endOfDay(),
-                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()
+                $this->getEnd()->isEndOfMonth() && $this->getEnd()->isEndOfYear() => $this->getStart()
                     ->subYear()
                     ->endOfYear(),
                 default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())) ?: 1)
@@ -73,7 +73,7 @@ trait IsTimeFrameAwareWidget
     {
         return $this->timeFrame === TimeFrameEnum::Custom && $this->start
             ? Carbon::parse($this->start)
-            : data_get($this->timeFrame->getRange(), 0)->startOfDay();
+            : data_get($this->timeFrame->getRange(), 0)?->startOfDay();
     }
 
     protected function getStartPrevious(): Carbon|CarbonImmutable|null

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -2,9 +2,10 @@
 
 namespace FluxErp\Traits\Livewire;
 
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use FluxErp\Enums\TimeFrameEnum;
 use FluxErp\Traits\Widgetable;
-use Illuminate\Support\Carbon;
 use Livewire\Attributes\Modelable;
 
 trait IsTimeFrameAwareWidget
@@ -41,5 +42,45 @@ trait IsTimeFrameAwareWidget
         }
 
         $this->calculateByTimeFrame();
+    }
+
+    protected function getEnd(): Carbon|CarbonImmutable|null
+    {
+        return $this->timeFrame === TimeFrameEnum::Custom && $this->end
+            ? Carbon::parse($this->end)
+            : data_get($this->timeFrame->getRange(), 1)->endOfDay();
+    }
+
+    protected function getEndPrevious(): Carbon|CarbonImmutable|null
+    {
+        if ($this->timeFrame === TimeFrameEnum::Custom) {
+            return match (true) {
+                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()->subMonthNoOverflow()->endOfMonth()->endOfDay(),
+                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()->subYear()->endOfYear(),
+                default => $this->getEnd()->subDays(round($this->getStart()->diffInDays($this->getEnd())))
+            };
+        }
+
+        return data_get($this->timeFrame->getPreviousRange(), 1)->endOfDay();
+    }
+
+    protected function getStart(): Carbon|CarbonImmutable|null
+    {
+        return $this->timeFrame === TimeFrameEnum::Custom && $this->start
+            ? Carbon::parse($this->start)
+            : data_get($this->timeFrame->getRange(), 0)->startOfDay();
+    }
+
+    protected function getStartPrevious(): Carbon|CarbonImmutable|null
+    {
+        if ($this->timeFrame === TimeFrameEnum::Custom) {
+            return match (true) {
+                $this->getStart()->isStartOfMonth() && $this->getEnd()->isEndOfMonth() => $this->getStart()->subMonthNoOverflow()->startOfMonth()->startOfDay(),
+                $this->getStart()->isStartOfYear() && $this->getEnd()->isEndOfYear() => $this->getStart()->subYear()->startOfYear(),
+                default => $this->getStart()->subDays(round($this->getStart()->diffInDays($this->getEnd())))
+            };
+        }
+
+        return data_get($this->timeFrame->getPreviousRange(), 0)->startOfDay();
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Centralize and simplify time frame handling across widgets by introducing helper methods in the IsTimeFrameAwareWidget trait, refactoring existing widgets to leverage these helpers, and enhancing the Outstanding widget with order type awareness and extracted query methods.

Bug Fixes:
- Fix blade component syntax for growth rate color attribute
- Add missing latest() ordering to UnassignedTickets query

Enhancements:
- Add getStart/End and getPrevious helpers in IsTimeFrameAwareWidget to centralize time frame calculations
- Refactor all time-aware widgets to use new time frame helpers for date range configuration
- Extract getOutstandingQuery and getOverdueQuery methods and initialize active orderTypeIds in Outstanding widget
- Apply Locked attribute and call parent::mount in Outstanding to prepare order type filters
- Adjust threshold logic in Trend metric for day and month units
- Update edit-dashboard blade to wrap time frame select and set minimum width