### PR TITLE
fix password property on login component

### DIFF
--- a/src/Livewire/Auth/Login.php
+++ b/src/Livewire/Auth/Login.php
@@ -20,7 +20,7 @@ class Login extends Component
     #[Rule(['required', 'email'])]
     public string $email;
 
-    public string $password = '';
+    public ?string $password = null;
 
     protected string $dashboardRoute = 'dashboard';
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change password property type in Login component from non-nullable string with empty default to nullable string with null default