### PR TITLE
fix: update Address model import path in LeadTableSeeder

### DIFF
--- a/database/seeders/LeadTableSeeder.php
+++ b/database/seeders/LeadTableSeeder.php
@@ -2,7 +2,7 @@
 
 namespace FluxErp\Database\Seeders;
 
-use App\Models\Address;
+use FluxErp\Models\Address;
 use FluxErp\Models\Lead;
 use FluxErp\Models\User;
 use Illuminate\Database\Seeder;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct Address model namespace import to FluxErp\Models in LeadTableSeeder.