### PR TITLE
style: add bottom margin to body in print media query

### DIFF
--- a/resources/views/components/print/style.blade.php
+++ b/resources/views/components/print/style.blade.php
@@ -120,4 +120,10 @@
             background: #f5f5f5;
         }
     }
+
+    @media print {
+        body {
+            margin-bottom: 30px;
+        }
+    }
 </style>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a 30px bottom margin to the body within the print media query to prevent content from clipping at the page edge