### PR TITLE
Add total gross price validation and field to purchase invoices

### DIFF
--- a/database/migrations/2025_07_19_163808_add_total_gross_price_to_purchase_invoices_table.php
+++ b/database/migrations/2025_07_19_163808_add_total_gross_price_to_purchase_invoices_table.php
@@ -9,7 +9,7 @@ return new class() extends Migration
     public function up(): void
     {
         Schema::table('purchase_invoices', function (Blueprint $table): void {
-            $table->decimal('total_gross_price', 10)->nullable()->after('bic');
+            $table->decimal('total_gross_price', 40, 10)->nullable()->after('bic');
         });
     }
 

--- a/database/migrations/2025_07_19_163808_add_total_gross_price_to_purchase_invoices_table.php
+++ b/database/migrations/2025_07_19_163808_add_total_gross_price_to_purchase_invoices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('purchase_invoices', function (Blueprint $table): void {
+            $table->decimal('total_gross_price', 10)->nullable()->after('bic');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('purchase_invoices', function (Blueprint $table): void {
+            $table->dropColumn('total_gross_price');
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -1793,6 +1793,7 @@
     "The media collection is read-only and cannot be modified.": "Die Mediensammlung ist schreibgeschützt und kann nicht geändert werden.",
     "The number has already been taken for this type.": "Die Nummer wurde bereits für diesen Typ vergeben.",
     "The token will not be shown again after closing the modal.": "Das Token wird nach dem Schließen des Dialogs nicht mehr angezeigt.",
+    "The total gross price must match the sum of all position total prices.": "Der Gesamt-Bruttopreis muss der Summe aller Positionen entsprechen.",
     "The transactions are being matched with the orders.": "Die Transaktionen werden den Aufträgen zugeordnet.",
     "This event": "Diesen Termin",
     "This event and following": "Diesen Termin und alle Folgenden",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1793,7 +1793,7 @@
     "The media collection is read-only and cannot be modified.": "Die Mediensammlung ist schreibgeschützt und kann nicht geändert werden.",
     "The number has already been taken for this type.": "Die Nummer wurde bereits für diesen Typ vergeben.",
     "The token will not be shown again after closing the modal.": "Das Token wird nach dem Schließen des Dialogs nicht mehr angezeigt.",
-    "The total gross price must match the sum of all position total prices.": "Der Gesamt-Bruttopreis muss der Summe aller Positionen entsprechen.",
+    "The total gross :total-gross must match the sum of all position total prices :pos-total.": "Der Gesamtbetrag brutto :total-gross muss der Summe aller Positionen Gesamtpreise :pos-total entsprechen.",
     "The transactions are being matched with the orders.": "Die Transaktionen werden den Aufträgen zugeordnet.",
     "This event": "Diesen Termin",
     "This event and following": "Diesen Termin und alle Folgenden",

--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -244,6 +244,13 @@
                     wire:model="purchaseInvoiceForm.is_net"
                     :label="__('Is Net')"
                 />
+                <x-number
+                    x-bind:readonly="$wire.purchaseInvoiceForm.order_id"
+                    wire:model="purchaseInvoiceForm.total_gross_price"
+                    step="0.01"
+                    min="0"
+                    :label="__('Total Gross Price')"
+                />
                 <div
                     x-data="{
                         recalculatePrices(position, $event) {

--- a/src/Actions/PurchaseInvoice/CreateOrderFromPurchaseInvoice.php
+++ b/src/Actions/PurchaseInvoice/CreateOrderFromPurchaseInvoice.php
@@ -106,7 +106,18 @@ class CreateOrderFromPurchaseInvoice extends FluxAction
         ) {
             throw ValidationException::withMessages([
                 'iban' => ['iban' => __('validation.required', ['attribute' => 'IBAN'])],
-            ])->errorBag('createOrderFromPurchaseInvoice');
+            ])
+                ->errorBag('createOrderFromPurchaseInvoice');
+        }
+
+        $positionsGrossSum = collect(data_get($this->data, 'purchase_invoice_positions', []))
+            ->sum('total_price');
+
+        if (bccomp($this->getData('total_gross_price'), $positionsGrossSum, 2) !== 0) {
+            throw ValidationException::withMessages([
+                'total_gross_price' => [__('The total gross price must match the sum of all position total prices.')],
+            ])
+                ->errorBag('createOrderFromPurchaseInvoice');
         }
     }
 }

--- a/src/Livewire/Forms/PurchaseInvoiceForm.php
+++ b/src/Livewire/Forms/PurchaseInvoiceForm.php
@@ -63,6 +63,8 @@ class PurchaseInvoiceForm extends FluxForm
 
     public ?string $system_delivery_date_end = null;
 
+    public ?string $total_gross_price = null;
+
     public function findMostUsedLedgerAccountId(): void
     {
         $this->lastLedgerAccountId = resolve_static(OrderPosition::class, 'query')

--- a/src/Models/PurchaseInvoice.php
+++ b/src/Models/PurchaseInvoice.php
@@ -67,7 +67,7 @@ class PurchaseInvoice extends FluxModel implements HasMedia, HasMediaForeignKey
                     $positionGross = $position->total_price;
                 }
 
-                return bcadd($carry, $positionGross, 2);
+                return bcadd($carry, $positionGross);
             },
             '0'
         );

--- a/src/Models/PurchaseInvoice.php
+++ b/src/Models/PurchaseInvoice.php
@@ -46,6 +46,7 @@ class PurchaseInvoice extends FluxModel implements HasMedia, HasMediaForeignKey
         return [
             'invoice_date' => 'date',
             'is_net' => 'boolean',
+            'total_gross_price' => 'decimal:2',
         ];
     }
 

--- a/src/Rulesets/PurchaseInvoice/CreateOrderFromPurchaseInvoiceRuleset.php
+++ b/src/Rulesets/PurchaseInvoice/CreateOrderFromPurchaseInvoiceRuleset.php
@@ -10,6 +10,7 @@ use FluxErp\Models\PaymentType;
 use FluxErp\Models\PurchaseInvoice;
 use FluxErp\Models\User;
 use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\Numeric;
 use FluxErp\Rulesets\ContactBankConnection\BankConnectionRuleset;
 use FluxErp\Rulesets\FluxRuleset;
 use FluxErp\Rulesets\PurchaseInvoicePosition\UpdatePurchaseInvoicePositionRuleset;
@@ -79,6 +80,10 @@ class CreateOrderFromPurchaseInvoiceRuleset extends FluxRuleset
             ],
             'invoice_number' => 'required|string|max:255',
             'invoice_date' => 'required|date',
+            'total_gross_price' => [
+                'required',
+                app(Numeric::class, ['min' => 0]),
+            ],
             'is_net' => 'boolean',
         ];
     }

--- a/src/Rulesets/PurchaseInvoice/CreatePurchaseInvoiceRuleset.php
+++ b/src/Rulesets/PurchaseInvoice/CreatePurchaseInvoiceRuleset.php
@@ -12,6 +12,7 @@ use FluxErp\Models\PurchaseInvoice;
 use FluxErp\Models\User;
 use FluxErp\Rules\MediaUploadType;
 use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\Numeric;
 use FluxErp\Rulesets\ContactBankConnection\BankConnectionRuleset;
 use FluxErp\Rulesets\FluxRuleset;
 
@@ -75,6 +76,10 @@ class CreatePurchaseInvoiceRuleset extends FluxRuleset
             'system_delivery_date' => 'date|nullable|required_with:system_delivery_date_end',
             'system_delivery_date_end' => 'date|nullable|after_or_equal:system_delivery_date',
             'invoice_number' => 'nullable|string|max:255',
+            'total_gross_price' => [
+                'nullable',
+                app(Numeric::class, ['min' => 0]),
+            ],
             'is_net' => 'boolean',
 
             'media' => 'required',

--- a/src/Rulesets/PurchaseInvoice/UpdatePurchaseInvoiceRuleset.php
+++ b/src/Rulesets/PurchaseInvoice/UpdatePurchaseInvoiceRuleset.php
@@ -11,6 +11,7 @@ use FluxErp\Models\PurchaseInvoice;
 use FluxErp\Models\PurchaseInvoicePosition;
 use FluxErp\Models\User;
 use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\Numeric;
 use FluxErp\Rulesets\ContactBankConnection\BankConnectionRuleset;
 use FluxErp\Rulesets\FluxRuleset;
 
@@ -82,6 +83,10 @@ class UpdatePurchaseInvoiceRuleset extends FluxRuleset
             'system_delivery_date' => 'date|nullable|required_with:system_delivery_date_end',
             'system_delivery_date_end' => 'date|nullable|after_or_equal:system_delivery_date',
             'invoice_number' => 'nullable|string|max:255',
+            'total_gross_price' => [
+                'nullable',
+                app(Numeric::class, ['min' => 0]),
+            ],
             'is_net' => 'boolean',
 
             'purchase_invoice_positions' => 'array',

--- a/tests/Feature/Api/PurchaseInvoiceTest.php
+++ b/tests/Feature/Api/PurchaseInvoiceTest.php
@@ -368,7 +368,7 @@ class PurchaseInvoiceTest extends BaseSetup
         $this->assertEquals($dbPurchaseInvoice->payment_type_id, $dbOrder->payment_type_id);
         $this->assertEquals($dbPurchaseInvoice->invoice_date->toDateString(), $dbOrder->invoice_date->toDateString());
         $this->assertEquals($dbPurchaseInvoice->invoice_number, $dbOrder->invoice_number);
-        $this->assertNotNull($dbPurchaseInvoice->total_gross_price);
+        $this->assertEquals($this->purchaseInvoices[0]->total_gross_price, $dbPurchaseInvoice->total_gross_price);
     }
 
     public function test_finish_purchase_invoice_validation_fails(): void

--- a/tests/Feature/Api/PurchaseInvoiceTest.php
+++ b/tests/Feature/Api/PurchaseInvoiceTest.php
@@ -87,6 +87,8 @@ class PurchaseInvoiceTest extends BaseSetup
             ->afterCreating(function (PurchaseInvoice $purchaseInvoice): void {
                 $purchaseInvoice->addMedia(UploadedFile::fake()->image($purchaseInvoice->invoice_number . '.jpeg'))
                     ->toMediaCollection('purchase_invoice');
+
+                $purchaseInvoice->update(['total_gross_price' => $purchaseInvoice->calculateTotalGrossPrice()]);
             })
             ->create([
                 'client_id' => $this->dbClient->getKey(),
@@ -364,6 +366,7 @@ class PurchaseInvoiceTest extends BaseSetup
         $this->assertEquals($dbPurchaseInvoice->payment_type_id, $dbOrder->payment_type_id);
         $this->assertEquals($dbPurchaseInvoice->invoice_date->toDateString(), $dbOrder->invoice_date->toDateString());
         $this->assertEquals($dbPurchaseInvoice->invoice_number, $dbOrder->invoice_number);
+        $this->assertNotNull($dbPurchaseInvoice->total_gross_price);
     }
 
     public function test_finish_purchase_invoice_validation_fails(): void

--- a/tests/Feature/Api/PurchaseInvoiceTest.php
+++ b/tests/Feature/Api/PurchaseInvoiceTest.php
@@ -88,7 +88,9 @@ class PurchaseInvoiceTest extends BaseSetup
                 $purchaseInvoice->addMedia(UploadedFile::fake()->image($purchaseInvoice->invoice_number . '.jpeg'))
                     ->toMediaCollection('purchase_invoice');
 
-                $purchaseInvoice->update(['total_gross_price' => $purchaseInvoice->calculateTotalGrossPrice()]);
+                $purchaseInvoice->update([
+                    'total_gross_price' => bcround($purchaseInvoice->calculateTotalGrossPrice(), 2),
+                ]);
             })
             ->create([
                 'client_id' => $this->dbClient->getKey(),


### PR DESCRIPTION
## Summary by Sourcery

Introduce total_gross_price to purchase invoices by extending the database, model, form and validation layers and ensuring it matches the sum of invoice positions

New Features:
- Add total_gross_price field to purchase invoices with database migration, model casting, and form input

Enhancements:
- Validate total_gross_price as a non-negative number and allow nullable where appropriate
- Enforce that total_gross_price matches the sum of all invoice position total prices during order creation

Chores:
- Add migration to add total_gross_price column to purchase_invoices table