### PR TITLE
replace isDirty(), isClean(), getOriginal() and getRawOriginal() in m…

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -171,13 +171,14 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
 
             $contactUpdates = [];
             $addressesUpdates = [];
-            if ($address->isDirty('contact_id') && ! $address->isDirty($address->getKeyName())) {
+            if ($address->wasChanged('contact_id') && ! $address->wasChanged($address->getKeyName())) {
+                $previousContactId = data_get($address->getPrevious(), 'contact_id');
                 if (! $oldContactHasAddresses = resolve_static(Address::class, 'query')
-                    ->where('contact_id', $address->getRawOriginal('contact_id'))
+                    ->where('contact_id', $previousContactId)
                     ->exists()
                 ) {
                     resolve_static(Contact::class, 'query')
-                        ->whereKey($address->getRawOriginal('contact_id'))
+                        ->whereKey($previousContactId)
                         ->first()
                         ?->delete();
                 }
@@ -187,32 +188,32 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                 $oldContactUpdates = [];
                 $oldContactAddressesUpdates = [];
                 $firstAddressId = resolve_static(Address::class, 'query')
-                    ->where('contact_id', $address->getRawOriginal('contact_id'))
+                    ->where('contact_id', $previousContactId)
                     ->value('id');
 
-                if ($address->getRawOriginal('is_main_address')) {
+                if (data_get($address->getPrevious(), 'is_main_address') ?? $address->is_main_address) {
                     $oldContactUpdates['main_address_id'] = $firstAddressId;
                     $oldContactAddressesUpdates['is_main_address'] = true;
 
-                    if ($address->isClean('is_main_address')) {
+                    if (! $address->wasChanged('is_main_address')) {
                         $addressUpdates['is_main_address'] = false;
                     }
                 }
 
-                if ($address->getRawOriginal('is_invoice_address')) {
+                if (data_get($address->getPrevious(), 'is_invoice_address') ?? $address->is_invoice_address) {
                     $oldContactUpdates['invoice_address_id'] = $firstAddressId;
                     $oldContactAddressesUpdates['is_invoice_address'] = true;
 
-                    if ($address->isClean('is_invoice_address')) {
+                    if (! $address->wasChanged('is_invoice_address')) {
                         $addressUpdates['is_invoice_address'] = false;
                     }
                 }
 
-                if ($address->getRawOriginal('is_delivery_address')) {
+                if (data_get($address->getPrevious(), 'is_delivery_address') ?? $address->is_delivery_address) {
                     $oldContactUpdates['delivery_address_id'] = $firstAddressId;
                     $oldContactAddressesUpdates['is_delivery_address'] = true;
 
-                    if ($address->isClean('is_delivery_address')) {
+                    if (! $address->wasChanged('is_delivery_address')) {
                         $addressUpdates['is_delivery_address'] = false;
                     }
                 }
@@ -227,17 +228,17 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                 // Update old contact and its addresses
                 if ($oldContactUpdates && $oldContactHasAddresses) {
                     resolve_static(Contact::class, 'query')
-                        ->whereKey($address->getRawOriginal('contact_id'))
+                        ->whereKey($previousContactId)
                         ->update($oldContactUpdates);
 
                     resolve_static(Address::class, 'query')
                         ->whereKeyNot($address->getKey())
-                        ->where('contact_id', $address->getRawOriginal('contact_id'))
+                        ->where('contact_id', $previousContactId)
                         ->update($oldContactAddressesUpdates);
                 }
             }
 
-            if ($address->isDirty('is_main_address') && $address->is_main_address) {
+            if ($address->wasChanged('is_main_address') && $address->is_main_address) {
                 $contactUpdates += [
                     'main_address_id' => $address->id,
                 ];
@@ -247,7 +248,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                 ];
             }
 
-            if ($address->isDirty('is_invoice_address') && $address->is_invoice_address) {
+            if ($address->wasChanged('is_invoice_address') && $address->is_invoice_address) {
                 $contactUpdates += [
                     'invoice_address_id' => $address->id,
                 ];
@@ -257,7 +258,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                 ];
             }
 
-            if ($address->isDirty('is_delivery_address') && $address->is_delivery_address) {
+            if ($address->wasChanged('is_delivery_address') && $address->is_delivery_address) {
                 $contactUpdates += [
                     'delivery_address_id' => $address->id,
                 ];
@@ -293,14 +294,20 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
             }
 
             $contactUpdates = [];
-            $addressesUpdates = [];
+            $addressUpdates = [];
             $mainAddress = resolve_static(Address::class, 'query')
                 ->where('contact_id', $address->contact_id)
-                ->where('is_main_address', true)
-                ->first();
+                ->orderByDesc('is_main_address')
+                ->first(['id', 'is_main_address', 'is_invoice_address', 'is_delivery_address']);
 
-            if (! $mainAddress) {
-                return;
+            if (! $mainAddress->is_main_address) {
+                $contactUpdates += [
+                    'main_address_id' => $mainAddress->id,
+                ];
+
+                $addressUpdates += [
+                    'is_main_address' => true,
+                ];
             }
 
             if ($address->is_invoice_address) {
@@ -308,7 +315,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                     'invoice_address_id' => $mainAddress->id,
                 ];
 
-                $addressesUpdates += [
+                $addressUpdates += [
                     'is_invoice_address' => true,
                 ];
             }
@@ -318,7 +325,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                     'delivery_address_id' => $mainAddress->id,
                 ];
 
-                $addressesUpdates += [
+                $addressUpdates += [
                     'is_delivery_address' => true,
                 ];
             }
@@ -328,7 +335,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                     ->whereKey($address->contact_id)
                     ->update($contactUpdates);
 
-                $mainAddress->update($addressesUpdates);
+                $mainAddress->update($addressUpdates);
             }
         });
     }

--- a/src/Models/OrderPosition.php
+++ b/src/Models/OrderPosition.php
@@ -112,13 +112,13 @@ class OrderPosition extends FluxModel implements InteractsWithDataTables, Sortab
         });
 
         static::saved(function (OrderPosition $orderPosition): void {
-            if ($orderPosition->isDirty('sort_number') || $orderPosition->isDirty('parent_id')) {
-                if ($orderPosition->isDirty('parent_id')) {
+            if ($orderPosition->wasChanged('sort_number') || $orderPosition->wasChanged('parent_id')) {
+                if ($orderPosition->wasChanged('parent_id')) {
                     DB::statement('SET @row_number = 0');
 
                     resolve_static(OrderPosition::class, 'query')
                         ->where('order_id', $orderPosition->order_id)
-                        ->where('parent_id', $orderPosition->getOriginal('parent_id'))
+                        ->where('parent_id', data_get($orderPosition->getPrevious(), 'parent_id'))
                         ->orderBy('sort_number')
                         ->update([
                             'sort_number' => DB::raw('(@row_number:=@row_number+1)'),

--- a/src/Models/Pivots/OrderTransaction.php
+++ b/src/Models/Pivots/OrderTransaction.php
@@ -24,7 +24,7 @@ class OrderTransaction extends FluxPivot
     protected static function booted(): void
     {
         static::saved(function (OrderTransaction $orderTransaction): void {
-            $originalOrderId = $orderTransaction->getRawOriginal('order_id');
+            $originalOrderId = data_get($orderTransaction->getPrevious(), 'order_id', $orderTransaction->order_id);
             if (
                 $originalOrderId
                 && $originalOrderId !== $orderTransaction->order_id

--- a/src/Traits/HasAttributeTranslations.php
+++ b/src/Traits/HasAttributeTranslations.php
@@ -74,7 +74,11 @@ trait HasAttributeTranslations
                         data_get($translation, 'value'),
                         [
                             '<p></p>',
-                            $model->getRawOriginal(data_get($translation, 'attribute')),
+                            data_get(
+                                $model->getPrevious(),
+                                data_get($translation, 'attribute'),
+                                $model->getAttribute(data_get($translation, 'attribute'))
+                            ),
                         ],
                         true
                     )

--- a/tests/Feature/Web/ContactsTest.php
+++ b/tests/Feature/Web/ContactsTest.php
@@ -26,10 +26,14 @@ class ContactsTest extends BaseSetup
             'payment_type_id' => $paymentType->id,
         ]);
 
-        Address::factory()->create([
+        $address = Address::factory()->create([
             'client_id' => $this->dbClient->getKey(),
             'contact_id' => $this->contact->id,
             'is_main_address' => true,
+        ]);
+
+        $this->contact->update([
+            'main_address_id' => $address->id,
         ]);
     }
 

--- a/tests/Livewire/Contact/ContactTest.php
+++ b/tests/Livewire/Contact/ContactTest.php
@@ -24,12 +24,18 @@ class ContactTest extends TestCase
             'client_id' => $client->id,
         ]);
 
-        Address::factory()->create([
+        $address = Address::factory()->create([
             'client_id' => $client->id,
             'contact_id' => $this->contact->id,
             'is_main_address' => true,
             'is_invoice_address' => true,
             'is_delivery_address' => true,
+        ]);
+
+        $this->contact->update([
+            'main_address_id' => $address->id,
+            'invoice_address_id' => $address->id,
+            'delivery_address_id' => $address->id,
         ]);
     }
 

--- a/tests/Livewire/Contacts/ContactTest.php
+++ b/tests/Livewire/Contacts/ContactTest.php
@@ -21,10 +21,14 @@ class ContactTest extends TestCase
             'client_id' => $dbClient->id,
         ]);
 
-        Address::factory()->create([
+        $address = Address::factory()->create([
             'client_id' => $dbClient->id,
             'contact_id' => $this->contact->id,
             'is_main_address' => true,
+        ]);
+
+        $this->contact->update([
+            'main_address_id' => $address->id,
         ]);
     }
 


### PR DESCRIPTION
…odel callbacks

fix address records merging

## Summary by Sourcery

Replace deprecated Eloquent change detection and original value methods in model callbacks with `wasChanged` and `getPrevious`, and fix address merging logic when `contact_id` changes

Bug Fixes:
- Prevent unintended deletion of contacts and maintain correct main/invoice/delivery flags when merging address records

Enhancements:
- Use `wasChanged` and negated `wasChanged` instead of `isDirty`/`isClean` in Address and OrderPosition callbacks
- Fetch previous values via `getPrevious` and `data_get` instead of `getOriginal`/`getRawOriginal` in multiple models and traits
- Consolidate update payload arrays and adjust main address lookup ordering in Address boot logic