### PR TITLE
Add download button for multiple media with permission check

### DIFF
--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -167,13 +167,16 @@
                                 />
                             @endcanAction
 
-                            <x-button
-                                color="secondary"
-                                light
-                                loading
-                                :text="__('Download folder')"
-                                x-on:click="$wire.downloadCollection(getNodePath(selection, 'collection_name'))"
-                            />
+                            @canAction(\FluxErp\Actions\Media\DownloadMultipleMedia::class)
+                                <x-button
+                                    color="secondary"
+                                    light
+                                    loading
+                                    :text="__('Download folder')"
+                                    x-on:click="$wire.downloadCollection(getNodePath(selection, 'collection_name'))"
+                                />
+                            @endcanAction
+
                             @show
                         </div>
                         @section('folder-tree.upload.attributes')


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Wrap the folder download button in a permission check for the DownloadMultipleMedia action