### PR TITLE
fix: update supplier selection to use contact_id in general.blade.php

### DIFF
--- a/resources/views/components/product/general.blade.php
+++ b/resources/views/components/product/general.blade.php
@@ -434,7 +434,7 @@
             <x-select.styled
                 :label="__('Contact')"
                 select="label:label|value:contact_id"
-                x-on:select="$wire.addSupplier($event.detail.select.value); clear();"
+                x-on:select="$wire.addSupplier($event.detail.select.contact_id); clear();"
                 unfiltered
                 :request="[
                     'url' => route('search', \FluxErp\Models\Address::class),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use contact_id instead of generic value in the x-on:select callback for adding suppliers