### PR TITLE
add ConversionRateByLeadOrigin widget and fix record origin

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -499,6 +499,7 @@
     "contacts.{id?}.get": "Kontaktdetails anzeigen",
     "Content": "Inhalt",
     "Continue": "Fortsetzen",
+    "Conversion Rate By Lead Origin": "Konversionsrate nach Leadherkunft",
     "Copies": "Kopien",
     "Copy the token to your clipboard.": "Kopieren Sie den Token in Ihre Zwischenablage.",
     "Copy token": "Token kopieren",

--- a/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
+++ b/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
@@ -72,7 +72,6 @@ class ConversionRateByLeadOrigin extends BarChart
             ])
             ->having('total', '>', 0)
             ->orderByDesc('total')
-            ->limit(10)
             ->get();
 
         $leadsWithWonLeadState = resolve_static(RecordOrigin::class, 'query')
@@ -88,7 +87,6 @@ class ConversionRateByLeadOrigin extends BarChart
             ])
             ->having('total', '>', 0)
             ->orderByDesc('total')
-            ->limit(10)
             ->get();
 
         $this->series = $leadsWithWonOrLostLeadState

--- a/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
+++ b/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
@@ -99,8 +99,10 @@ class ConversionRateByLeadOrigin extends BarChart
                             $leadsWithWonLeadState->find($leadWithWonOrLostLeadState->getKey())?->total ?? 0,
                             $leadWithWonOrLostLeadState->total
                         ),
-                        100),
-                    1);
+                        100
+                    ),
+                    1
+                );
 
                 return [
                     'id' => $leadWithWonOrLostLeadState->getKey(),

--- a/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
+++ b/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets;
+
+use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
+use FluxErp\Models\Lead;
+use FluxErp\Models\RecordOrigin;
+use FluxErp\Traits\Livewire\IsTimeFrameAwareWidget;
+use FluxErp\Traits\Widgetable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Js;
+use Livewire\Attributes\Renderless;
+
+class ConversionRateByLeadOrigin extends BarChart
+{
+    use IsTimeFrameAwareWidget, Widgetable;
+
+    public ?array $chart = [
+        'type' => 'bar',
+    ];
+
+    public ?array $dataLabels = [
+        'enabled' => true,
+    ];
+
+    public ?array $plotOptions = [
+        'bar' => [
+            'horizontal' => true,
+            'endingShape' => 'rounded',
+            'columnWidth' => '75%',
+        ],
+    ];
+
+    public bool $showTotals = false;
+
+    public static function dashboardComponent(): array|string
+    {
+        return Dashboard::class;
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->calculateChart();
+        $this->updateData();
+    }
+
+    #[Renderless]
+    public function calculateChart(): void
+    {
+        // Default colors of apexcharts
+        $colors = [
+            '#2E93fA',
+            '#66DA26',
+            '#546E7A',
+            '#E91E63',
+            '#FF9800',
+        ];
+
+        $start = $this->getStart()->toDateString();
+        $end = $this->getEnd()->toDateString();
+
+        $LeadsWithWonOrLostLeadState = resolve_static(RecordOrigin::class, 'query')
+            ->where('model_type', morph_alias(Lead::class))
+            ->withCount([
+                'leads as total' => function (Builder $query) use ($start, $end): void {
+                    $query->whereHas('leadState', function (Builder $query): void {
+                        $query
+                            ->where('is_won', true)
+                            ->orWhere('is_lost', true);
+                    })
+                        ->whereBetween('end', [$start, $end]);
+                },
+            ])
+            ->having('total', '>', 0)
+            ->orderByDesc('total')
+            ->limit(10)
+            ->get();
+
+        $LeadsWithWonLeadState = resolve_static(RecordOrigin::class, 'query')
+            ->where('model_type', morph_alias(Lead::class))
+            ->withCount([
+                'leads as total' => function (Builder $query) use ($start, $end): void {
+                    $query->whereHas('leadState', function (Builder $query): void {
+                        $query
+                            ->where('is_won', true);
+                    })
+                        ->whereBetween('end', [$start, $end]);
+                },
+            ])
+            ->having('total', '>', 0)
+            ->orderByDesc('total')
+            ->limit(10)
+            ->get();
+
+        $i = 0;
+        $this->series = $LeadsWithWonOrLostLeadState
+            ->map(function (Model $LeadWithWonOrLostLeadState) use (&$i, $colors, $LeadsWithWonLeadState): array {
+                $conversionRate = round((float) bcdiv(
+                    $LeadsWithWonLeadState->find($LeadWithWonOrLostLeadState->getKey())?->total ?? 0,
+                    $LeadWithWonOrLostLeadState->total,
+                    3
+                ) * 100, 1);
+
+                return [
+                    'id' => $LeadWithWonOrLostLeadState->getKey(),
+                    'name' => $LeadWithWonOrLostLeadState->name,
+                    'color' => $colors[$i++ % count($colors)],
+                    'data' => [$conversionRate],
+                ];
+            })
+            ->values()
+            ->all();
+
+        $this->yaxis = [
+            'labels' => ['show' => false],
+        ];
+    }
+
+    #[Js]
+    public function dataLabelsFormatter(): string
+    {
+        return <<<'JS'
+            return opts.w.config.series[opts.seriesIndex].name + ': ' + val + '%';
+        JS;
+    }
+}

--- a/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
+++ b/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Livewire\Widgets;
 
+use FluxErp\Enums\ChartColorEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
 use FluxErp\Models\Lead;
@@ -50,15 +51,6 @@ class ConversionRateByLeadOrigin extends BarChart
     #[Renderless]
     public function calculateChart(): void
     {
-        // Default colors of apexcharts
-        $colors = [
-            '#2E93fA',
-            '#66DA26',
-            '#546E7A',
-            '#E91E63',
-            '#FF9800',
-        ];
-
         $start = $this->getStart()->toDateString();
         $end = $this->getEnd()->toDateString();
 
@@ -95,10 +87,9 @@ class ConversionRateByLeadOrigin extends BarChart
             ->limit(10)
             ->get();
 
-        $i = 0;
         $this->series = $LeadsWithWonOrLostLeadState
-            ->map(function (Model $LeadWithWonOrLostLeadState) use (&$i, $colors, $LeadsWithWonLeadState): array {
-                $conversionRate = round((float) bcdiv(
+            ->map(function (Model $LeadWithWonOrLostLeadState) use ($LeadsWithWonLeadState): array {
+                $conversionRate = round(bcdiv(
                     $LeadsWithWonLeadState->find($LeadWithWonOrLostLeadState->getKey())?->total ?? 0,
                     $LeadWithWonOrLostLeadState->total,
                     3
@@ -107,7 +98,7 @@ class ConversionRateByLeadOrigin extends BarChart
                 return [
                     'id' => $LeadWithWonOrLostLeadState->getKey(),
                     'name' => $LeadWithWonOrLostLeadState->name,
-                    'color' => $colors[$i++ % count($colors)],
+                    'color' => ChartColorEnum::forKey($LeadWithWonOrLostLeadState->getKey())->value,
                     'data' => [$conversionRate],
                 ];
             })

--- a/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
+++ b/src/Livewire/Widgets/ConversionRateByLeadOrigin.php
@@ -59,6 +59,7 @@ class ConversionRateByLeadOrigin extends BarChart
         $end = $this->getEnd()->toDateString();
 
         $leadsWithWonOrLostLeadState = resolve_static(RecordOrigin::class, 'query')
+            ->select(['id', 'name'])
             ->where('model_type', morph_alias(Lead::class))
             ->withCount([
                 'leads as total' => function (Builder $query) use ($start, $end): void {
@@ -75,6 +76,7 @@ class ConversionRateByLeadOrigin extends BarChart
             ->get();
 
         $leadsWithWonLeadState = resolve_static(RecordOrigin::class, 'query')
+            ->select(['id', 'name'])
             ->where('model_type', morph_alias(Lead::class))
             ->withCount([
                 'leads as total' => function (Builder $query) use ($start, $end): void {


### PR DESCRIPTION
## Summary by Sourcery

Add a new ConversionRateByLeadOrigin widget and correct the RecordOrigin model's leads relationship to use the correct Lead class

New Features:
- Add ConversionRateByLeadOrigin widget for visualizing lead origin conversion rates over a time frame

Bug Fixes:
- Fix RecordOrigin leads relationship to reference the proper Lead model