### PR TITLE
add HasClientAssignment and HasTags traits to LedgerAccount and Transaction models; update table name in OrderTransaction

### DIFF
--- a/resources/js/components/tiptap-font-size-color-handler.js
+++ b/resources/js/components/tiptap-font-size-color-handler.js
@@ -1,4 +1,4 @@
-import TextStyle from '@tiptap/extension-text-style';
+import { TextStyle } from '@tiptap/extension-text-style';
 
 export const FontSizeColorConfig = TextStyle.extend({
     addOptions() {

--- a/src/Models/LedgerAccount.php
+++ b/src/Models/LedgerAccount.php
@@ -4,6 +4,7 @@ namespace FluxErp\Models;
 
 use FluxErp\Enums\LedgerAccountTypeEnum;
 use FluxErp\Traits\CacheModelQueries;
+use FluxErp\Traits\HasClientAssignment;
 use FluxErp\Traits\HasPackageFactory;
 use FluxErp\Traits\HasUuid;
 use FluxErp\Traits\Scout\Searchable;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class LedgerAccount extends FluxModel
 {
-    use CacheModelQueries, HasPackageFactory, HasUuid;
+    use CacheModelQueries, HasClientAssignment, HasPackageFactory, HasUuid;
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
     }

--- a/src/Models/Pivots/OrderTransaction.php
+++ b/src/Models/Pivots/OrderTransaction.php
@@ -19,6 +19,8 @@ class OrderTransaction extends FluxPivot
 
     protected $primaryKey = 'pivot_id';
 
+    protected $table = 'order_transaction';
+
     protected static function booted(): void
     {
         static::saved(function (OrderTransaction $orderTransaction): void {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -8,6 +8,7 @@ use FluxErp\Traits\Categorizable;
 use FluxErp\Traits\Commentable;
 use FluxErp\Traits\HasPackageFactory;
 use FluxErp\Traits\HasParentChildRelations;
+use FluxErp\Traits\HasTags;
 use FluxErp\Traits\HasUserModification;
 use FluxErp\Traits\HasUuid;
 use FluxErp\Traits\LogsActivity;
@@ -22,7 +23,7 @@ use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 
 class Transaction extends FluxModel implements InteractsWithDataTables
 {
-    use Categorizable, Commentable, HasFrontendAttributes, HasPackageFactory, HasParentChildRelations,
+    use Categorizable, Commentable, HasFrontendAttributes, HasPackageFactory, HasParentChildRelations, HasTags,
         HasUserModification, HasUuid, LogsActivity, Searchable, SoftDeletes;
 
     protected static function booted(): void


### PR DESCRIPTION
## Summary by Sourcery

Add client assignment and tagging traits to models and correct pivot table name

New Features:
- Enable client assignment on LedgerAccount via HasClientAssignment trait
- Enable tag support on Transaction via HasTags trait

Bug Fixes:
- Set explicit table name to 'order_transaction' in OrderTransaction model

Enhancements:
- Use named import for TextStyle extension in tiptap config