### PR TITLE
refactor: improve modal structure and close handling in purchase invoice forms

### DIFF
--- a/database/migrations/2025_06_27_060306_change_is_net_to_default_false_on_purchase_invoices_table.php
+++ b/database/migrations/2025_06_27_060306_change_is_net_to_default_false_on_purchase_invoices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('purchase_invoices', function (Blueprint $table): void {
+            $table->boolean('is_net')->default(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('purchase_invoices', function (Blueprint $table): void {
+            $table->boolean('is_net')->default(true)->change();
+        });
+    }
+};

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -31,7 +31,7 @@
                             : 0
                     }}
                 @endif
-            "
+            )"
         x-init="initTextArea('{{ $id }}',$refs['editor-{{ $id }}'], @json($transparent), @json($tooltipDropdown), @json($defaultFontSize))"
         {{ $attributes->whereDoesntStartWith("wire:model") }}
         wire:ignore

--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -1,434 +1,438 @@
-<x-modal
-    id="edit-purchase-invoice-modal"
-    size="full"
-    scope="fullscreen"
-    spacing=""
->
-    <div class="grid h-full min-h-screen content-stretch gap-4 sm:grid-cols-2">
-        @section('invoice-file')
-        @section('invoice-upload')
-        <div x-cloak x-show="! $wire.purchaseInvoiceForm.id">
-            <x-flux::features.media.upload-form-object
-                :label="__('Invoice')"
-                :multiple="false"
-                accept="application/pdf;image/*"
-                wire:model="mediaForm"
-            />
-        </div>
-        @show
-        @section('invoice-preview')
-        <div x-cloak x-show="$wire.purchaseInvoiceForm.id">
-            <iframe
-                width="100%"
-                height="100%"
-                lazy
-                class="h-full w-full"
-                x-bind:src="$wire.purchaseInvoiceForm.mediaUrl"
-                type="application/pdf"
-            ></iframe>
-        </div>
-        @show
-        @show
-        <div class="flex flex-col gap-1.5 overflow-auto px-2">
-            @section('client')
-            @if (count($clients ?? []) > 1)
+<div>
+    <x-modal
+        id="edit-purchase-invoice-modal"
+        size="full"
+        scope="fullscreen"
+        scrollable
+    >
+        <div
+            class="grid h-full min-h-screen content-stretch gap-4 sm:grid-cols-2"
+        >
+            @section('invoice-file')
+            @section('invoice-upload')
+            <div x-cloak x-show="! $wire.purchaseInvoiceForm.id">
+                <x-flux::features.media.upload-form-object
+                    :label="__('Invoice')"
+                    :multiple="false"
+                    accept="application/pdf;image/*"
+                    wire:model="mediaForm"
+                />
+            </div>
+            @show
+            @section('invoice-preview')
+            <div x-cloak x-show="$wire.purchaseInvoiceForm.id">
+                <iframe
+                    width="100%"
+                    height="100%"
+                    lazy
+                    class="h-full w-full"
+                    x-bind:src="$wire.purchaseInvoiceForm.mediaUrl"
+                    type="application/pdf"
+                ></iframe>
+            </div>
+            @show
+            @show
+            <div class="flex flex-col gap-1.5 overflow-auto px-2">
+                @section('client')
+                @if (count($clients ?? []) > 1)
+                    <div
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-select.styled
+                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                            wire:model="purchaseInvoiceForm.client_id"
+                            :label="__('Client')"
+                            select="label:name|value:id"
+                            :options="$clients"
+                        />
+                    </div>
+                @endif
+
+                @show
+                @section('supplier-data')
                 <div
                     x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
                 >
                     <x-select.styled
+                        x-on:select="$wire.fillFromSelectedContact($event.detail.select?.contact?.id)"
                         x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        wire:model="purchaseInvoiceForm.client_id"
-                        :label="__('Client')"
-                        select="label:name|value:id"
-                        :options="$clients"
-                    />
-                </div>
-            @endif
-
-            @show
-            @section('supplier-data')
-            <div
-                x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-            >
-                <x-select.styled
-                    x-on:select="$wire.fillFromSelectedContact($event.detail.select?.contact?.id)"
-                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                    :label="__('Supplier')"
-                    wire:model="purchaseInvoiceForm.contact_id"
-                    select="label:label|value:contact_id"
-                    unfiltered
-                    :request="[
-                        'url' => route('search', \FluxErp\Models\Address::class),
-                        'method' => 'POST',
-                        'params' => [
-                            'option-value' => 'contact_id',
-                            'fields' => [
-                                'name',
-                                'contact_id',
-                                'firstname',
-                                'lastname',
-                                'company',
-                                'contact',
-                            ],
-                            'where' => [
-                                [
-                                    'is_main_address',
-                                    '=',
-                                    true,
+                        :label="__('Supplier')"
+                        wire:model="purchaseInvoiceForm.contact_id"
+                        select="label:label|value:contact_id"
+                        unfiltered
+                        :request="[
+                            'url' => route('search', \FluxErp\Models\Address::class),
+                            'method' => 'POST',
+                            'params' => [
+                                'option-value' => 'contact_id',
+                                'fields' => [
+                                    'name',
+                                    'contact_id',
+                                    'firstname',
+                                    'lastname',
+                                    'company',
+                                    'contact',
+                                ],
+                                'where' => [
+                                    [
+                                        'is_main_address',
+                                        '=',
+                                        true,
+                                    ],
+                                ],
+                                'with' => [
+                                    'contact.media',
                                 ],
                             ],
-                            'with' => [
-                                'contact.media',
-                            ],
-                        ],
-                    ]"
-                />
-            </div>
-            <div class="flex w-full gap-1.5">
-                @if (count($currencies ?? []) > 1)
+                        ]"
+                    />
+                </div>
+                <div class="flex w-full gap-1.5">
+                    @if (count($currencies ?? []) > 1)
+                        <div
+                            class="flex-1"
+                            x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                        >
+                            <x-select.styled
+                                x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                wire:model="purchaseInvoiceForm.currency_id"
+                                :label="__('Currency')"
+                                select="label:name|value:id"
+                                :options="$currencies"
+                            />
+                        </div>
+                    @endif
+
                     <div
                         class="flex-1"
                         x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
                     >
                         <x-select.styled
                             x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                            wire:model="purchaseInvoiceForm.currency_id"
-                            :label="__('Currency')"
+                            wire:model="purchaseInvoiceForm.order_type_id"
+                            :label="__('Order Type')"
                             select="label:name|value:id"
-                            :options="$currencies"
+                            :options="$orderTypes"
                         />
                     </div>
-                @endif
-
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-select.styled
-                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        wire:model="purchaseInvoiceForm.order_type_id"
-                        :label="__('Order Type')"
-                        select="label:name|value:id"
-                        :options="$orderTypes"
-                    />
-                </div>
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-select.styled
-                        :label="__('Approval User')"
-                        wire:model="purchaseInvoiceForm.approval_user_id"
-                        select="label:label|value:id"
-                        unfiltered
-                        :request="[
-                            'url' => route('search', \FluxErp\Models\User::class),
-                            'method' => 'POST',
-                            'params' => [
-                                'with' => 'media',
-                            ],
-                        ]"
-                    />
-                </div>
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-select.styled
-                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        wire:model="purchaseInvoiceForm.payment_type_id"
-                        :label="__('Payment Type')"
-                        select="label:name|value:id"
-                        :options="$paymentTypes"
-                    />
-                </div>
-            </div>
-            @show
-            @section('invoice-data')
-            <div class="flex w-full gap-1.5">
-                <x-input
-                    class="flex-1"
-                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                    wire:model="purchaseInvoiceForm.invoice_number"
-                    :label="__('Invoice Number')"
-                />
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-date
-                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        without-time
-                        wire:model="purchaseInvoiceForm.invoice_date"
-                        :label="__('Invoice Date')"
-                    />
-                </div>
-            </div>
-            <div class="flex w-full gap-1.5">
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-date
-                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        without-time
-                        wire:model="purchaseInvoiceForm.system_delivery_date"
-                        :label="__('Performance/Delivery date')"
-                    />
-                </div>
-                <div
-                    class="flex-1"
-                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                >
-                    <x-date
-                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                        without-time
-                        wire:model="purchaseInvoiceForm.system_delivery_date_end"
-                        :label="__('Performance/Delivery date end')"
-                    />
-                </div>
-            </div>
-            @show
-            @section('bank-data')
-            <div class="grid grid-cols-2 gap-1.5">
-                <div class="col-span-2">
-                    <x-select.styled
-                        :label="__('Lay out user')"
-                        autocomplete="off"
-                        x-on:select="$wire.purchaseInvoiceForm.iban = $event.detail.select?.iban; $wire.purchaseInvoiceForm.bic = $event.detail.select?.bic; $wire.purchaseInvoiceForm.bank_name = $event.detail.select?.bank_name; $wire.purchaseInvoiceForm.account_holder = $event.detail.select?.account_holder"
-                        wire:model="purchaseInvoiceForm.lay_out_user_id"
-                        select="label:label|value:id"
-                        unfiltered
-                        :request="[
-                            'url' => route('search', \FluxErp\Models\User::class),
-                            'method' => 'POST',
-                            'params' => [
-                                'with' => 'media',
-                                'fields' => [
-                                    'id',
-                                    'name',
-                                    'email',
-                                    'iban',
-                                    'bic',
-                                    'bank_name',
-                                    'account_holder',
+                    <div
+                        class="flex-1"
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-select.styled
+                            :label="__('Approval User')"
+                            wire:model="purchaseInvoiceForm.approval_user_id"
+                            select="label:label|value:id"
+                            unfiltered
+                            :request="[
+                                'url' => route('search', \FluxErp\Models\User::class),
+                                'method' => 'POST',
+                                'params' => [
+                                    'with' => 'media',
                                 ],
-                            ],
-                        ]"
+                            ]"
+                        />
+                    </div>
+                    <div
+                        class="flex-1"
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-select.styled
+                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                            wire:model="purchaseInvoiceForm.payment_type_id"
+                            :label="__('Payment Type')"
+                            select="label:name|value:id"
+                            :options="$paymentTypes"
+                        />
+                    </div>
+                </div>
+                @show
+                @section('invoice-data')
+                <div class="flex w-full gap-1.5">
+                    <x-input
+                        class="flex-1"
+                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                        wire:model="purchaseInvoiceForm.invoice_number"
+                        :label="__('Invoice Number')"
+                    />
+                    <div
+                        class="flex-1"
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-date
+                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                            without-time
+                            wire:model="purchaseInvoiceForm.invoice_date"
+                            :label="__('Invoice Date')"
+                        />
+                    </div>
+                </div>
+                <div class="flex w-full gap-1.5">
+                    <div
+                        class="flex-1"
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-date
+                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                            without-time
+                            wire:model="purchaseInvoiceForm.system_delivery_date"
+                            :label="__('Performance/Delivery date')"
+                        />
+                    </div>
+                    <div
+                        class="flex-1"
+                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                    >
+                        <x-date
+                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                            without-time
+                            wire:model="purchaseInvoiceForm.system_delivery_date_end"
+                            :label="__('Performance/Delivery date end')"
+                        />
+                    </div>
+                </div>
+                @show
+                @section('bank-data')
+                <div class="grid grid-cols-2 gap-1.5">
+                    <div class="col-span-2">
+                        <x-select.styled
+                            :label="__('Lay out user')"
+                            autocomplete="off"
+                            x-on:select="$wire.purchaseInvoiceForm.iban = $event.detail.select?.iban; $wire.purchaseInvoiceForm.bic = $event.detail.select?.bic; $wire.purchaseInvoiceForm.bank_name = $event.detail.select?.bank_name; $wire.purchaseInvoiceForm.account_holder = $event.detail.select?.account_holder"
+                            wire:model="purchaseInvoiceForm.lay_out_user_id"
+                            select="label:label|value:id"
+                            unfiltered
+                            :request="[
+                                'url' => route('search', \FluxErp\Models\User::class),
+                                'method' => 'POST',
+                                'params' => [
+                                    'with' => 'media',
+                                    'fields' => [
+                                        'id',
+                                        'name',
+                                        'email',
+                                        'iban',
+                                        'bic',
+                                        'bank_name',
+                                        'account_holder',
+                                    ],
+                                ],
+                            ]"
+                        />
+                    </div>
+                    <x-input
+                        wire:model="purchaseInvoiceForm.account_holder"
+                        :label="__('Account Holder')"
+                    />
+                    <x-input
+                        wire:model="purchaseInvoiceForm.iban"
+                        :label="__('IBAN')"
+                    />
+                    <x-input
+                        wire:model="purchaseInvoiceForm.bic"
+                        :label="__('BIC')"
+                    />
+                    <x-input
+                        wire:model="purchaseInvoiceForm.bank_name"
+                        :label="__('Bank Name')"
                     />
                 </div>
-                <x-input
-                    wire:model="purchaseInvoiceForm.account_holder"
-                    :label="__('Account Holder')"
+                @show
+                @section('purchase-invoice-positions')
+                <x-toggle
+                    x-bind:disabled="$wire.purchaseInvoiceForm.order_id"
+                    wire:model="purchaseInvoiceForm.is_net"
+                    :label="__('Is Net')"
                 />
-                <x-input
-                    wire:model="purchaseInvoiceForm.iban"
-                    :label="__('IBAN')"
-                />
-                <x-input
-                    wire:model="purchaseInvoiceForm.bic"
-                    :label="__('BIC')"
-                />
-                <x-input
-                    wire:model="purchaseInvoiceForm.bank_name"
-                    :label="__('Bank Name')"
-                />
-            </div>
-            @show
-            @section('purchase-invoice-positions')
-            <x-toggle
-                x-bind:disabled="$wire.purchaseInvoiceForm.order_id"
-                wire:model="purchaseInvoiceForm.is_net"
-                :label="__('Is Net')"
-            />
-            <div
-                x-data="{
-                    recalculatePrices(position, $event) {
-                        const attribute = $event.target.getAttribute('x-model.number')
+                <div
+                    x-data="{
+                        recalculatePrices(position, $event) {
+                            const attribute = $event.target.getAttribute('x-model.number')
 
-                        if (attribute === 'position.total_price') {
-                            position.unit_price = position.total_price / position.amount
-                        } else if (attribute === 'position.unit_price') {
-                            position.total_price = this.position.amount * position.unit_price
-                        } else if (attribute === 'position.amount') {
-                            position.total_price = position.amount * position.unit_price
-                        }
-                    },
-                }"
-            >
-                <template
-                    x-for="(position, index) in $wire.purchaseInvoiceForm.purchase_invoice_positions"
+                            if (attribute === 'position.total_price') {
+                                position.unit_price = position.total_price / position.amount
+                            } else if (attribute === 'position.unit_price') {
+                                position.total_price = this.position.amount * position.unit_price
+                            } else if (attribute === 'position.amount') {
+                                position.total_price = position.amount * position.unit_price
+                            }
+                        },
+                    }"
                 >
-                    <x-card>
-                        <div class="flex flex-col gap-4">
-                            <div
-                                x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                            >
-                                <x-select.styled
-                                    :label="__('Product')"
-                                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                    x-model.number="position.product_id"
-                                    x-on:select="position.name = $event.detail.select?.label"
-                                    select="label:label|value:id|description:product_number"
-                                    unfiltered
-                                    :request="[
-                                        'url' => route('search', \FluxErp\Models\Product::class),
-                                        'method' => 'POST',
-                                        'params' => [
-                                            'whereDoesntHave' => 'children',
-                                            'fields' => [
-                                                'id',
-                                                'name',
-                                                'product_number',
-                                            ],
-                                            'with' => 'media',
-                                        ],
-                                    ]"
-                                />
-                            </div>
-                            <x-input
-                                x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                x-model="position.name"
-                                :label="__('Name')"
-                            />
-                            <div class="flex flex-col gap-1.5 xl:flex-row">
-                                <x-number
-                                    step="0.01"
-                                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                    x-on:keyup="recalculatePrices(position, $event)"
-                                    x-model.number="position.amount"
-                                    :label="__('Amount')"
-                                />
+                    <template
+                        x-for="(position, index) in $wire.purchaseInvoiceForm.purchase_invoice_positions"
+                    >
+                        <x-card>
+                            <div class="flex flex-col gap-4">
                                 <div
                                     x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
                                 >
                                     <x-select.styled
+                                        :label="__('Product')"
                                         x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                        :label="__('Vat Rate')"
-                                        x-model.number="position.vat_rate_id"
-                                        x-init="$el.value = position.vat_rate_id; fillSelectedFromInputValue();"
-                                        select="label:name|value:id"
-                                        :options="$vatRates"
+                                        x-model.number="position.product_id"
+                                        x-on:select="position.name = $event.detail.select?.label"
+                                        select="label:label|value:id|description:product_number"
+                                        unfiltered
+                                        :request="[
+                                            'url' => route('search', \FluxErp\Models\Product::class),
+                                            'method' => 'POST',
+                                            'params' => [
+                                                'whereDoesntHave' => 'children',
+                                                'fields' => [
+                                                    'id',
+                                                    'name',
+                                                    'product_number',
+                                                ],
+                                                'with' => 'media',
+                                            ],
+                                        ]"
                                     />
                                 </div>
-                                <x-number
-                                    step="0.01"
+                                <x-input
                                     x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                    x-on:keyup="recalculatePrices(position, $event)"
-                                    x-model.number="position.unit_price"
-                                    :label="__('Unit Price')"
+                                    x-model="position.name"
+                                    :label="__('Name')"
                                 />
-                                <x-number
-                                    step="0.01"
-                                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                    x-on:keyup="recalculatePrices(position, $event)"
-                                    x-model.number="position.total_price"
-                                    :label="__('Total Price')"
-                                />
-                            </div>
-                            <div
-                                x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
-                                class="w-full"
-                            >
-                                <x-select.styled
-                                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
-                                    :label="__('Ledger Account')"
-                                    x-init="$el.value = position.ledger_account_id; init();"
-                                    x-model.number="position.ledger_account_id"
-                                    select="label:name|value:id|description:number"
-                                    unfiltered
-                                    :request="[
-                                        'url' => route('search', \FluxErp\Models\LedgerAccount::class),
-                                        'method' => 'POST',
-                                        'params' => [
-                                            'where' => [
-                                                [
-                                                    'ledger_account_type_enum',
-                                                    '=',
-                                                    \FluxErp\Enums\LedgerAccountTypeEnum::Expense,
+                                <div class="flex flex-col gap-1.5 xl:flex-row">
+                                    <x-number
+                                        step="0.01"
+                                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                        x-on:keyup="recalculatePrices(position, $event)"
+                                        x-model.number="position.amount"
+                                        :label="__('Amount')"
+                                    />
+                                    <div
+                                        x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                                    >
+                                        <x-select.styled
+                                            x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                            :label="__('Vat Rate')"
+                                            x-model.number="position.vat_rate_id"
+                                            x-init="$el.value = position.vat_rate_id; fillSelectedFromInputValue();"
+                                            select="label:name|value:id"
+                                            :options="$vatRates"
+                                        />
+                                    </div>
+                                    <x-number
+                                        step="0.01"
+                                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                        x-on:keyup="recalculatePrices(position, $event)"
+                                        x-model.number="position.unit_price"
+                                        :label="__('Unit Price')"
+                                    />
+                                    <x-number
+                                        step="0.01"
+                                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                        x-on:keyup="recalculatePrices(position, $event)"
+                                        x-model.number="position.total_price"
+                                        :label="__('Total Price')"
+                                    />
+                                </div>
+                                <div
+                                    x-bind:class="$wire.purchaseInvoiceForm.order_id && 'pointer-events-none'"
+                                    class="w-full"
+                                >
+                                    <x-select.styled
+                                        x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                                        :label="__('Ledger Account')"
+                                        x-init="$el.value = position.ledger_account_id; init();"
+                                        x-model.number="position.ledger_account_id"
+                                        select="label:name|value:id|description:number"
+                                        unfiltered
+                                        :request="[
+                                            'url' => route('search', \FluxErp\Models\LedgerAccount::class),
+                                            'method' => 'POST',
+                                            'params' => [
+                                                'where' => [
+                                                    [
+                                                        'ledger_account_type_enum',
+                                                        '=',
+                                                        \FluxErp\Enums\LedgerAccountTypeEnum::Expense,
+                                                    ],
                                                 ],
                                             ],
-                                        ],
-                                    ]"
-                                />
-                            </div>
-                        </div>
-                        <x-slot:footer>
-                            <div class="flex justify-end">
-                                @canAction(\FluxErp\Actions\PurchaseInvoicePosition\DeletePurchaseInvoicePosition::class)
-                                    <x-button
-                                        x-cloak
-                                        x-show="! $wire.purchaseInvoiceForm.order_id"
-                                        color="red"
-                                        :text="__('Delete')"
-                                        x-on:click="$wire.purchaseInvoiceForm.purchase_invoice_positions.splice(index, 1)"
+                                        ]"
                                     />
-                                @endcanAction
+                                </div>
                             </div>
-                        </x-slot>
-                    </x-card>
-                </template>
-                <div class="flex justify-center pt-4">
-                    @canAction(\FluxErp\Actions\PurchaseInvoicePosition\CreatePurchaseInvoicePosition::class)
-                        <x-button
-                            x-cloak
-                            x-show="! $wire.purchaseInvoiceForm.order_id"
-                            color="emerald"
-                            :text="__('Add Position')"
-                            x-on:click="$wire.purchaseInvoiceForm.purchase_invoice_positions.push({ ledger_account_id: $wire.purchaseInvoiceForm.lastLedgerAccountId, vat_rate_id: null, product_id: null, name: null, amount: 1, unit_price: 0, total_price: 0 })"
-                        />
-                    @endcanAction
+                            <x-slot:footer>
+                                <div class="flex justify-end">
+                                    @canAction(\FluxErp\Actions\PurchaseInvoicePosition\DeletePurchaseInvoicePosition::class)
+                                        <x-button
+                                            x-cloak
+                                            x-show="! $wire.purchaseInvoiceForm.order_id"
+                                            color="red"
+                                            :text="__('Delete')"
+                                            x-on:click="$wire.purchaseInvoiceForm.purchase_invoice_positions.splice(index, 1)"
+                                        />
+                                    @endcanAction
+                                </div>
+                            </x-slot>
+                        </x-card>
+                    </template>
+                    <div class="flex justify-center pt-4">
+                        @canAction(\FluxErp\Actions\PurchaseInvoicePosition\CreatePurchaseInvoicePosition::class)
+                            <x-button
+                                x-cloak
+                                x-show="! $wire.purchaseInvoiceForm.order_id"
+                                color="emerald"
+                                :text="__('Add Position')"
+                                x-on:click="$wire.purchaseInvoiceForm.purchase_invoice_positions.push({ ledger_account_id: $wire.purchaseInvoiceForm.lastLedgerAccountId, vat_rate_id: null, product_id: null, name: null, amount: 1, unit_price: 0, total_price: 0 })"
+                            />
+                        @endcanAction
+                    </div>
                 </div>
-            </div>
-            @show
-        </div>
-    </div>
-    <x-slot:footer>
-        @section('footer-buttons')
-        <div class="flex justify-between">
-            <div>
-                @section('footer-buttons.left')
-                @canAction(\FluxErp\Actions\PurchaseInvoice\ForceDeletePurchaseInvoice::class)
-                    <x-button
-                        color="red"
-                        x-cloak
-                        x-show="$wire.purchaseInvoiceForm.id && ! $wire.purchaseInvoiceForm.order_id"
-                        :text="__('Delete')"
-                        wire:click="delete().then((success) => { if (success) close(); })"
-                        wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Purchase Invoice')]) }}"
-                    />
-                @endcanAction
-
                 @show
             </div>
-            <div class="flex gap-2">
-                @section('footer-buttons.right')
-                <x-button
-                    color="secondary"
-                    light
-                    :text="__('Cancel')"
-                    x-on:click="$modalClose('edit-purchase-invoice-modal')"
-                />
-                <x-button
-                    color="indigo"
-                    x-cloak
-                    x-show="! $wire.purchaseInvoiceForm.order_id"
-                    :text="__('Save')"
-                    wire:click="save().then((success) => { if (success) $modalClose('edit-purchase-invoice-modal'); })"
-                />
-                @canAction(\FluxErp\Actions\PurchaseInvoice\CreateOrderFromPurchaseInvoice::class)
+        </div>
+        <x-slot:footer>
+            @section('footer-buttons')
+            <div class="flex justify-between">
+                <div>
+                    @section('footer-buttons.left')
+                    @canAction(\FluxErp\Actions\PurchaseInvoice\ForceDeletePurchaseInvoice::class)
+                        <x-button
+                            color="red"
+                            x-cloak
+                            x-show="$wire.purchaseInvoiceForm.id && ! $wire.purchaseInvoiceForm.order_id"
+                            :text="__('Delete')"
+                            wire:click="delete().then((success) => { if (success) $modalClose('edit-purchase-invoice-modal'); })"
+                            wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Purchase Invoice')]) }}"
+                        />
+                    @endcanAction
+
+                    @show
+                </div>
+                <div class="flex gap-2">
+                    @section('footer-buttons.right')
+                    <x-button
+                        color="secondary"
+                        light
+                        :text="__('Cancel')"
+                        x-on:click="$modalClose('edit-purchase-invoice-modal')"
+                    />
                     <x-button
                         color="indigo"
                         x-cloak
-                        x-show="$wire.purchaseInvoiceForm.id && ! $wire.purchaseInvoiceForm.order_id"
-                        :text="__('Finish')"
-                        wire:click="finish().then((success) => { if (success) $modalClose('edit-purchase-invoice-modal'); })"
+                        x-show="! $wire.purchaseInvoiceForm.order_id"
+                        :text="__('Save')"
+                        wire:click="save().then((success) => { if (success) $modalClose('edit-purchase-invoice-modal'); })"
                     />
-                @endcanAction
+                    @canAction(\FluxErp\Actions\PurchaseInvoice\CreateOrderFromPurchaseInvoice::class)
+                        <x-button
+                            color="indigo"
+                            x-cloak
+                            x-show="$wire.purchaseInvoiceForm.id && ! $wire.purchaseInvoiceForm.order_id"
+                            :text="__('Finish')"
+                            wire:click="finish().then((success) => { if (success) $modalClose('edit-purchase-invoice-modal'); })"
+                        />
+                    @endcanAction
 
-                @show
+                    @show
+                </div>
             </div>
-        </div>
-        @show
-    </x-slot>
-</x-modal>
+            @show
+        </x-slot>
+    </x-modal>
+</div>

--- a/resources/views/livewire/project/project-task-list.blade.php
+++ b/resources/views/livewire/project/project-task-list.blade.php
@@ -3,7 +3,10 @@
     edit: true,
 }">
     <div id="new-task-modal">
-        <x-modal id="task-form-modal">
+        <x-modal
+            id="task-form-modal"
+            x-on:close="$wire.set('taskTab', 'task.general')"
+        >
             <x-flux::tabs
                 wire:model.live="taskTab"
                 wire:loading="taskTab"
@@ -18,7 +21,7 @@
                             :text="__('Delete')"
                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Task')]) }}"
                             wire:click="delete().then((success) => {
-                                if (success) close();
+                                if (success) $modalClose('task-form-modal');
                             })"
                         />
                     </div>
@@ -41,11 +44,5 @@
                 </div>
             </x-slot>
         </x-modal>
-    </div>
-    <div
-        wire:ignore
-        x-on:data-table-row-clicked="$wire.edit($event.detail.id)"
-    >
-        @include('tall-datatables::livewire.data-table')
     </div>
 </div>

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -55,6 +55,7 @@ class PurchaseInvoiceList extends BaseDataTable
         ];
     }
 
+    #[Renderless]
     public function delete(): bool
     {
         try {
@@ -70,6 +71,7 @@ class PurchaseInvoiceList extends BaseDataTable
         return true;
     }
 
+    #[Renderless]
     public function downloadMedia(Media $media): false|BinaryFileResponse
     {
         if (! file_exists($media->getPath())) {
@@ -119,6 +121,7 @@ class PurchaseInvoiceList extends BaseDataTable
         $this->purchaseInvoiceForm->findMostUsedLedgerAccountId();
     }
 
+    #[Renderless]
     public function finish(): bool
     {
         try {
@@ -151,6 +154,7 @@ class PurchaseInvoiceList extends BaseDataTable
         }
     }
 
+    #[Renderless]
     public function save(): bool
     {
         $this->purchaseInvoiceForm->media = $this->mediaForm->uploadedFile[0] ?? null;

--- a/src/Livewire/Forms/PurchaseInvoiceForm.php
+++ b/src/Livewire/Forms/PurchaseInvoiceForm.php
@@ -11,6 +11,7 @@ use FluxErp\Enums\LedgerAccountTypeEnum;
 use FluxErp\Models\Client;
 use FluxErp\Models\Currency;
 use FluxErp\Models\OrderPosition;
+use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Locked;
 
 class PurchaseInvoiceForm extends FluxForm
@@ -67,7 +68,7 @@ class PurchaseInvoiceForm extends FluxForm
         $this->lastLedgerAccountId = resolve_static(OrderPosition::class, 'query')
             ->whereHas(
                 'ledgerAccount',
-                fn ($query) => $query->where('ledger_account_type_enum', LedgerAccountTypeEnum::Expense)
+                fn (Builder $query) => $query->where('ledger_account_type_enum', LedgerAccountTypeEnum::Expense)
             )
             ->whereHas('order', fn ($query) => $query->where('contact_id', $this->contact_id))
             ->groupBy('ledger_account_id')

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -30,7 +30,7 @@ class ProjectTaskList extends BaseTaskList
 
     public string $taskTab = 'task.general';
 
-    protected string $view = 'flux::livewire.project.project-task-list';
+    protected ?string $includeBefore = 'flux::livewire.project.project-task-list';
 
     public function mount(): void
     {

--- a/tests/Feature/Api/PurchaseInvoiceTest.php
+++ b/tests/Feature/Api/PurchaseInvoiceTest.php
@@ -247,7 +247,7 @@ class PurchaseInvoiceTest extends BaseSetup
             Carbon::parse($dbPurchaseInvoice->invoice_date)->toDateString()
         );
         $this->assertNull($dbPurchaseInvoice->invoice_number);
-        $this->assertTrue($dbPurchaseInvoice->is_net);
+        $this->assertFalse($dbPurchaseInvoice->is_net);
         $this->assertTrue($this->user->is($dbPurchaseInvoice->getCreatedBy()));
         $this->assertTrue($this->user->is($dbPurchaseInvoice->getUpdatedBy()));
         $this->assertEmpty($dbPurchaseInvoice->purchaseInvoicePositions);


### PR DESCRIPTION
## Summary by Sourcery

Refactor and simplify the purchase invoice modal layout, standardize modal close and footer actions across invoice and task forms, optimize Livewire components, and introduce a migration to update the default of is_net on purchase invoices.

Bug Fixes:
- Ensure consistent modal closing on invoice and task forms using $modalClose
- Fix query closure type hint to use Illuminate\Database\Eloquent\Builder in PurchaseInvoiceForm

Enhancements:
- Restructure purchase invoice edit modal into scrollable, sectional layout (file upload, preview, client/supplier, invoice data, bank data, positions)
- Standardize footer buttons for save, delete, finish, and cancel with conditional visibility and modal-close logic
- Add x-on:close handler to project task modal to reset taskTab and use $modalClose for delete actions
- Mark delete, save, finish, and downloadMedia methods as Renderless in Livewire PurchaseInvoiceList to reduce unnecessary rerenders
- Fix syntax in editor component's x-init call

Chores:
- Add migration to change default is_net to false on purchase_invoices table
- Switch ProjectTaskList to use includeBefore view override instead of fixed view