### PR TITLE
added radial bar chart base class

### DIFF
--- a/resources/js/components/apex-charts.js
+++ b/resources/js/components/apex-charts.js
@@ -385,9 +385,9 @@ export default function ($wire) {
                                             0,
                                         );
                                     },
-                            }
-                        }
-                    }
+                            },
+                        },
+                    },
                 },
             };
         },

--- a/resources/js/components/apex-charts.js
+++ b/resources/js/components/apex-charts.js
@@ -370,6 +370,24 @@ export default function ($wire) {
                             },
                         },
                     },
+                    radialBar: {
+                        dataLabels: {
+                            total: {
+                                show: true,
+                                label: 'Total',
+                                formatter:
+                                    this.plotOptionsTotalFormatter ??
+                                    function (w) {
+                                        return w.globals.seriesTotals.reduce(
+                                            (a, b) => {
+                                                return a + b;
+                                            },
+                                            0,
+                                        );
+                                    },
+                            }
+                        }
+                    }
                 },
             };
         },

--- a/resources/views/livewire/support/widgets/charts/radial-bar-chart.blade.php
+++ b/resources/views/livewire/support/widgets/charts/radial-bar-chart.blade.php
@@ -1,0 +1,5 @@
+@extends('flux::livewire.support.widgets.charts.chart')
+
+@section('options')
+    @parent
+@endsection

--- a/resources/views/livewire/support/widgets/charts/radial-bar-chart.blade.php
+++ b/resources/views/livewire/support/widgets/charts/radial-bar-chart.blade.php
@@ -1,5 +1,0 @@
-@extends('flux::livewire.support.widgets.charts.chart')
-
-@section('options')
-    @parent
-@endsection

--- a/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
+++ b/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
@@ -15,7 +15,7 @@ abstract class RadialBarChart extends Chart
 
     public function render(): View|Factory
     {
-        return view('flux::livewire.support.widgets.charts.radial-bar-chart');
+        return view('flux::livewire.support.widgets.charts.chart');
     }
 
     public function getPlotOptions(): array
@@ -41,12 +41,12 @@ abstract class RadialBarChart extends Chart
     {
         $options = parent::getOptions();
 
-        if (isset($options['series'])) {
+        if (data_get($options, 'series')) {
             $max = $this->max ?? max($options['series']);
 
             if ($max > 0) {
                 $options['series'] = array_map(
-                    fn ($value) => ($value / $max) * 100,
+                    fn ($value) => bcmul(bcdiv($value, $max, 10), 100, 2),
                     $options['series']
                 );
             }

--- a/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
+++ b/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
@@ -46,7 +46,7 @@ abstract class RadialBarChart extends Chart
 
             if ($max > 0) {
                 $options['series'] = array_map(
-                    fn ($value) => bcmul(bcdiv($value, $max, 10), 100, 2),
+                    fn ($value) => bcmul(bcdiv($value, $max), 100, 2),
                     $options['series']
                 );
             }

--- a/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
+++ b/src/Livewire/Support/Widgets/Charts/RadialBarChart.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace FluxErp\Livewire\Support\Widgets\Charts;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+
+abstract class RadialBarChart extends Chart
+{
+    public ?array $chart = [
+        'type' => 'radialBar',
+    ];
+
+    public ?int $max = null;
+
+    public function render(): View|Factory
+    {
+        return view('flux::livewire.support.widgets.charts.radial-bar-chart');
+    }
+
+    public function getPlotOptions(): array
+    {
+        return [
+            'radialBar' => [
+                'dataLabels' => [
+                    'total' => [
+                        'show' => true,
+                        'label' => __('Total'),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function placeholder(): View|Factory
+    {
+        return view('flux::livewire.placeholders.circle');
+    }
+
+    protected function getOptions(): array
+    {
+        $options = parent::getOptions();
+
+        if (isset($options['series'])) {
+            $max = $this->max ?? max($options['series']);
+
+            if ($max > 0) {
+                $options['series'] = array_map(
+                    fn ($value) => ($value / $max) * 100,
+                    $options['series']
+                );
+            }
+        }
+
+        return $options;
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable radial bar chart base class with client-side total label support and automatic series normalization.

New Features:
- Add JavaScript radialBar dataLabels.total configuration with optional formatter for summing series totals.
- Create abstract PHP RadialBarChart widget with default type, plot options, view rendering, placeholder, and series normalization based on a max value.
- Add Blade template for radial-bar-chart extending the base chart layout to include the new options section.