### PR TITLE
allow multiple whereHas and whereDoesntHave in SearchController

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -138,11 +138,25 @@ class SearchController extends Controller
         }
 
         if ($request->has('whereDoesntHave')) {
-            $query->whereDoesntHave($request->get('whereDoesntHave'));
+            $whereDoesntHave = $request->get('whereDoesntHave');
+            if (is_array($whereDoesntHave) && array_is_list($whereDoesntHave)) {
+                foreach ($whereDoesntHave as $relation) {
+                    $query->whereDoesntHave($relation);
+                }
+            } else {
+                $query->whereDoesntHave($whereDoesntHave);
+            }
         }
 
         if ($request->has('whereHas')) {
-            $query->whereHas($request->get('whereHas'));
+            $whereHas = $request->get('whereHas');
+            if (is_array($whereHas) && array_is_list($whereHas)) {
+                foreach ($whereHas as $relation) {
+                    $query->whereHas($relation);
+                }
+            } else {
+                $query->whereHas($whereHas);
+            }
         }
 
         $result = $query->latest()->get();


### PR DESCRIPTION
## Summary by Sourcery

Support passing multiple relation constraints in SearchController

Enhancements:
- Allow whereHas to accept an array or list of relations and apply each constraint
- Allow whereDoesntHave to accept an array or list of relations and apply each constraint