### PR TITLE
refactor category edit modal for improved functionality

### DIFF
--- a/resources/views/livewire/settings/categories.blade.php
+++ b/resources/views/livewire/settings/categories.blade.php
@@ -7,10 +7,7 @@
                     .querySelector('[x-data]'),
             )
             $tallstackuiSelect('category-parent-id').mergeRequestParams({
-                where: [
-                    ['model_type', '=', $wire.category.model_type],
-                    ['contact_id', '=', $wire.category.id],
-                ],
+                where: [['model_type', '=', $wire.category.model_type]],
             })
         },
     }"
@@ -18,12 +15,16 @@
     @section('modals')
     <x-modal
         id="edit-category-modal"
-        x-on:open="setCategorySearch()"
+        x-on:open="setCategorySearch(); $focusOn('category-name');"
         :title="$category->id ? __('Edit Category') : __('Create Category')"
     >
         <div class="flex flex-col gap-1.5">
             @section('modals.edit-category.content')
-            <x-input wire:model="category.name" :label="__('Name')"></x-input>
+            <x-input
+                id="category-name"
+                wire:model="category.name"
+                :label="__('Name')"
+            ></x-input>
             <div class="mt-2">
                 <x-toggle
                     wire:model="category.is_active"
@@ -35,6 +36,7 @@
                     x-bind:disabled="$wire.category.id"
                     label="{{ __('Model') }}"
                     placeholder="{{ __('Model') }}"
+                    x-on:select="setCategorySearch()"
                     wire:model="category.model_type"
                     required
                     :options="$models"

--- a/resources/views/livewire/settings/countries.blade.php
+++ b/resources/views/livewire/settings/countries.blade.php
@@ -1,4 +1,4 @@
-<x-modal id="edit-country-modal">
+<x-modal id="edit-country-modal" x-on:open="$focusOn('country.name')">
     <div class="flex flex-col gap-1.5">
         <x-input wire:model="country.name" :label="__('Country Name')" />
         <x-select.styled


### PR DESCRIPTION
## Summary by Sourcery

Refactor the category edit modal to improve usability by auto-focusing the name field on open, refreshing parent category search on modal open or model type changes, and simplifying parent category filtering to only use model type.

Enhancements:
- Simplify parent category dropdown filtering to only consider model type
- Auto-focus the category name input when opening the edit modal
- Add an ID to the name input to support focusing
- Trigger category search upon model type selection changes