### PR TITLE
hide checkbox if node is not selectable

### DIFF
--- a/resources/views/components/checkbox-tree.blade.php
+++ b/resources/views/components/checkbox-tree.blade.php
@@ -85,18 +85,22 @@
                         x-on:click.stop="node[childrenAttribute] ? toggleOpen(node, $event) : null"
                     ></i>
                     @if ($selectable)
-                        @if ($checkbox?->isNotEmpty())
-                            {{ $checkbox }}
-                        @else
-                            <x-checkbox
-                                sm
-                                x-effect="$el.indeterminate = isIndeterminate(node)"
-                                x-on:change="toggleCheck(node, $event.target.checked)"
-                                x-bind:checked="isChecked(node)"
-                                x-bind:value="node.id"
-                                class="form-checkbox"
-                            />
-                        @endif
+                        <template x-if="node.isSelectable ?? true">
+                            <div>
+                                @if ($checkbox?->isNotEmpty())
+                                    {{ $checkbox }}
+                                @else
+                                    <x-checkbox
+                                        sm
+                                        x-effect="$el.indeterminate = isIndeterminate(node)"
+                                        x-on:change="toggleCheck(node, $event.target.checked)"
+                                        x-bind:checked="isChecked(node)"
+                                        x-bind:value="node.id"
+                                        class="form-checkbox"
+                                    />
+                                @endif
+                            </div>
+                        </template>
                     @endif
 
                     @if (! $hideIcon)

--- a/resources/views/livewire/features/calendar/calendar.blade.php
+++ b/resources/views/livewire/features/calendar/calendar.blade.php
@@ -181,6 +181,7 @@
                     @endcanAction
 
                     <x-slot:checkbox>
+                        @section('checkbox-slot')
                         <x-checkbox
                             sm
                             x-on:folder-tree-uncheck.window="$el.checked = isChecked(node); $el.indeterminate = isIndeterminate(node);"
@@ -192,6 +193,7 @@
                             x-bind:style="'background-color: ' + node.color"
                             class="form-checkbox"
                         />
+                        @show
                     </x-slot>
                     <x-slot:suffix>
                         <div class="size-6">


### PR DESCRIPTION
add checkbox-slot section to calendar

## Summary by Sourcery

Add support for hiding checkboxes on non-selectable nodes in the tree component and introduce a Blade 'checkbox-slot' section in the calendar component for customizing checkbox markup.

Enhancements:
- Render node checkboxes only when `node.isSelectable` is true in the checkbox-tree component
- Wrap checkbox rendering in a `template x-if` block to conditionally hide checkboxes
- Add a `checkbox-slot` Blade section to the calendar component to allow custom checkbox content