### PR TITLE
fix-contact-lead-list

### DIFF
--- a/resources/views/livewire/lead/general.blade.php
+++ b/resources/views/livewire/lead/general.blade.php
@@ -99,19 +99,15 @@
                     ]"
                 />
             </div>
-            <x-currency
+            <x-number
                 x-bind:readonly="!edit"
                 :label="__('Expected Revenue')"
-                :locale="app()->getLocale()"
-                :symbol="resolve_static(\FluxErp\Models\Currency::class, 'default')?->symbol"
-                wire:model.blur="leadForm.expected_revenue"
+                wire:model="leadForm.expected_revenue"
             />
-            <x-currency
+            <x-number
                 x-bind:readonly="!edit"
                 :label="__('Expected Gross Profit')"
-                :locale="app()->getLocale()"
-                :symbol="resolve_static(\FluxErp\Models\Currency::class, 'default')?->symbol"
-                wire:model.blur="leadForm.expected_gross_profit"
+                wire:model="leadForm.expected_gross_profit"
             />
             <div x-bind:class="! edit && 'pointer-events-none'">
                 <x-rating

--- a/src/Livewire/Contact/Leads.php
+++ b/src/Livewire/Contact/Leads.php
@@ -3,6 +3,8 @@
 namespace FluxErp\Livewire\Contact;
 
 use FluxErp\Livewire\Lead\LeadList;
+use FluxErp\Models\Contact;
+use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Modelable;
 
 class Leads extends LeadList
@@ -14,8 +16,13 @@ class Leads extends LeadList
     {
         parent::edit($id);
 
-        $this->leadForm->address_id ??= resolve_static(\FluxErp\Models\Contact::class, 'query')
+        $this->leadForm->address_id ??= resolve_static(Contact::class, 'query')
             ->whereKey($this->contactId)
             ->value('main_address_id');
+    }
+
+    public function getBuilder(Builder $builder): Builder
+    {
+        return $builder->whereRelation('address.contact', 'id', $this->contactId);
     }
 }

--- a/src/Livewire/Contact/Leads.php
+++ b/src/Livewire/Contact/Leads.php
@@ -23,6 +23,6 @@ class Leads extends LeadList
 
     public function getBuilder(Builder $builder): Builder
     {
-        return $builder->whereRelation('address.contact', 'id', $this->contactId);
+        return $builder->whereRelation('address', 'contact_id', $this->contactId);
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -66,9 +66,12 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
     protected static function booted(): void
     {
         static::saving(function (Lead $lead): void {
-            $lead->expected_gross_profit_percentage = percentage_of(
-                $lead->expected_revenue ?? 0,
-                $lead->expected_gross_profit ?? 0,
+            $lead->expected_gross_profit_percentage = bcdiv(
+                percentage_of(
+                    $lead->expected_revenue ?? 0,
+                    $lead->expected_gross_profit ?? 0,
+                ),
+                100
             );
 
             if ($lead->isDirty('lead_state_id')

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -66,13 +66,9 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
     protected static function booted(): void
     {
         static::saving(function (Lead $lead): void {
-            $lead->expected_gross_profit_percentage = bcdiv(
-                percentage_of(
-                    $lead->expected_revenue ?? 0,
-                    $lead->expected_gross_profit ?? 0,
-                ),
-                100
-            );
+            $lead->expected_gross_profit_percentage = $lead->expected_revenue && $lead->expected_gross_profit
+                ? bcround(bcdiv($lead->expected_gross_profit, $lead->expected_revenue), 4)
+                : 0;
 
             if ($lead->isDirty('lead_state_id')
                 && ! is_null(($probability = $lead->leadState()->value('probability_percentage')))


### PR DESCRIPTION
## Summary by Sourcery

Switch revenue and profit inputs to simple numeric components, scope contact-specific leads by address, and correct profit percentage computation to yield decimal values.

Enhancements:
- Switch expected revenue and gross profit inputs from currency to number components with direct model binding and remove locale/symbol settings
- Add getBuilder method in Contact\Leads component to filter leads by the contact's address and simplify Contact model resolution
- Update expected gross profit percentage calculation to divide the percentage_of result by 100 using bcdiv for proper decimal storage