### PR TITLE
add Order model import to Attachments and extend LeadTableSeeder from Seeder

### DIFF
--- a/database/seeders/LeadTableSeeder.php
+++ b/database/seeders/LeadTableSeeder.php
@@ -5,8 +5,9 @@ namespace FluxErp\Database\Seeders;
 use App\Models\Address;
 use FluxErp\Models\Lead;
 use FluxErp\Models\User;
+use Illuminate\Database\Seeder;
 
-class LeadTableSeeder
+class LeadTableSeeder extends Seeder
 {
     public function run(): void
     {

--- a/src/Livewire/Order/Attachments.php
+++ b/src/Livewire/Order/Attachments.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Livewire\Order;
 
 use FluxErp\Livewire\Support\FolderTree;
+use FluxErp\Models\Order;
 
 class Attachments extends FolderTree
 {


### PR DESCRIPTION
## Summary by Sourcery

Extend LeadTableSeeder to inherit from the base Seeder class and import the Order model into the Attachments Livewire component.

Enhancements:
- Extend LeadTableSeeder from Illuminate\Database\Seeder by adding the base Seeder import.
- Import FluxErp\Models\Order in the Attachments Livewire component.