### PR TITLE
additional columns donut chart

### DIFF
--- a/src/Livewire/Widgets/ContactsByContactOrigin.php
+++ b/src/Livewire/Widgets/ContactsByContactOrigin.php
@@ -2,15 +2,20 @@
 
 namespace FluxErp\Livewire\Widgets;
 
+use FluxErp\Contracts\HasWidgetOptions;
 use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Livewire\DataTables\ContactList;
 use FluxErp\Livewire\Support\Widgets\Charts\CircleChart;
 use FluxErp\Models\Contact;
 use FluxErp\Support\Metrics\Charts\Donut;
 use FluxErp\Traits\Livewire\IsTimeFrameAwareWidget;
 use FluxErp\Traits\Widgetable;
+use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Renderless;
+use Livewire\Livewire;
+use TeamNiftyGmbH\DataTable\Helpers\SessionFilter;
 
-class ContactsByContactOrigin extends CircleChart
+class ContactsByContactOrigin extends CircleChart implements HasWidgetOptions
 {
     use IsTimeFrameAwareWidget, Widgetable;
 
@@ -19,6 +24,8 @@ class ContactsByContactOrigin extends CircleChart
     ];
 
     public bool $showTotals = false;
+
+    protected $contactOriginIds = [];
 
     public static function dashboardComponent(): array|string
     {
@@ -34,21 +41,40 @@ class ContactsByContactOrigin extends CircleChart
 
     public function calculateChart(): void
     {
-        $metrics = Donut::make(
+        $assignedMetrics = Donut::make(
             resolve_static(Contact::class, 'query')
                 ->whereNotNull('contact_origin_id')
-                ->join('contact_origins', 'contact_origins.id', '=', 'contacts.contact_origin_id')
-                ->where('contact_origins.is_active', true)
+                ->whereHas('contactOrigin', function ($query): void {
+                    $query->where('is_active', true);
+                })
+                ->with('contactOrigin:id,name,is_active')
                 ->orderByRaw('COUNT(*) DESC')
         )
             ->setRange($this->timeFrame)
-            ->setEndingDate($this->end)
-            ->setStartingDate($this->start)
+            ->setEndingDate($this->getEnd())
+            ->setStartingDate($this->getStart())
+            ->additionalColumns(['contactOrigin.id'])
             ->setLabelKey('contactOrigin.name')
             ->count('contact_origin_id');
 
-        $this->series = $metrics->getData();
-        $this->labels = $metrics->getLabels();
+        $startDate = $this->getStart();
+        $endDate = $this->getEnd();
+
+        $this->contactOriginIds = $assignedMetrics->getAdditionalData()[0];
+
+        $unassignedCount = resolve_static(Contact::class, 'query')
+            ->whereNull('contact_origin_id')
+            ->where('contacts.created_at', '>=', $startDate)
+            ->where('contacts.created_at', '<=', $endDate)
+            ->count();
+
+        $this->series = $assignedMetrics->getData();
+        $this->labels = $assignedMetrics->getLabels();
+
+        if ($unassignedCount > 0) {
+            $this->series[] = $unassignedCount;
+            $this->labels[] = __('Unassigned Contacts');
+        }
     }
 
     public function getPlotOptions(): array
@@ -66,6 +92,48 @@ class ContactsByContactOrigin extends CircleChart
                 ],
             ],
         ];
+    }
+
+    #[Renderless]
+    public function options(): array
+    {
+        return collect($this->labels)
+            ->map(fn (string $label, int $index) => [
+                'label' => $label,
+                'method' => 'show',
+                'params' => [$label, $this->contactOriginIds[$index] ?? null],
+            ])
+            ->toArray();
+    }
+
+    #[Renderless]
+    public function show(array $params): void
+    {
+        $startCarbon = $this->getStart();
+        $endCarbon = $this->getEnd();
+
+        $localizedStart = $startCarbon->translatedFormat('j. F Y');
+        $localizedEnd = $endCarbon->translatedFormat('j. F Y');
+
+        $contactLabel = $params[0];
+        $contactOriginId = $params[1] ?? null;
+
+        $isUnassigned = $contactLabel === __('Unassigned Contacts');
+
+        SessionFilter::make(
+            Livewire::new(resolve_static(ContactList::class, 'class'))->getCacheKey(),
+            fn (Builder $query) => $query
+                ->whereBetween('created_at', [$startCarbon, $endCarbon])
+                ->when(! $isUnassigned, function (Builder $query) use ($contactOriginId) {
+                    return $query->where('contact_origin_id', $contactOriginId);
+                })
+                ->when($isUnassigned, fn ($q) => $q->whereNull('contact_origin_id')),
+            __('Contacts by :contact-origin', ['contact-origin' => $contactLabel]) . ' ' .
+            __('between :start and :end', ['start' => $localizedStart, 'end' => $localizedEnd]),
+        )
+            ->store();
+
+        $this->redirectRoute('contacts.contacts', navigate: true);
     }
 
     public function showTitle(): bool

--- a/src/Support/Metrics/Results/Result.php
+++ b/src/Support/Metrics/Results/Result.php
@@ -7,16 +7,27 @@ class Result
     public function __construct(
         protected array $data,
         protected array $labels,
-        protected null|string|float|array $growthRate
+        protected null|string|float|array $growthRate,
+        protected array $additionalData = []
     ) {}
 
-    public static function make(array $data, array $labels, null|string|float|array $growthRate): static
-    {
+    public static function make(
+        array $data,
+        array $labels,
+        null|string|float|array $growthRate,
+        array $additionalData = []
+    ): static {
         return app(static::class, [
             'data' => $data,
             'labels' => $labels,
             'growthRate' => $growthRate,
+            'additionalData' => $additionalData,
         ]);
+    }
+
+    public function getAdditionalData(): array
+    {
+        return $this->additionalData;
     }
 
     public function getCombinedData(): array


### PR DESCRIPTION
## Summary by Sourcery

Implement additionalColumns support in Donut metrics and wire it into the ContactsByContactOrigin Livewire widget to enable clickable chart segments that apply session filters and navigate to the contact list

New Features:
- Allow specifying additional columns in Donut metrics to include extra data per segment
- Expose additional data from Donut Result objects through a new getAdditionalData() method
- Add interactive segment-click behavior in ContactsByContactOrigin widget to filter and navigate to contact list

Enhancements:
- Replace raw join with whereHas and eager loading for contact origins
- Include unassigned contacts as a separate segment in the donut chart