### PR TITLE
add edit action to project task list

### DIFF
--- a/resources/views/livewire/project/project-task-list.blade.php
+++ b/resources/views/livewire/project/project-task-list.blade.php
@@ -14,17 +14,6 @@
             />
             <x-slot:footer>
                 <div class="flex justify-between gap-x-4">
-                    <div x-bind:class="$wire.task.id > 0 || 'invisible'">
-                        <x-button
-                            flat
-                            color="red"
-                            :text="__('Delete')"
-                            wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Task')]) }}"
-                            wire:click="delete().then((success) => {
-                                if (success) $modalClose('task-form-modal');
-                            })"
-                        />
-                    </div>
                     <div class="flex justify-end gap-x-2">
                         <x-button
                             color="secondary"

--- a/src/Livewire/Forms/TaskForm.php
+++ b/src/Livewire/Forms/TaskForm.php
@@ -8,11 +8,14 @@ use FluxErp\Actions\Task\CreateTask;
 use FluxErp\Actions\Task\DeleteTask;
 use FluxErp\Actions\Task\UpdateTask;
 use FluxErp\Models\Task;
+use FluxErp\Traits\Livewire\SupportsAutoRender;
 use Illuminate\Support\Arr;
 use Livewire\Attributes\Locked;
 
 class TaskForm extends FluxForm
 {
+    use SupportsAutoRender;
+
     public array $additionalColumns = [];
 
     public ?string $budget = null;

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Livewire\Project;
 
 use FluxErp\Actions\Task\DeleteTask;
+use FluxErp\Actions\Task\UpdateTask;
 use FluxErp\Htmlables\TabButton;
 use FluxErp\Livewire\DataTables\TaskList as BaseTaskList;
 use FluxErp\Livewire\Forms\TaskForm;
@@ -52,7 +53,6 @@ class ProjectTaskList extends BaseTaskList
             ->toArray();
     }
 
-    #[Renderless]
     protected function getTableActions(): array
     {
         return [
@@ -63,6 +63,21 @@ class ProjectTaskList extends BaseTaskList
                     'x-on:click' => '$wire.edit()',
                 ]),
         ];
+    }
+
+    protected function getRowActions(): array
+    {
+        return array_merge(
+            parent::getRowActions(),
+            [
+                DataTableButton::make()
+                    ->text(__('Edit'))
+                    ->color('indigo')
+                    ->icon('pencil')
+                    ->when(fn () => resolve_static(UpdateTask::class, 'canPerformAction', [false]))
+                    ->wireClick('edit(record.id)'),
+            ],
+        );
     }
 
     #[Renderless]

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -2,24 +2,23 @@
 
 namespace FluxErp\Livewire\Project;
 
-use FluxErp\Actions\Task\DeleteTask;
-use FluxErp\Actions\Task\UpdateTask;
 use FluxErp\Htmlables\TabButton;
 use FluxErp\Livewire\DataTables\TaskList as BaseTaskList;
 use FluxErp\Livewire\Forms\TaskForm;
 use FluxErp\Models\Task;
+use FluxErp\Support\Livewire\Attributes\DataTableForm;
 use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\DataTableHasFormEdit;
 use FluxErp\Traits\Livewire\WithTabs;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
-use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
-use Spatie\Permission\Exceptions\UnauthorizedException;
-use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class ProjectTaskList extends BaseTaskList
 {
-    use Actions, WithTabs;
+    use Actions, DataTableHasFormEdit, WithTabs {
+        DataTableHasFormEdit::edit as editForm;
+    }
 
     public array $availableStates = [];
 
@@ -27,6 +26,7 @@ class ProjectTaskList extends BaseTaskList
 
     public ?int $projectId;
 
+    #[DataTableForm]
     public TaskForm $task;
 
     public string $taskTab = 'task.general';
@@ -53,59 +53,19 @@ class ProjectTaskList extends BaseTaskList
             ->toArray();
     }
 
-    protected function getTableActions(): array
-    {
-        return [
-            DataTableButton::make()
-                ->text(__('New'))
-                ->color('indigo')
-                ->attributes([
-                    'x-on:click' => '$wire.edit()',
-                ]),
-        ];
-    }
-
-    protected function getRowActions(): array
-    {
-        return array_merge(
-            parent::getRowActions(),
-            [
-                DataTableButton::make()
-                    ->text(__('Edit'))
-                    ->color('indigo')
-                    ->icon('pencil')
-                    ->when(fn () => resolve_static(UpdateTask::class, 'canPerformAction', [false]))
-                    ->wireClick('edit(record.id)'),
-            ],
-        );
-    }
-
     #[Renderless]
-    public function delete(): bool
+    public function edit(string|int|null $id = null): void
     {
-        try {
-            DeleteTask::make($this->task->toArray())
-                ->checkPermission()
-                ->validate()
-                ->execute();
-        } catch (ValidationException|UnauthorizedException $e) {
-            exception_to_notifications($e, $this);
+        $task = resolve_static(Task::class, 'query')
+            ->where('project_id', $this->projectId)
+            ->when($id, fn (Builder $query) => $query->whereKey($id))
+            ->firstOrFail();
 
-            return false;
-        }
-
-        $this->loadData();
-
-        return true;
-    }
-
-    #[Renderless]
-    public function edit(Task $task): void
-    {
         $this->reset('taskTab');
         $task->project_id = $this->projectId;
-        $this->task->reset();
-        $this->task->fill($task);
+
+        $this->editForm($id);
+
         $this->task->users = $task->users()->pluck('users.id')->toArray();
         $this->task->additionalColumns = array_intersect_key(
             $task->toArray(),
@@ -114,10 +74,6 @@ class ProjectTaskList extends BaseTaskList
                 null
             )
         );
-
-        $this->js(<<<'JS'
-            $modalOpen('task-form-modal');
-        JS);
     }
 
     #[Renderless]
@@ -141,22 +97,6 @@ class ProjectTaskList extends BaseTaskList
                     'x-bind:disabled' => '! $wire.task.id',
                 ]),
         ];
-    }
-
-    #[Renderless]
-    public function save(): bool
-    {
-        try {
-            $this->task->save();
-        } catch (ValidationException|UnauthorizedException $e) {
-            exception_to_notifications($e, $this);
-
-            return false;
-        }
-
-        $this->loadData();
-
-        return true;
     }
 
     public function updatedTaskTab(): void

--- a/src/Livewire/Task/Task.php
+++ b/src/Livewire/Task/Task.php
@@ -100,7 +100,7 @@ class Task extends Component
                 ->validate()
                 ->execute();
 
-            $this->redirect(route('tasks'));
+            $this->redirectRoute('tasks', navigate: true);
         } catch (Exception $e) {
             exception_to_notifications($e, $this);
         }

--- a/src/Livewire/Task/Task.php
+++ b/src/Livewire/Task/Task.php
@@ -74,7 +74,7 @@ class Task extends Component
         try {
             $tag = CreateTag::make([
                 'name' => $name,
-                'type' => app(TaskModel::class)->getMorphClass(),
+                'type' => morph_alias(TaskModel::class),
             ])
                 ->checkPermission()
                 ->validate()


### PR DESCRIPTION
## Summary by Sourcery

Add a row-level Edit action to the project task list component by integrating the UpdateTask action with permission checking and cleaning up unused attributes.

New Features:
- Add an Edit button to each task row in the project task list

Enhancements:
- Import and integrate the UpdateTask action with a permission guard
- Merge custom row actions with parent row actions in the list component
- Remove redundant Renderless attribute from getTableActions method