### PR TITLE
fix: add mutators and recalculation methods for lead model attributes

### DIFF
--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -19,12 +19,10 @@ class LeadFactory extends Factory
             'loss_reason' => $this->faker->realText(),
             'start' => $start->format('Y-m-d'),
             'end' => $this->faker->dateTimeBetween($start, '+2 months')->format('Y-m-d'),
-            'probability_percentage' => $probability = $this->faker->randomFloat(2, 0, 1),
+            'probability_percentage' => $this->faker->randomFloat(2, 0, 1),
             'expected_revenue' => $expectedRevenue = $this->faker->numberBetween(100, 90000),
-            'expected_gross_profit' => $expectedGrossProfit = $this->faker->numberBetween(0, $expectedRevenue),
+            'expected_gross_profit' => $this->faker->numberBetween(0, $expectedRevenue),
             'score' => $this->faker->numberBetween(0, 5),
-            'weighted_gross_profit' => bcmul($expectedGrossProfit, $probability),
-            'weighted_revenue' => bcmul($expectedRevenue, $probability),
         ];
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -259,7 +259,7 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
         $revenue = data_get($this->attributes, 'expected_revenue');
 
         $this->attributes['weighted_revenue'] = ($prob !== null && $revenue !== null)
-            ? bcmul($prob, $revenue, 2)
+            ? bcmul($prob, $revenue)
             : null;
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -130,8 +130,13 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
                 $lead->probability_percentage = $probability;
             }
 
-            $lead->recalculateWeightedGrossProfit();
-            $lead->recalculateWeightedRevenue();
+            if ($lead->isDirty('probability_percentage') || $lead->isDirty('expected_gross_profit')) {
+                $lead->recalculateWeightedGrossProfit();
+            }
+
+            if ($lead->isDirty('probability_percentage') || $lead->isDirty('expected_revenue')) {
+                $lead->recalculateWeightedRevenue();
+            }
         });
     }
 

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -200,6 +200,25 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
         });
     }
 
+    public function setExpectedGrossProfitAttribute(float $value): void
+    {
+        $this->attributes['expected_gross_profit'] = $value;
+        $this->recalculateWeightedGrossProfit();
+    }
+
+    public function setExpectedRevenueAttribute(float $value): void
+    {
+        $this->attributes['expected_revenue'] = $value;
+        $this->recalculateWeightedRevenue();
+    }
+
+    public function setProbabilityPercentageAttribute(float $value): void
+    {
+        $this->attributes['probability_percentage'] = $value;
+        $this->recalculateWeightedRevenue();
+        $this->recalculateWeightedGrossProfit();
+    }
+
     public function toCalendarEvent(?array $info = null): array
     {
         return [
@@ -222,5 +241,25 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    protected function recalculateWeightedGrossProfit(): void
+    {
+        $prob = data_get($this->attributes, 'probability_percentage');
+        $revenue = data_get($this->attributes, 'expected_gross_profit');
+
+        $this->attributes['weighted_gross_profit'] = ($prob !== null && $revenue !== null)
+            ? bcmul($prob, $revenue)
+            : null;
+    }
+
+    protected function recalculateWeightedRevenue(): void
+    {
+        $prob = data_get($this->attributes, 'probability_percentage');
+        $revenue = data_get($this->attributes, 'expected_revenue');
+
+        $this->attributes['weighted_revenue'] = ($prob !== null && $revenue !== null)
+            ? bcmul($prob, $revenue, 2)
+            : null;
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -245,21 +245,25 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
 
     protected function recalculateWeightedGrossProfit(): void
     {
-        $prob = data_get($this->attributes, 'probability_percentage');
-        $revenue = data_get($this->attributes, 'expected_gross_profit');
-
-        $this->attributes['weighted_gross_profit'] = ($prob !== null && $revenue !== null)
-            ? bcmul($prob, $revenue)
-            : null;
+        if (! is_null($this->probability_percentage) && ! is_null($this->expected_gross_profit)) {
+            $this->weighted_gross_profit = bcmul(
+                $this->probability_percentage,
+                $this->expected_gross_profit
+            );
+        } else {
+            $this->weighted_gross_profit = null;
+        }
     }
 
     protected function recalculateWeightedRevenue(): void
     {
-        $prob = data_get($this->attributes, 'probability_percentage');
-        $revenue = data_get($this->attributes, 'expected_revenue');
-
-        $this->attributes['weighted_revenue'] = ($prob !== null && $revenue !== null)
-            ? bcmul($prob, $revenue)
-            : null;
+        if (! is_null($this->probability_percentage) && ! is_null($this->expected_revenue)) {
+            $this->weighted_revenue = bcmul(
+                $this->probability_percentage,
+                $this->expected_revenue
+            );
+        } else {
+            $this->weighted_revenue = null;
+        }
     }
 }


### PR DESCRIPTION
Add mutators to automaticly calculate weighted_gross_profit and weighted_revenue every time a change to relevant values is made

## Summary by Sourcery

Add mutators to recalculate weighted revenue and gross profit whenever probability, expected revenue, or expected gross profit attributes change, and update the Lead factory to rely on these automatic calculations.

New Features:
- Automatically recalculate weighted_revenue when expected_revenue or probability_percentage is set
- Automatically recalculate weighted_gross_profit when expected_gross_profit or probability_percentage is set

Enhancements:
- Extract weighted calculation logic into recalculateWeightedRevenue and recalculateWeightedGrossProfit methods
- Remove precomputed weighted values from the Lead factory since they are now derived automatically