### PR TITLE
bump laravel/framework version to ^12.21.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "barryvdh/laravel-dompdf": "^3.0",
         "dompdf/dompdf": "^3.1.0",
         "laravel-notification-channels/webpush": "^10.2",
-        "laravel/framework": "^12.9.0",
+        "laravel/framework": "^12.21.0",
         "laravel/reverb": "^1.0.0",
         "laravel/sanctum": "^4.0",
         "laravel/scout": "^10.0",


### PR DESCRIPTION
bump Laravel from 12.9.0 to 12.21.0 in preparation for https://github.com/Team-Nifty-GmbH/flux-core/pull/1035