### PR TITLE
update tallstackui version to ^2.12 and enhance card header styling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spatie/laravel-translatable": "^6.0",
         "spatie/laravel-translation-loader": "^2.7",
         "spatie/pdf-to-image": "^3.0",
-        "tallstackui/tallstackui": "^2.8",
+        "tallstackui/tallstackui": "^2.12",
         "team-nifty-gmbh/tall-datatables": "^1.0",
         "webklex/laravel-imap": "^6.1"
     },

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -131,6 +131,7 @@ class ViewServiceProvider extends ServiceProvider
 
         TallStackUi::personalize()
             ->card()
+            ->block('header.wrapper.border', 'dark:border-b-dark-600 border-b border-gray-100 p-2')
             ->block('header.text.size', 'text-sm font-medium w-full');
 
         TallStackUi::personalize()


### PR DESCRIPTION
## Summary by Sourcery

Update tallstackui dependency to ^2.12 and enhance card header styling

Enhancements:
- Add new wrapper border, padding, and dark mode styling for card headers in TallStackUi personalization

Build:
- Bump tallstackui to version ^2.12