### PR TITLE
fix: adjust end and start date parsing to set to end of day for custo…

### DIFF
--- a/resources/views/livewire/settings/user-edit.blade.php
+++ b/resources/views/livewire/settings/user-edit.blade.php
@@ -50,17 +50,20 @@
         @section('user-edit.selects')
         <x-select.styled
             wire:model="userForm.language_id"
+            searchable
             :label="__('Language')"
             select="label:name|value:id"
             :options="$languages"
         />
         <x-select.styled
             wire:model="userForm.timezone"
+            searchable
             :label="__('Timezone')"
             :options="timezone_identifiers_list()"
         />
         <x-select.styled
             wire:model="userForm.parent_id"
+            searchable
             :label="__('Parent')"
             select="label:name|value:id|description:email"
             :options="$users"

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -72,7 +72,7 @@ trait IsTimeFrameAwareWidget
     protected function getStart(): Carbon|CarbonImmutable|null
     {
         return $this->timeFrame === TimeFrameEnum::Custom && $this->start
-            ? Carbon::parse($this->start)->endOfDay()
+            ? Carbon::parse($this->start)->startOfDay()
             : data_get($this->timeFrame->getRange(), 0)?->startOfDay();
     }
 

--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -47,7 +47,7 @@ trait IsTimeFrameAwareWidget
     protected function getEnd(): Carbon|CarbonImmutable|null
     {
         return $this->timeFrame === TimeFrameEnum::Custom && $this->end
-            ? Carbon::parse($this->end)
+            ? Carbon::parse($this->end)->endOfDay()
             : data_get($this->timeFrame->getRange(), 1)?->endOfDay();
     }
 
@@ -72,7 +72,7 @@ trait IsTimeFrameAwareWidget
     protected function getStart(): Carbon|CarbonImmutable|null
     {
         return $this->timeFrame === TimeFrameEnum::Custom && $this->start
-            ? Carbon::parse($this->start)
+            ? Carbon::parse($this->start)->endOfDay()
             : data_get($this->timeFrame->getRange(), 0)?->startOfDay();
     }
 


### PR DESCRIPTION
…m time frames

## Summary by Sourcery

Ensure that custom time frame dates are normalized to the end of the day when parsed.

Bug Fixes:
- Parse custom end dates with endOfDay() to include the full day
- Parse custom start dates with endOfDay() to include the full day