### PR TITLE
refactor: enhance authentication checks in views and tests

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -39,12 +39,15 @@
 
         @show
         @persist('notifications')
-            <div
-                id="{{ \Illuminate\Support\Str::uuid() }}"
-                x-on:tallstackui:toast-upsert.window="$tallstackuiToast($el.id).upsertToast($event)"
-            >
-                <x-toast z-index="z-50"></x-toast>
-            </div>
+            @if (auth()->check() && auth()->id())
+                <div
+                    id="{{ \Illuminate\Support\Str::uuid() }}"
+                    x-on:tallstackui:toast-upsert.window="$tallstackuiToast($el.id).upsertToast($event)"
+                >
+                    <x-toast z-index="z-50"></x-toast>
+                </div>
+            @endif
+
             <x-dialog z-index="z-40" blur="md" align="center" />
         @endpersist
 
@@ -101,7 +104,7 @@
         @endauth
 
         <x-flux::layout>
-            @if (! $navigation && auth()->check() && ! request()->routeIs('logout'))
+            @if (! $navigation && auth()->check() && auth()->id() && ! request()->routeIs('logout'))
                 <x-slot:header>
                     <x-layout.header without-mobile-button>
                         <x-slot:left>
@@ -112,12 +115,15 @@
                                 x-on:click="$dispatch('menu-force-open')"
                             />
                         </x-slot>
-                        <div
-                            x-persist="layout.header.search-bar"
-                            class="grow"
-                        >
-                            <livewire:features.search-bar />
-                        </div>
+                        @auth('web')
+                            <div
+                                x-persist="layout.header.search-bar"
+                                class="grow"
+                            >
+                                <livewire:features.search-bar />
+                            </div>
+                        @endauth
+
                         <div class="flex gap-2 overflow-hidden">
                             @persist('layout.header.cart')
                                 @canAction(\FluxErp\Actions\Cart\CreateCart::class)
@@ -125,9 +131,11 @@
                                 @endcanAction
                             @endpersist
 
-                            @canAction(\FluxErp\Actions\WorkTime\CreateWorkTime::class)
-                                <livewire:work-time lazy />
-                            @endcanAction
+                            @auth('web')
+                                @canAction(\FluxErp\Actions\WorkTime\CreateWorkTime::class)
+                                    <livewire:work-time lazy />
+                                @endcanAction
+                            @endauth
 
                             @persist('layout.header.notifications')
                                 <livewire:features.notifications lazy />
@@ -137,7 +145,7 @@
                 </x-slot>
             @endif
 
-            @if (auth()->check() && ! request()->routeIs('logout') && method_exists(auth()->guard(), 'getName') && ! $navigation)
+            @if (auth()->check() && auth()->id() && ! request()->routeIs('logout') && method_exists(auth()->guard(), 'getName') && ! $navigation)
                 <x-slot:menu>
                     @php($navigation = true)
                     @persist('navigation')

--- a/src/View/Components/Layout.php
+++ b/src/View/Components/Layout.php
@@ -18,7 +18,7 @@ class Layout extends TallStackUiLayout
         return Arr::dot([
             'wrapper' => [
                 'first' => 'h-full flex flex-col',
-                'second' => 'flex flex-col w-full grow md:pl-20',
+                'second' => 'flex flex-col w-full grow' . (auth()->check() && auth()->id() ? ' md:pl-20' : ''),
             ],
             'main' => 'h-full mx-auto w-full max-w-full p-4 md:p-10',
         ]);

--- a/tests/Livewire/InstallWizardTest.php
+++ b/tests/Livewire/InstallWizardTest.php
@@ -25,7 +25,8 @@ class InstallWizardTest extends TestCase
         Config::set('flux.install_done', false);
         Config::set('queue.default', 'sync');
 
-        $component = Livewire::test(InstallWizard::class)
+        $component = Livewire::withoutLazyLoading()
+            ->test(InstallWizard::class)
             ->assertStatus(200)
             ->call('testDatabaseConnection')
             ->assertHasNoErrors()
@@ -171,7 +172,8 @@ class InstallWizardTest extends TestCase
     {
         Config::set('flux.install_done', false);
 
-        Livewire::test(InstallWizard::class)
+        Livewire::withoutLazyLoading()
+            ->test(InstallWizard::class)
             ->assertStatus(200);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Tighten authentication checks in views by requiring auth()->id() and wrap interface components accordingly, and adjust Livewire tests to disable lazy loading for the InstallWizard component.

Enhancements:
- Tighten authentication guards in Blade templates to require an authenticated user ID before rendering toast notifications, search bar, work time component, and navigation menu.
- Apply conditional CSS padding in the layout component only if an authenticated user is present.

Tests:
- Disable Livewire lazy loading in InstallWizard tests via Livewire::withoutLazyLoading().