### PR TITLE
Won leads by sales representative widget

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2046,6 +2046,7 @@
     "wire:confirm.recalculate-product-names": "Produktnamen neu berechnen|Sollen die ausgewählten Produktnamen neu berechnet werden?|Abbrechen|Ja",
     "wire:confirm.uninstall-plugin": "Plugin deinstallieren|Soll das Plugin wirklich deinstalliert werden?|Abbrechen|Deinstallieren",
     "With column layout": "Mit Spaltenlayout",
+    "Won Leads By Sales Representative": "Gewonnene Leads nach Vertriebsmitarbeiter",
     "Work Time": "Arbeitszeit",
     "Work Time Type": "Arbeitszeitart",
     "Work Time Type Id": "Arbeitszeitart-ID",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2046,6 +2046,7 @@
     "wire:confirm.recalculate-product-names": "Produktnamen neu berechnen|Sollen die ausgewählten Produktnamen neu berechnet werden?|Abbrechen|Ja",
     "wire:confirm.uninstall-plugin": "Plugin deinstallieren|Soll das Plugin wirklich deinstalliert werden?|Abbrechen|Deinstallieren",
     "With column layout": "Mit Spaltenlayout",
+    "Won leads by :user": "Gewonnene Leads von :user",
     "Won Leads By Sales Representative": "Gewonnene Leads nach Vertriebsmitarbeiter",
     "Work Time": "Arbeitszeit",
     "Work Time Type": "Arbeitszeitart",

--- a/lang/de.json
+++ b/lang/de.json
@@ -349,6 +349,7 @@
     "Bcc": "BCC",
     "Between": "Zwischen",
     "between": "zwischen",
+    "between :start and :end": "zwischen :start und :end",
     "Bic": "BIC",
     "Birthdays": "Geburtstage",
     "Booking Date": "Buchungsdatum",

--- a/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
+++ b/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets;
+
+use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
+use FluxErp\Models\User;
+use FluxErp\Traits\Livewire\IsTimeFrameAwareWidget;
+use Livewire\Attributes\Js;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Renderless;
+
+class WonLeadsBySalesRepresentative extends BarChart
+{
+    use IsTimeFrameAwareWidget;
+
+    public ?array $chart = [
+        'type' => 'bar',
+    ];
+
+    public ?array $dataLabels = [
+        'enabled' => true,
+    ];
+
+    public ?array $plotOptions = [
+        'bar' => [
+            'horizontal' => true,
+            'endingShape' => 'rounded',
+            'columnWidth' => '75%',
+        ],
+    ];
+
+    public bool $showTotals = false;
+
+    #[Locked]
+    public ?int $userId = null;
+
+    public static function dashboardComponent(): array|string
+    {
+        return Dashboard::class;
+    }
+
+    public function mount(): void
+    {
+        $this->userId = $this->userId ?? auth()->id();
+
+        parent::mount();
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->calculateChart();
+        $this->updateData();
+    }
+
+    public function calculateChart(): void
+    {
+        $colors = [
+            'lime-400',
+            'sky-400',
+            'violet-400',
+            'cyan-400',
+            'blue-400',
+            'purple-400',
+            'green-400',
+            'indigo-400',
+            'fuchsia-400',
+            'emerald-400',
+            'pink-400',
+            'teal-400',
+        ];
+
+        $leadCounts = resolve_static(User::class, 'query')
+            ->withCount([
+                'leads as total' => function ($query): void {
+                    $query->whereHas('leadState', function ($q): void {
+                        $q->where('is_won', 1);
+                    });
+                },
+            ])
+            ->limit(10)
+            ->get(['name', 'color'])
+            ->filter(fn ($user) => $user->total > 0);
+
+        $data = $leadCounts
+            ->map(function ($user) use (&$colors) {
+                return [
+                    'name' => $user->name,
+                    'color' => $user->color ?: array_shift($colors),
+                    'data' => [$user->total],
+                ];
+            })
+            ->sortByDesc(fn ($item) => $item['data'][0])
+            ->values()
+            ->all();
+
+        $this->xaxis = [
+            'categories' => [''], // necessary to remove y-label
+        ];
+
+        $this->series = $data;
+    }
+
+    #[Js]
+    public function dataLabelsFormatter(): string
+    {
+        return <<<'JS'
+        return opts.w.config.series[opts.seriesIndex].name + ': ' + val;
+    JS;
+    }
+
+    public function showTitle(): bool
+    {
+        return true;
+    }
+}

--- a/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
+++ b/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
@@ -10,6 +10,7 @@ use FluxErp\Models\User;
 use FluxErp\Traits\Livewire\IsTimeFrameAwareWidget;
 use FluxErp\Traits\Widgetable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Js;
 use Livewire\Attributes\Renderless;
 use Livewire\Livewire;
@@ -79,10 +80,10 @@ class WonLeadsBySalesRepresentative extends BarChart implements HasWidgetOptions
 
         $i = 0;
         $this->series = $leadCounts
-            ->map(function ($user) use (&$i, $colors): array {
+            ->map(function (Model $user) use (&$i, $colors): array {
                 return [
-                    'id' => $user->id,
-                    'name' => $user->name,
+                    'id' => $user->getKey(),
+                    'name' => $user->getLabel(),
                     'color' => $user->color ?? $colors[$i++ % count($colors)],
                     'data' => [$user->total],
                 ];
@@ -131,7 +132,10 @@ class WonLeadsBySalesRepresentative extends BarChart implements HasWidgetOptions
             fn (Builder $query) => $query
                 ->where('user_id', data_get($params, 'id'))
                 ->whereBetween('end', [$start, $end])
-                ->whereHas('leadState', fn (Builder $q) => $q->where('is_won', true)),
+                ->whereHas(
+                    'leadState',
+                    fn (Builder $query) => $query->where('is_won', true)
+                ),
             __('Won leads by :user', ['user' => data_get($params, 'name')]) . ' ' .
             __('between :start and :end', ['start' => $start, 'end' => $end]),
         )

--- a/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
+++ b/src/Livewire/Widgets/WonLeadsBySalesRepresentative.php
@@ -152,8 +152,8 @@ class WonLeadsBySalesRepresentative extends BarChart implements HasWidgetOptions
                 ->where('user_id', $salesRepresentativeId)
                 ->whereBetween('end', [$start, $end])
                 ->whereHas('leadState', fn (Builder $q) => $q->where('is_won', true)),
-            __('Leads von :user', ['user' => $salesRepresentativeName]) . ' ' .
-            __('zwischen :start und :end', ['start' => $localizedStart, 'end' => $localizedEnd]),
+            __('Won leads by :user', ['user' => $salesRepresentativeName]) . ' ' .
+            __('between :start and :end', ['start' => $localizedStart, 'end' => $localizedEnd]),
         )->store();
 
         $this->redirectRoute('sales.leads', navigate: true);


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new dashboard widget that visualizes the number of won leads by sales representative over a selectable time frame, with per-user scoping, color-coded series, and formatted data labels.

New Features:
- Add WonLeadsBySalesRepresentative Livewire widget to display won leads per sales representative as a horizontal bar chart with time-frame filtering.

Enhancements:
- Default the widget’s scope to the authenticated user, enable toggling of total values, and assign dynamic colors to each series sorted by lead count.
- Implement a custom JavaScript data-labels formatter and configure chart options (horizontal orientation, rounded ends, and enabled labels).

Documentation:
- Include German locale entries for the new widget.