### PR TITLE
add weighted gross profit and revenue columns to leads table

### DIFF
--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -19,10 +19,12 @@ class LeadFactory extends Factory
             'loss_reason' => $this->faker->realText(),
             'start' => $start->format('Y-m-d'),
             'end' => $this->faker->dateTimeBetween($start, '+2 months')->format('Y-m-d'),
-            'probability_percentage' => $this->faker->randomFloat(2, 0, 1),
+            'probability_percentage' => $probability = $this->faker->randomFloat(2, 0, 1),
             'expected_revenue' => $expectedRevenue = $this->faker->numberBetween(100, 90000),
-            'expected_gross_profit' => $this->faker->numberBetween(0, $expectedRevenue),
+            'expected_gross_profit' => $expectedGrossProfit = $this->faker->numberBetween(0, $expectedRevenue),
             'score' => $this->faker->numberBetween(0, 5),
+            'weighted_gross_profit' => $expectedGrossProfit * $probability,
+            'weighted_revenue' => $expectedRevenue * $probability,
         ];
     }
 }

--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -23,8 +23,8 @@ class LeadFactory extends Factory
             'expected_revenue' => $expectedRevenue = $this->faker->numberBetween(100, 90000),
             'expected_gross_profit' => $expectedGrossProfit = $this->faker->numberBetween(0, $expectedRevenue),
             'score' => $this->faker->numberBetween(0, 5),
-            'weighted_gross_profit' => $expectedGrossProfit * $probability,
-            'weighted_revenue' => $expectedRevenue * $probability,
+            'weighted_gross_profit' => bcmul($expectedGrossProfit, $probability),
+            'weighted_revenue' => bcmul($expectedRevenue, $probability),
         ];
     }
 }

--- a/database/migrations/2025_06_17_120707_add_weighted_revenue_and_weighted_gross_profit_to_leads_table.php
+++ b/database/migrations/2025_06_17_120707_add_weighted_revenue_and_weighted_gross_profit_to_leads_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table): void {
+            $table->decimal('weighted_gross_profit', 40, 10)->nullable()->after('score');
+            $table->decimal('weighted_revenue', 40, 10)->nullable()->after('weighted_gross_profit');
+        });
+
+        $this->calculate_weighted_gross_profit();
+        $this->calculate_weighted_revenue();
+    }
+
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table): void {
+            $table->dropColumn(['weighted_gross_profit', 'weighted_revenue']);
+        });
+    }
+
+    protected function calculate_weighted_gross_profit(): void
+    {
+        DB::transaction(function (): void {
+            DB::table('leads')
+                ->update([
+                    'weighted_gross_profit' => DB::raw(
+                        'COALESCE(expected_gross_profit, 0) * COALESCE(probability_percentage, 0)'
+                    ),
+                ]);
+        });
+    }
+
+    protected function calculate_weighted_revenue(): void
+    {
+        DB::transaction(function (): void {
+            DB::table('leads')
+                ->update([
+                    'weighted_revenue' => DB::raw(
+                        'COALESCE(expected_revenue, 0) * COALESCE(probability_percentage, 0)'
+                    ),
+                ]);
+        });
+    }
+};

--- a/database/migrations/2025_06_17_120707_add_weighted_revenue_and_weighted_gross_profit_to_leads_table.php
+++ b/database/migrations/2025_06_17_120707_add_weighted_revenue_and_weighted_gross_profit_to_leads_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class() extends Migration
@@ -13,8 +14,7 @@ return new class() extends Migration
             $table->decimal('weighted_revenue', 40, 10)->nullable()->after('weighted_gross_profit');
         });
 
-        $this->calculate_weighted_gross_profit();
-        $this->calculate_weighted_revenue();
+        $this->calculateWeightedValues();
     }
 
     public function down(): void
@@ -24,27 +24,11 @@ return new class() extends Migration
         });
     }
 
-    protected function calculate_weighted_gross_profit(): void
+    protected function calculateWeightedValues(): void
     {
-        DB::transaction(function (): void {
-            DB::table('leads')
-                ->update([
-                    'weighted_gross_profit' => DB::raw(
-                        'COALESCE(expected_gross_profit, 0) * COALESCE(probability_percentage, 0)'
-                    ),
-                ]);
-        });
-    }
-
-    protected function calculate_weighted_revenue(): void
-    {
-        DB::transaction(function (): void {
-            DB::table('leads')
-                ->update([
-                    'weighted_revenue' => DB::raw(
-                        'COALESCE(expected_revenue, 0) * COALESCE(probability_percentage, 0)'
-                    ),
-                ]);
-        });
+        DB::statement('UPDATE leads
+            SET weighted_gross_profit = COALESCE(expected_gross_profit, 0) * COALESCE(probability_percentage, 0),
+                weighted_revenue = COALESCE(expected_revenue, 0) * COALESCE(probability_percentage, 0)'
+        );
     }
 };


### PR DESCRIPTION
## Summary by Sourcery

Add new weighted gross profit and revenue columns to the leads table and populate them based on existing expected values and probability percentage during migration.

Enhancements:
- Add weighted_gross_profit and weighted_revenue decimal columns to the leads table
- Backfill weighted_gross_profit and weighted_revenue from expected gross profit/revenue multiplied by probability percentage