### PR TITLE
fix: filter user groups to avoid duplicates in default dashboard

### DIFF
--- a/src/Traits/Livewire/Dashboard/RendersWidgets.php
+++ b/src/Traits/Livewire/Dashboard/RendersWidgets.php
@@ -131,7 +131,7 @@ trait RendersWidgets
 
         $defaultWidgets = static::getDefaultWidgets() ?? [];
         $defaultGroups = collect($defaultWidgets)->pluck('group')->unique()->filter();
-        $userGroups = $userWidgets ? $userWidgets->keys() : collect();
+        $userGroups = $userWidgets ? $userWidgets->keys()->filter() : collect();
         $allGroups = $defaultGroups->merge($userGroups)->unique();
 
         foreach ($allGroups as $group) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Filter out falsy values from user widget group keys to avoid duplicate or empty group entries in dashboard