### PR TITLE
add Active Leads By Closing Probability widget

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -214,6 +214,7 @@
     "Activate Web Push": "Web Push aktivieren",
     "Active": "Aktiv",
     "Active Daily Work Times": "Aktive Tagesarbeitszeit",
+    "Active Leads By Closing Probability": "Aktive Leads nach Abschlusswahrscheinlichkeit",
     "Active menu item": "Ausgewählter Navigationspunkt",
     "Active Task Times": "Aktive Aufgabenzeiten",
     "Active Work Times": "Aktive Arbeitszeiten",

--- a/lang/de.json
+++ b/lang/de.json
@@ -9,6 +9,7 @@
     ":job_name is finished": ":job_name ist beendet",
     ":job_name is processing": ":job_name wird verarbeitet",
     ":job_name started": ":job_name gestartet",
+    ":lower%–:upper%": ":lower%–:upper%",
     ":model created": ":model erstellt",
     ":model Export Ready": ":model Export bereit",
     ":model restored": ":model wiederhergestellt",

--- a/lang/de.json
+++ b/lang/de.json
@@ -9,7 +9,7 @@
     ":job_name is finished": ":job_name ist beendet",
     ":job_name is processing": ":job_name wird verarbeitet",
     ":job_name started": ":job_name gestartet",
-    ":lower%–:upper%": ":lower%–:upper%",
+    ":lower% – :upper%": ":lower% – :upper%",
     ":model created": ":model erstellt",
     ":model Export Ready": ":model Export bereit",
     ":model restored": ":model wiederhergestellt",

--- a/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
+++ b/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
@@ -64,8 +64,17 @@ class ActiveLeadsByClosingProbability extends BarChart
             })
             ->get();
 
+        // Group leads into probability intervals ("bins") for histogram-like aggregation
         $bins = $activeLeads->groupBy(function ($lead) use ($granularity) {
-            return floor($lead->probability_percentage * 100 / $granularity) * $granularity;
+            return bcmul(
+                bcfloor(
+                    bcdiv(
+                        bcmul($lead->probability_percentage, 100),
+                        $granularity
+                    )
+                ),
+                $granularity
+            );
         })->sortKeys();
 
         $this->series = [
@@ -79,7 +88,7 @@ class ActiveLeadsByClosingProbability extends BarChart
 
         foreach ($bins as $lower => $leadsInBin) {
             $upper = $lower + $granularity;
-            $label = __(':lower%–:upper%', [
+            $label = __(':lower% – :upper%', [
                 'lower' => $lower,
                 'upper' => $upper,
             ]);

--- a/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
+++ b/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets;
+
+use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
+use FluxErp\Models\Lead;
+use FluxErp\Traits\Livewire\IsTimeFrameAwareWidget;
+use FluxErp\Traits\Widgetable;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Attributes\Renderless;
+
+class ActiveLeadsByClosingProbability extends BarChart
+{
+    use IsTimeFrameAwareWidget, Widgetable;
+
+    public ?array $chart = [
+        'type' => 'bar',
+    ];
+
+    public ?array $dataLabels = [
+        'enabled' => true,
+    ];
+
+    public ?array $plotOptions = [
+        'bar' => [
+            'horizontal' => false,
+            'endingShape' => 'rounded',
+            'columnWidth' => '75%',
+        ],
+    ];
+
+    public bool $showTotals = false;
+
+    public static function dashboardComponent(): array|string
+    {
+        return Dashboard::class;
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->calculateChart();
+        $this->updateData();
+    }
+
+    #[Renderless]
+    public function calculateChart(): void
+    {
+        $granularity = 25;
+
+        $start = $this->getStart()->toDateString();
+        $end = $this->getEnd()->toDateString();
+
+        $activeLeads = resolve_static(Lead::class, 'query')
+            ->whereBetween('end', [$start, $end])
+            ->where('probability_percentage', '<', 1)
+            ->where('probability_percentage', '>', 0)
+            ->whereHas('leadState', function (Builder $query): void {
+                $query
+                    ->where('is_won', false)
+                    ->where('is_lost', false);
+            })
+            ->get();
+
+        $bins = $activeLeads->groupBy(function ($lead) use ($granularity) {
+            return floor($lead->probability_percentage * 100 / $granularity) * $granularity;
+        })->sortKeys();
+
+        $this->series = [
+            [
+                'color' => '#2E93fA',
+                'data' => [],
+            ],
+        ];
+
+        $this->xaxis['categories'] = [];
+
+        foreach ($bins as $lower => $leadsInBin) {
+            $upper = $lower + $granularity;
+            $label = "{$lower}%–{$upper}%";
+
+            $this->series[0]['data'][] = $leadsInBin->count();
+            $this->xaxis['categories'][] = $label;
+        }
+    }
+}

--- a/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
+++ b/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Livewire\Widgets;
 
+use FluxErp\Enums\ChartColorEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
 use FluxErp\Models\Lead;
@@ -69,7 +70,7 @@ class ActiveLeadsByClosingProbability extends BarChart
 
         $this->series = [
             [
-                'color' => '#2E93fA',
+                'color' => ChartColorEnum::Blue->value,
                 'data' => [],
             ],
         ];

--- a/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
+++ b/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
@@ -79,7 +79,10 @@ class ActiveLeadsByClosingProbability extends BarChart
 
         foreach ($bins as $lower => $leadsInBin) {
             $upper = $lower + $granularity;
-            $label = "{$lower}%–{$upper}%";
+            $label = __(':lower%–:upper%', [
+                'lower' => $lower,
+                'upper' => $upper,
+            ]);
 
             $this->series[0]['data'][] = $leadsInBin->count();
             $this->xaxis['categories'][] = $label;

--- a/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
+++ b/src/Livewire/Widgets/ActiveLeadsByClosingProbability.php
@@ -75,7 +75,8 @@ class ActiveLeadsByClosingProbability extends BarChart
                 ),
                 $granularity
             );
-        })->sortKeys();
+        })
+            ->sortKeys();
 
         $this->series = [
             [


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce ActiveLeadsByClosingProbability Livewire widget that bins active leads by closing probability and renders them in a bar chart