### PR TITLE
add timeline chart

### DIFF
--- a/src/Livewire/Support/Widgets/Charts/TimelineChart.php
+++ b/src/Livewire/Support/Widgets/Charts/TimelineChart.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FluxErp\Livewire\Support\Widgets\Charts;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Js;
+
+abstract class TimelineChart extends Chart
+{
+    public ?array $chart = [
+        'type' => 'rangeBar',
+    ];
+
+    public bool $showTotals = false;
+
+    public function render(): View|Factory
+    {
+        return view('flux::livewire.support.widgets.charts.bar-chart');
+    }
+
+    public function placeholder(): View|Factory
+    {
+        return view('flux::livewire.placeholders.vertical-bar');
+    }
+
+    #[Js]
+    public function xAxisFormatter(): string
+    {
+        return <<<'JS'
+            return new Date(val).toLocaleDateString(document.documentElement.lang);
+    JS;
+    }
+}

--- a/src/Livewire/Support/Widgets/Charts/TimelineChart.php
+++ b/src/Livewire/Support/Widgets/Charts/TimelineChart.php
@@ -29,6 +29,6 @@ abstract class TimelineChart extends Chart
     {
         return <<<'JS'
             return new Date(val).toLocaleDateString(document.documentElement.lang);
-    JS;
+        JS;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce an abstract TimelineChart widget for rendering range bar charts with date-based formatting and default placeholders

New Features:
- Add TimelineChart class extending Chart with 'rangeBar' type, showTotals property, and default render/placeholder views
- Include a JS-annotated xAxisFormatter method for locale-aware date formatting on the chart's x-axis