### PR TITLE
Add loading state to payment button and enhance executePaymentRun logic

### DIFF
--- a/resources/views/livewire/accounting/payment-run/include-before.blade.php
+++ b/resources/views/livewire/accounting/payment-run/include-before.blade.php
@@ -10,7 +10,7 @@
             },
         }"
     >
-        <div class="flex grid grid-cols-1">
+        <div class="grid grid-cols-1">
             <div class="max-h-96 overflow-y-auto">
                 <template x-for="order in $wire.paymentRunForm.orders">
                     <x-flux::list-item class="flex justify-between" :item="[]">
@@ -115,6 +115,7 @@
                 <x-button
                     color="indigo"
                     :text="__('Execute Payment Run')"
+                    loading="executePaymentRun"
                     wire:click="executePaymentRun().then((success) => {if(success) $modalClose('execute-payment-run');})"
                 />
             </div>


### PR DESCRIPTION
## Summary by Sourcery

Add loading indicator to the Execute Payment Run button, refine execution logic to close the modal upon success, and simplify wrapper markup.

Enhancements:
- Show a loading state on the Execute Payment Run button while the payment execution is in progress
- Close the payment run modal only after executePaymentRun resolves successfully
- Simplify the grid wrapper by removing an unnecessary flex class