### PR TITLE
fix reactivate calendar event

### DIFF
--- a/resources/views/livewire/features/calendar/calendar-event.blade.php
+++ b/resources/views/livewire/features/calendar/calendar-event.blade.php
@@ -562,6 +562,7 @@
             @show
         </div>
         <x-slot:footer>
+            @section('event-edit.footer')
             <div class="flex w-full justify-between gap-2">
                 <div class="flex justify-start gap-2">
                     <x-button
@@ -575,7 +576,7 @@
                     <x-button
                         :text="__('Cancel Event')"
                         color="red"
-                        x-show="$wire.event.id && !$wire.event.is_cancelled"
+                        x-show="$wire.event.id && !$wire.event.is_cancelled && !$wire.event.calendar_type"
                         x-cloak
                         x-on:click="dialogType = 'cancel'; $modalOpen('confirm-dialog')"
                     />
@@ -609,6 +610,7 @@
                     @endcanAction
                 </div>
             </div>
+            @show
         </x-slot>
     </x-card>
 </div>

--- a/src/Actions/CalendarEvent/ReactivateCalendarEvent.php
+++ b/src/Actions/CalendarEvent/ReactivateCalendarEvent.php
@@ -27,10 +27,12 @@ class ReactivateCalendarEvent extends FluxAction
             ->whereKey($this->data['id'])
             ->first();
 
-        $confirmOption = Arr::pull($event, 'confirm_option');
-        $originalStart = Arr::pull($event, 'original_start');
+        $confirmOption = Arr::pull($this->data, 'confirm_option');
+        $originalStart = Arr::pull($this->data, 'original_start');
 
-        $event->fill($this->getData());
+        if ($confirmOption !== 'this') {
+            $event->fill($this->getData());
+        }
 
         return match ($confirmOption) {
             'this' => $event->fill(
@@ -59,6 +61,10 @@ class ReactivateCalendarEvent extends FluxAction
         $event = resolve_static(CalendarEvent::class, 'query')
             ->whereKey($this->data['id'])
             ->first();
+
+        if ($this->getData('confirm_option') === 'this') {
+            $event->start = $this->getData('original_start');
+        }
 
         if (! $event->isCancelled) {
             throw ValidationException::withMessages([


### PR DESCRIPTION
hide cancel event button on model related calendar events
add footer section to calendar-event.blade.php

## Summary by Sourcery

Fix ReactivateCalendarEvent logic and adjust calendar-event UI to hide cancel button for model-related events and add a footer slot

Bug Fixes:
- Fix ReactivateCalendarEvent to correctly extract confirm_option and original_start from request data and handle single vs. series reactivations

Enhancements:
- Add an `event-edit.footer` Blade section in calendar-event.blade.php for footer customization
- Hide the “Cancel Event” button when the event is associated with a model (calendar_type)