### PR TITLE
fix: improve VAT calculation to prevent negative amounts and ensure proper discount application

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -385,24 +385,27 @@ class Order extends FluxModel implements HasMedia, InteractsWithDataTables, Offe
 
     public function calculateDiscounts(): static
     {
-        $this->total_net_price = $this->discounts()
-            ->ordered()
-            ->get(['id', 'discount', 'is_percentage'])
-            ->reduce(
-                function (string|float|int $previous, Discount $discount): string|float|int {
-                    $new = $discount->is_percentage
-                        ? discount($previous, $discount->discount)
-                        : bcsub($previous, $discount->discount, 9);
+        $this->total_net_price = bcround(
+            $this->discounts()
+                ->ordered()
+                ->get(['id', 'discount', 'is_percentage'])
+                ->reduce(
+                    function (string|float|int $previous, Discount $discount): string|float|int {
+                        $new = $discount->is_percentage
+                            ? max(0, discount($previous, $discount->discount))
+                            : max(0, bcsub($previous, $discount->discount, 9));
 
-                    $discount->update([
-                        'discount_percentage' => diff_percentage($previous, $new),
-                        'discount_flat' => bcsub($previous, $new, 9),
-                    ]);
+                        $discount->update([
+                            'discount_percentage' => diff_percentage($previous, $new),
+                            'discount_flat' => bcsub($previous, $new, 9),
+                        ]);
 
-                    return $new;
-                },
-                $this->total_net_price ?? 0
-            );
+                        return $new;
+                    },
+                    $this->total_net_price ?? 0
+                ),
+            2
+        );
 
         $this->total_discount_percentage = diff_percentage($this->total_base_net_price, $this->total_net_price);
         $this->total_discount_flat = bcsub($this->total_base_net_price, $this->total_net_price, 9);
@@ -536,59 +539,68 @@ class Order extends FluxModel implements HasMedia, InteractsWithDataTables, Offe
 
     public function calculateTotalVats(): static
     {
-        $totalVats = $this->orderPositions()
+        $vatGroups = $this->orderPositions()
             ->where('is_alternative', false)
             ->whereNotNull('vat_rate_percentage')
             ->groupBy('vat_rate_percentage')
-            ->selectRaw('sum(vat_price) as total_vat_price,
-                sum(total_net_price) as total_net_price,
-                sum(total_base_net_price) as total_base_net_price,
-                sum(total_base_gross_price) as total_base_gross_price,
-                vat_rate_percentage'
-            )
+            ->selectRaw('sum(total_net_price) as total_net_price, vat_rate_percentage')
             ->get()
-            ->map(function (OrderPosition $item) {
-                if ($this->total_discount_percentage) {
-                    $item->total_net_price = discount(
-                        $item->total_base_net_price,
-                        $this->total_discount_percentage
-                    );
-                    $item->total_vat_price = bcsub(
-                        discount($item->total_base_gross_price, $this->total_discount_percentage),
-                        $item->total_net_price
-                    );
-                }
+            ->keyBy('vat_rate_percentage');
 
-                return $item->only(
+        foreach ($this->discounts()->ordered()->get() as $discount) {
+            if ($discount->is_percentage) {
+                $vatGroups->transform(function (OrderPosition $item) use ($discount): OrderPosition {
+                    $item->total_net_price = discount($item->total_net_price, $discount->discount);
+
+                    return $item;
+                });
+            } else {
+                $total = $vatGroups->reduce(function (string $carry, OrderPosition $item): string {
+                    return bcadd($carry, $item->total_net_price, 9);
+                }, '0');
+
+                if (bccomp($total, '0', 9) > 0) {
+                    $remainingTotal = max(0, bcsub($total, $discount->discount, 9));
+
+                    $vatGroups->transform(function (OrderPosition $item) use ($total, $remainingTotal): OrderPosition {
+                        $proportion = bcdiv($item->total_net_price, $total, 9);
+                        $item->total_net_price = bcmul($remainingTotal, $proportion, 9);
+
+                        return $item;
+                    });
+                }
+            }
+        }
+
+        $this->total_vats = $vatGroups
+            ->map(function (OrderPosition $item): array {
+                return [
+                    'vat_rate_percentage' => $item->vat_rate_percentage,
+                    'total_vat_price' => bcround(bcmul($item->total_net_price, $item->vat_rate_percentage, 9), 2),
+                    'total_net_price' => bcround($item->total_net_price, 2),
+                ];
+            })
+            ->when($this->shipping_costs_vat_price, function (Collection $vats): Collection {
+                return $vats->put(
+                    $this->shipping_costs_vat_rate_percentage,
                     [
-                        'vat_rate_percentage',
-                        'total_vat_price',
-                        'total_net_price',
+                        'vat_rate_percentage' => $this->shipping_costs_vat_rate_percentage,
+                        'total_vat_price' => bcadd(
+                            $this->shipping_costs_vat_price,
+                            $vats->get($this->shipping_costs_vat_rate_percentage)['total_vat_price'] ?? 0,
+                            9
+                        ),
+                        'total_net_price' => bcadd(
+                            $this->shipping_costs_net_price,
+                            $vats->get($this->shipping_costs_vat_rate_percentage)['total_net_price'] ?? 0,
+                            9
+                        ),
                     ]
                 );
             })
-            ->keyBy('vat_rate_percentage');
-
-        if ($this->shipping_costs_vat_price) {
-            $totalVats->put(
-                $this->shipping_costs_vat_rate_percentage,
-                [
-                    'total_vat_price' => bcadd(
-                        $this->shipping_costs_vat_price,
-                        $totalVats->get($this->shipping_costs_vat_rate_percentage)['total_vat_price'] ?? 0,
-                        9
-                    ),
-                    'total_net_price' => bcadd(
-                        $this->shipping_costs_net_price,
-                        $totalVats->get($this->shipping_costs_vat_rate_percentage)['total_net_price'] ?? 0,
-                        9
-                    ),
-                    'vat_rate_percentage' => $this->shipping_costs_vat_rate_percentage,
-                ]
-            );
-        }
-
-        $this->total_vats = $totalVats->sortBy('vat_rate_percentage')->values();
+            ->sortBy('vat_rate_percentage')
+            ->values()
+            ->toArray();
 
         return $this;
     }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -588,12 +588,12 @@ class Order extends FluxModel implements HasMedia, InteractsWithDataTables, Offe
                         'vat_rate_percentage' => $this->shipping_costs_vat_rate_percentage,
                         'total_vat_price' => bcadd(
                             $this->shipping_costs_vat_price,
-                            $vats->get($this->shipping_costs_vat_rate_percentage)['total_vat_price'] ?? 0,
+                            data_get($vats->get($this->shipping_costs_vat_rate_percentage), 'total_vat_price') ?? 0,
                             9
                         ),
                         'total_net_price' => bcadd(
                             $this->shipping_costs_net_price,
-                            $vats->get($this->shipping_costs_vat_rate_percentage)['total_net_price'] ?? 0,
+                            data_get($vats->get($this->shipping_costs_vat_rate_percentage), 'total_net_price') ?? 0,
                             9
                         ),
                     ]

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -56,6 +56,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Spatie\MediaLibrary\HasMedia;
@@ -580,7 +581,7 @@ class Order extends FluxModel implements HasMedia, InteractsWithDataTables, Offe
                     'total_net_price' => bcround($item->total_net_price, 2),
                 ];
             })
-            ->when($this->shipping_costs_vat_price, function (Collection $vats): Collection {
+            ->when($this->shipping_costs_vat_price, function (SupportCollection $vats): SupportCollection {
                 return $vats->put(
                     $this->shipping_costs_vat_rate_percentage,
                     [

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -28,6 +28,8 @@ class OrderTest extends BaseSetup
 {
     private Order $order;
 
+    private OrderType $orderType;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -50,7 +52,7 @@ class OrderTest extends BaseSetup
         $currency = Currency::factory()->create();
         $vatRate = VatRate::factory()->create();
 
-        $orderType = OrderType::factory()->create([
+        $this->orderType = OrderType::factory()->create([
             'client_id' => $this->dbClient->getKey(),
             'order_type_enum' => OrderTypeEnum::Order,
             'print_layouts' => ['invoice'],
@@ -84,7 +86,7 @@ class OrderTest extends BaseSetup
             ->create([
                 'client_id' => $this->dbClient->getKey(),
                 'language_id' => $this->defaultLanguage->id,
-                'order_type_id' => $orderType->id,
+                'order_type_id' => $this->orderType->id,
                 'payment_type_id' => $paymentType->id,
                 'price_list_id' => $priceList->id,
                 'contact_id' => $this->contact->id,

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -431,4 +431,463 @@ class OrderTest extends BaseSetup
         $this->assertEquals($commission, $this->order->commission);
         $this->assertEquals($invoiceNumber, $this->order->invoice_number);
     }
+
+    public function test_vat_calculation_prevents_negative_amounts(): void
+    {
+        // Test that flat discounts don't create negative amounts
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add flat discount larger than order total
+        $order->discounts()->create([
+            'discount' => 150, // More than the 100 order total
+            'is_percentage' => false,
+            'order_column' => 1,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        // Should be 0, not negative
+        $this->assertEquals('0.00', $order->total_net_price);
+
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $this->assertEquals('0.00', $vat19['total_net_price']);
+        $this->assertEquals('0.00', $vat19['total_vat_price']);
+    }
+
+    public function test_vat_calculation_with_combined_discounts(): void
+    {
+        // Test complex scenario: position discount + percentage header + flat header
+        $vatRate7 = VatRate::factory()->create(['rate_percentage' => 0.07]);
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 50, // 50% position discount
+                    'discount_percentage' => 0.5,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate7)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100, // no position discount
+                    'vat_rate_percentage' => 0.07,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add 50% header discount first
+        $order->discounts()->create([
+            'discount' => 0.5,
+            'is_percentage' => true,
+            'order_column' => 1,
+        ]);
+
+        // Add 37.50 flat discount after percentage
+        $order->discounts()->create([
+            'discount' => 37.5,
+            'is_percentage' => false,
+            'order_column' => 2,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        $this->assertEquals('37.50', $order->total_net_price);
+
+        // After 50% header: 19% = 25, 7% = 50, total = 75
+        // After 37.50 flat: proportional distribution of remaining 37.50
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $vat7 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.0700000000');
+
+        // 19% portion: 25/75 * 37.50 = 12.50
+        $this->assertEquals('12.50', $vat19['total_net_price']);
+        $this->assertEquals('2.37', $vat19['total_vat_price']);
+
+        // 7% portion: 50/75 * 37.50 = 25.00
+        $this->assertEquals('25.00', $vat7['total_net_price']);
+        $this->assertEquals('1.75', $vat7['total_vat_price']);
+    }
+
+    public function test_vat_calculation_with_flat_header_discount(): void
+    {
+        // Create order with flat amount header discount
+        $vatRate7 = VatRate::factory()->create(['rate_percentage' => 0.07]);
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 50, // 50% position discount
+                    'discount_percentage' => 0.5,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate7)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100, // no position discount
+                    'vat_rate_percentage' => 0.07,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add 37.50 flat header discount (25% of 150)
+        $order->discounts()->create([
+            'discount' => 37.5,
+            'is_percentage' => false,
+            'order_column' => 1,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        $this->assertEquals('112.50', $order->total_net_price);
+
+        // Check proportional distribution of flat discount
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $vat7 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.0700000000');
+
+        // 19% portion: 50/150 * 112.50 = 37.50
+        $this->assertEquals('37.50', $vat19['total_net_price']);
+        $this->assertEquals('7.12', $vat19['total_vat_price']);
+
+        // 7% portion: 100/150 * 112.50 = 75.00
+        $this->assertEquals('75.00', $vat7['total_net_price']);
+        $this->assertEquals('5.25', $vat7['total_vat_price']);
+    }
+
+    public function test_vat_calculation_with_floating_point_precision(): void
+    {
+        // Test with values that typically cause floating point issues
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+        $vatRate7 = VatRate::factory()->create(['rate_percentage' => 0.07]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 0.1,  // Problematic floating point value
+                    'total_base_net_price' => 0.1,
+                    'total_net_price' => 0.1,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 0.2,  // Another problematic value
+                    'total_base_net_price' => 0.2,
+                    'total_net_price' => 0.2,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate7)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 0.3,  // 0.1 + 0.2 = 0.3 is a classic floating point problem
+                    'total_base_net_price' => 0.3,
+                    'total_net_price' => 0.3,
+                    'vat_rate_percentage' => 0.07,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add a flat discount that would cause rounding issues
+        $order->discounts()->create([
+            'discount' => 0.17,  // Discount that doesn't divide evenly
+            'is_percentage' => false,
+            'order_column' => 1,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        // Total should be 0.60 - 0.17 = 0.43
+        $this->assertEquals('0.43', $order->total_net_price);
+
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $vat7 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.0700000000');
+
+        // Check that proportional distribution works correctly with bcmath
+        // 19% group had 0.30 out of 0.60 = 50%
+        // So they get 50% of 0.43 = 0.215
+        $this->assertEquals('0.22', $vat19['total_net_price']); // Rounded from 0.215
+        $this->assertEquals('0.04', $vat19['total_vat_price']); // 0.22 * 0.19 = 0.0418
+
+        // 7% group had 0.30 out of 0.60 = 50%
+        // So they get 50% of 0.43 = 0.215
+        $this->assertEquals('0.22', $vat7['total_net_price']); // Rounded from 0.215
+        $this->assertEquals('0.02', $vat7['total_vat_price']); // 0.22 * 0.07 = 0.0154
+    }
+
+    public function test_vat_calculation_with_percentage_header_discount(): void
+    {
+        // Create order with header percentage discount
+        $vatRate7 = VatRate::factory()->create(['rate_percentage' => 0.07]);
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 50, // 50% position discount
+                    'discount_percentage' => 0.5,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate7)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100, // no position discount
+                    'vat_rate_percentage' => 0.07,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add 50% header discount
+        $order->discounts()->create([
+            'discount' => 0.5,
+            'is_percentage' => true,
+            'order_column' => 1,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        $this->assertEquals('75.00', $order->total_net_price);
+
+        // Check VAT calculations after header discount
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $vat7 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.0700000000');
+
+        $this->assertEquals('25.00', $vat19['total_net_price']); // 50 * 0.5
+        $this->assertEquals('4.75', $vat19['total_vat_price']);
+        $this->assertEquals('50.00', $vat7['total_net_price']); // 100 * 0.5
+        $this->assertEquals('3.50', $vat7['total_vat_price']);
+    }
+
+    public function test_vat_calculation_with_position_discounts(): void
+    {
+        // Create order with mixed VAT rates and position discounts
+        $vatRate7 = VatRate::factory()->create(['rate_percentage' => 0.07]);
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 50, // 50% position discount
+                    'discount_percentage' => 0.5,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->has(OrderPosition::factory()
+                ->for($vatRate7)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100, // no position discount
+                    'vat_rate_percentage' => 0.07,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        $order->calculatePrices()->save();
+
+        $this->assertEquals('150.00', $order->total_net_price);
+        $this->assertEquals(2, count($order->total_vats));
+
+        // Check individual VAT calculations
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+        $vat7 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.0700000000');
+
+        $this->assertEquals('50.00', $vat19['total_net_price']);
+        $this->assertEquals('9.50', $vat19['total_vat_price']);
+        $this->assertEquals('100.00', $vat7['total_net_price']);
+        $this->assertEquals('7.00', $vat7['total_vat_price']);
+    }
+
+    public function test_vat_calculation_with_repeating_decimals(): void
+    {
+        // Test with 1/3 values that create repeating decimals
+        $vatRate19 = VatRate::factory()->create(['rate_percentage' => 0.19]);
+
+        $order = Order::factory()
+            ->has(OrderPosition::factory()
+                ->for($vatRate19)
+                ->state([
+                    'amount' => 1,
+                    'unit_net_price' => 100,
+                    'total_base_net_price' => 100,
+                    'total_net_price' => 100,
+                    'vat_rate_percentage' => 0.19,
+                    'client_id' => $this->dbClient->getKey(),
+                    'is_alternative' => false,
+                ])
+            )
+            ->create([
+                'client_id' => $this->dbClient->getKey(),
+                'language_id' => $this->defaultLanguage->id,
+                'order_type_id' => $this->orderType->id,
+                'currency_id' => Currency::factory()->create()->id,
+                'contact_id' => $contact = Contact::factory()->create(['client_id' => $this->dbClient->getKey()])->id,
+                'address_invoice_id' => Address::factory()->create(['client_id' => $this->dbClient->getKey(), 'contact_id' => $contact])->id,
+                'price_list_id' => PriceList::factory()->create()->id,
+                'payment_type_id' => PaymentType::factory()->create()->id,
+                'shipping_costs_net_price' => 0,
+                'shipping_costs_gross_price' => 0,
+                'shipping_costs_vat_price' => 0,
+            ]);
+
+        // Add percentage discount that creates repeating decimal (1/3)
+        $order->discounts()->create([
+            'discount' => 0.333333333,  // 33.3333333%
+            'is_percentage' => true,
+            'order_column' => 1,
+        ]);
+
+        $order->calculatePrices()->save();
+
+        // 100 * (1 - 0.333333) = 66.6667, but bcround should round to 66.67
+        $this->assertEquals('66.67', $order->total_net_price);
+
+        $vat19 = collect($order->total_vats)->firstWhere('vat_rate_percentage', '0.1900000000');
+
+        $this->assertEquals('66.67', $vat19['total_net_price']);
+        $this->assertEquals('12.67', $vat19['total_vat_price']); // 66.67 * 0.19 = 12.6673
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Strengthen the order calculation logic to clamp negative values, apply and round discounts accurately, distribute flat discounts proportionally across VAT groups, include shipping costs correctly, and validate all scenarios with extensive unit tests.

Bug Fixes:
- Prevent total net price and VAT amounts from dropping below zero when discounts exceed order totals.

Enhancements:
- Clamp discount results to non-negative values and round net prices to two decimals in calculateDiscounts.
- Refactor calculateTotalVats to apply percentage and flat discounts sequentially and distribute flat discounts proportionally across VAT rate groups.
- Integrate shipping costs into VAT group totals and use bcmath operations to ensure precise floating-point handling and correct rounding.

Tests:
- Add comprehensive tests for VAT calculation under negative discounts, combined discount scenarios, flat and percentage header discounts, position discounts, floating-point precision cases, and repeating decimal rounding.