### PR TITLE
add default attributes to widget retrieval

### DIFF
--- a/resources/views/components/dashboard/edit-dashboard.blade.php
+++ b/resources/views/components/dashboard/edit-dashboard.blade.php
@@ -1,6 +1,6 @@
 @use('FluxErp\Enums\TimeFrameEnum')
 <div class="flex items-center gap-4">
-    @if(in_array(\FluxErp\Traits\Livewire\Dashboard\SupportsGrouping::class, class_uses_recursive($this)))
+    @if(in_array(\FluxErp\Traits\Livewire\Dashboard\SupportsGrouping::class, class_uses_recursive($this)) && $canEdit)
         <template x-for="group in allGroups">
             <div class="relative">
                 <x-button

--- a/src/Facades/Widget.php
+++ b/src/Facades/Widget.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void register(string $name, string $widget)
  * @method static void unregister(string $name)
  * @method static array all()
- * @method static string|null get(string $name)
+ * @method static string|null get(string $name, array $defaultAttributes = [])
  * @method static void autoDiscoverWidgets(string $directory = null, string $namespace = null)
  *
  * @see WidgetManager

--- a/src/Livewire/Support/Dashboard.php
+++ b/src/Livewire/Support/Dashboard.php
@@ -42,6 +42,7 @@ abstract class Dashboard extends Component
                 $widget['height'] ??= data_get($widget, 'defaultHeight');
                 $widget['order_column'] ??= data_get($widget, 'defaultOrderColumn');
                 $widget['order_row'] ??= data_get($widget, 'defaultOrderRow');
+                $widget['group'] ??= null;
 
                 return $widget;
             })

--- a/src/Widgets/WidgetManager.php
+++ b/src/Widgets/WidgetManager.php
@@ -105,7 +105,7 @@ class WidgetManager
                 )
                 ->get($name) ?? [],
             $defaultAttributes
-        );
+        ) ?: null;
     }
 
     /**

--- a/src/Widgets/WidgetManager.php
+++ b/src/Widgets/WidgetManager.php
@@ -95,14 +95,17 @@ class WidgetManager
         }
     }
 
-    public function get(string $name): ?array
+    public function get(string $name, array $defaultAttributes = []): ?array
     {
-        return collect($this->widgets)
-            ->when(
-                class_exists($name),
-                fn (Collection $widgets) => $widgets->keyBy('class')
-            )
-            ->get($name);
+        return array_merge(
+            collect($this->widgets)
+                ->when(
+                    class_exists($name),
+                    fn (Collection $widgets) => $widgets->keyBy('class')
+                )
+                ->get($name) ?? [],
+            $defaultAttributes
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary by Sourcery

Allow supplying default attributes when fetching widgets and ensure the 'group' key is initialized in the default dashboard widget mapping

New Features:
- Support passing default attributes to WidgetManager::get to merge with retrieved widget data

Enhancements:
- Update Widget facade docblock to include the new defaultAttributes parameter
- Provide a fallback null value for the 'group' attribute when mapping default dashboard widgets