### PR TITLE
use key() with uniqid() for improved uniqueness in grid component

### DIFF
--- a/resources/views/components/dashboard/grid.blade.php
+++ b/resources/views/components/dashboard/grid.blade.php
@@ -36,7 +36,7 @@
                             'wire:model' => $this->wireModel(),
                             'lazy' => true,
                         ]),
-                        uniqid()
+                        key(uniqid())
                     )
                 </div>
             </div>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Wrap uniqid() calls within key() in the grid component to ensure unique keys for Livewire-rendered elements