### PR TITLE
fix: add soft delete exclusion for child orders in query

### DIFF
--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -678,9 +678,9 @@ class Order extends Component
         $orderPositions = resolve_static(OrderPosition::class, 'query')
             ->whereIntegerInRaw('order_positions.id', $positionIds)
             ->where('order_positions.order_id', $this->order->id)
-            ->leftJoin('order_positions AS descendants', function (JoinClause $join) {
+            ->leftJoin('order_positions AS descendants', function (JoinClause $join): void {
                 $join->on('order_positions.id', '=', 'descendants.origin_position_id')
-                     ->whereNull('descendants.deleted_at');
+                    ->whereNull('descendants.deleted_at');
             })
             ->selectRaw(
                 'order_positions.id' .

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -43,6 +43,7 @@ use FluxErp\Traits\Livewire\CreatesDocuments;
 use FluxErp\Traits\Livewire\WithTabs;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -677,7 +678,10 @@ class Order extends Component
         $orderPositions = resolve_static(OrderPosition::class, 'query')
             ->whereIntegerInRaw('order_positions.id', $positionIds)
             ->where('order_positions.order_id', $this->order->id)
-            ->leftJoin('order_positions AS descendants', 'order_positions.id', '=', 'descendants.origin_position_id')
+            ->leftJoin('order_positions AS descendants', function (JoinClause $join) {
+                $join->on('order_positions.id', '=', 'descendants.origin_position_id')
+                     ->whereNull('descendants.deleted_at');
+            })
             ->selectRaw(
                 'order_positions.id' .
                 ', order_positions.amount' .


### PR DESCRIPTION
## Summary by Sourcery

Exclude soft-deleted child order positions from the join when querying order positions

Bug Fixes:
- Filter out descendant order positions with a non-null deleted_at in the join clause

Chores:
- Import JoinClause for custom join definition