### PR TITLE
add ReplicateTask action

### DIFF
--- a/resources/views/components/dashboard/edit-dashboard.blade.php
+++ b/resources/views/components/dashboard/edit-dashboard.blade.php
@@ -1,6 +1,6 @@
 @use('FluxErp\Enums\TimeFrameEnum')
 <div class="flex items-center gap-4">
-    @if(in_array(\FluxErp\Traits\Livewire\Dashboard\SupportsGrouping::class, class_uses_recursive($this)) && $canEdit)
+    @if (in_array(\FluxErp\Traits\Livewire\Dashboard\SupportsGrouping::class, class_uses_recursive($this)) && $canEdit)
         <template x-for="group in allGroups">
             <div class="relative">
                 <x-button

--- a/resources/views/components/task/general.blade.php
+++ b/resources/views/components/task/general.blade.php
@@ -9,7 +9,7 @@
         <x-input
             x-bind:readonly="!edit"
             wire:model="task.name"
-            label="{{ __('Name') }}"
+            :label="__('Name')"
         />
         @section('task.model')
         <x-link

--- a/src/Actions/Task/CreateTask.php
+++ b/src/Actions/Task/CreateTask.php
@@ -46,7 +46,7 @@ class CreateTask extends FluxAction
             $task->attachTags(resolve_static(Tag::class, 'query')->whereIntegerInRaw('id', $tags)->get());
         }
 
-        return $task->fresh();
+        return $task->refresh();
     }
 
     protected function prepareForValidation(): void

--- a/src/Actions/Task/ReplicateTask.php
+++ b/src/Actions/Task/ReplicateTask.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace FluxErp\Actions\Task;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Models\Tag;
+use FluxErp\Models\Task;
+use FluxErp\Rulesets\Task\ReplicateTaskRuleset;
+use FluxErp\States\Task\Open;
+use Illuminate\Support\Arr;
+
+class ReplicateTask extends FluxAction
+{
+    public static function models(): array
+    {
+        return [Task::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return ReplicateTaskRuleset::class;
+    }
+
+    public function performAction(): Task
+    {
+        $categories = Arr::pull($this->data, 'categories');
+        $tags = Arr::pull($this->data, 'tags');
+        $users = Arr::pull($this->data, 'users');
+
+        $originTask = resolve_static(Task::class, 'query')
+            ->whereKey($this->getData('id'))
+            ->first();
+
+        $task = $originTask->replicate(array_merge(array_keys($this->getData()), ['state']));
+        $task->fill(array_merge($this->getData(), ['state' => Open::$name]))
+            ->save();
+
+        $categories = ! is_null($categories) ? $categories : $originTask->categories()->pluck('id')->toArray();
+        if ($categories) {
+            $task->categories()->attach($categories);
+        }
+
+        $users = ! is_null($users) ? $users : $originTask->users()->pluck('id')->toArray();
+        if ($users) {
+            $task->users()->attach($users);
+        }
+
+        $tags = ! is_null($tags) ? $tags : $originTask->tags()->pluck('id')->toArray();
+        if ($tags) {
+            $task->attachTags(resolve_static(Tag::class, 'query')->whereIntegerInRaw('id', $tags)->get());
+        }
+
+        return $task->refresh();
+    }
+}

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -159,6 +159,14 @@ class SearchController extends Controller
             }
         }
 
+        if ($request->has('whereRelation')) {
+            $query->whereRelation(...$request->get('whereRelation'));
+        }
+
+        if ($request->has('whereDoesntHaveRelation')) {
+            $query->whereDoesntHaveRelation(...$request->get('whereDoesntHaveRelation'));
+        }
+
         $result = $query->latest()->get();
 
         if ($request->has('appends')) {

--- a/src/Rulesets/Task/ReplicateTaskRuleset.php
+++ b/src/Rulesets/Task/ReplicateTaskRuleset.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace FluxErp\Rulesets\Task;
+
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\Project;
+use FluxErp\Models\Task;
+use FluxErp\Models\User;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\MorphClassExists;
+use FluxErp\Rules\MorphExists;
+use FluxErp\Rulesets\FluxRuleset;
+
+class ReplicateTaskRuleset extends FluxRuleset
+{
+    protected static ?string $model = Task::class;
+
+    public static function getRules(): array
+    {
+        return array_merge(
+            parent::getRules(),
+            resolve_static(UserRuleset::class, 'getRules'),
+            resolve_static(CategoryRuleset::class, 'getRules'),
+            resolve_static(TagRuleset::class, 'getRules')
+        );
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => Task::class]),
+            ],
+            'project_id' => [
+                'integer',
+                'nullable',
+                app(ModelExists::class, ['model' => Project::class]),
+            ],
+            'responsible_user_id' => [
+                'integer',
+                'nullable',
+                app(ModelExists::class, ['model' => User::class]),
+            ],
+            'order_position_id' => [
+                'integer',
+                'nullable',
+                app(ModelExists::class, ['model' => OrderPosition::class]),
+            ],
+            'model_type' => [
+                'required_with:model_id',
+                'string',
+                'max:255',
+                'nullable',
+                app(MorphClassExists::class),
+            ],
+            'model_id' => [
+                'required_with:model_type',
+                'integer',
+                'nullable',
+                app(MorphExists::class),
+            ],
+            'name' => 'string|nullable|max:255',
+            'description' => 'string|nullable',
+            'start_date' => 'date|nullable',
+            'due_date' => 'date|nullable|after_or_equal:start_date',
+            'priority' => 'integer|nullable|min:0',
+            'time_budget' => 'nullable|regex:/[0-9]*:[0-5][0-9]/',
+            'budget' => 'numeric|nullable|min:0',
+        ];
+    }
+}


### PR DESCRIPTION
add whereRelation/whereDoesntHaveRelation to SearchController

## Summary by Sourcery

Add end-to-end task replication support by introducing a ReplicateTask action and ruleset, wiring it into the Livewire Task component with a modal UI and replicate methods, and enhance search filtering and action consistency.

New Features:
- Implement ReplicateTask action with validation rules for duplicating tasks
- Integrate task replication UI into the Livewire Task component via a modal form and replicate button

Enhancements:
- Extend SearchController to support whereRelation and whereDoesntHaveRelation filters
- Replace fresh() with refresh() in CreateTask action for consistency

Chores:
- Apply minor Blade template formatting and attribute binding tweaks