### PR TITLE
task widgets: add link to the model the task belong sto

### DIFF
--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -25,7 +25,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{__(Str::headline(morph_alias(get_class($task->model))))}}:
+                                    {{__(Str::headline($task->model->getMorphClass()))}}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             @endif

--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -16,22 +16,39 @@
                     {!! $task->state->badge() !!}
                 </x-slot>
                 <x-slot:sub-value>
-                    @if ($task->due_date)
-                        <x-badge
-                            :color="$task->due_date->diffInDays(now(), false) > 0
-                                ? 'red'
-                                : ($task->due_date->diffInDays(now(), false) === 0 ? 'amber' : 'emerald')
-                            "
-                            :text="__('Due At') . ' ' . $task->due_date->locale(app()->getLocale())->isoFormat('L')"
-                        />
-                    @endif
+                    <div class="mt-1 flex flex-col">
+                        <div>
+                            @if ($task->model && method_exists($task->model, 'getUrl') && method_exists($task->model, 'getLabel'))
+                                <x-link
+                                    sm
+                                    icon="link"
+                                    :href="$task->model->getUrl()"
+                                    wire:navigate
+                                >
+                                    {{ class_basename($task->model) }}:
+                                    {{ $task->model->getLabel() }}
+                                </x-link>
+                            @endif
+                        </div>
+                        <div class="flex flex-wrap">
+                            @if ($task->due_date)
+                                <x-badge
+                                    :color="$task->due_date->diffInDays(now(), false) > 0
+                                        ? 'red'
+                                        : ($task->due_date->diffInDays(now(), false) === 0 ? 'amber' : 'emerald')
+                                    "
+                                    :text="__('Due At') . ' ' . $task->due_date->locale(app()->getLocale())->isoFormat('L')"
+                                />
+                            @endif
 
-                    @foreach ($task->users as $user)
-                        <x-badge
-                            :color="$user->id === auth()->id() ? 'indigo' : 'gray'"
-                            :text="$user->name"
-                        />
-                    @endforeach
+                            @foreach ($task->users as $user)
+                                <x-badge
+                                    :color="$user->id === auth()->id() ? 'indigo' : 'gray'"
+                                    :text="$user->name"
+                                />
+                            @endforeach
+                        </div>
+                    </div>
                 </x-slot>
                 <x-slot:actions>
                     <x-button

--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -25,7 +25,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{__(Str::headline($task->model->getMorphClass()))}}:
+                                    {{ __(Str::headline($task->model->getMorphClass())) }}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             @endif

--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -25,7 +25,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{ class_basename($task->model) }}:
+                                    {{__(Str::headline(morph_alias(get_class($task->model))))}}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             @endif

--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -16,7 +16,7 @@
                     {!! $task->state->badge() !!}
                 </x-slot>
                 <x-slot:sub-value>
-                    <div class="mt-1 flex flex-col">
+                    <div class="mt-1 flex flex-col gap-1">
                         <div>
                             @if ($task->model && method_exists($task->model, 'getUrl') && method_exists($task->model, 'getLabel'))
                                 <x-link

--- a/resources/views/livewire/widgets/my-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-tasks.blade.php
@@ -15,6 +15,20 @@
                 <x-slot:sub-value>
                     <div>
                         <div>{{ $task->project?->name }}</div>
+                        @if ($task->model && method_exists($task->model, 'getUrl') && method_exists($task->model, 'getLabel'))
+                            <div>
+                                <x-link
+                                    sm
+                                    icon="link"
+                                    :href="$task->model->getUrl()"
+                                    wire:navigate
+                                >
+                                    {{ class_basename($task->model) }}:
+                                    {{ $task->model->getLabel() }}
+                                </x-link>
+                            </div>
+                        @endif
+
                         @if ($task->due_date)
                             <x-badge
                                 :color="($diff = $task->due_date->diffInDays(now(), false)) > 0

--- a/resources/views/livewire/widgets/my-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-tasks.blade.php
@@ -23,7 +23,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{ class_basename($task->model) }}:
+                                    {{__(Str::headline(morph_alias(get_class($task->model))))}}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             </div>

--- a/resources/views/livewire/widgets/my-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-tasks.blade.php
@@ -23,7 +23,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{__(Str::headline($task->model->getMorphClass()))}}:
+                                    {{ __(Str::headline($task->model->getMorphClass())) }}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             </div>

--- a/resources/views/livewire/widgets/my-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-tasks.blade.php
@@ -23,7 +23,7 @@
                                     :href="$task->model->getUrl()"
                                     wire:navigate
                                 >
-                                    {{__(Str::headline(morph_alias(get_class($task->model))))}}:
+                                    {{__(Str::headline($task->model->getMorphClass()))}}:
                                     {{ $task->model->getLabel() }}
                                 </x-link>
                             </div>

--- a/src/Livewire/Widgets/MyResponsibleTasks.php
+++ b/src/Livewire/Widgets/MyResponsibleTasks.php
@@ -38,6 +38,7 @@ class MyResponsibleTasks extends Component
                 'tasks' => auth()
                     ->user()
                     ->tasksResponsible()
+                    ->with('model')
                     ->whereNotIn('state', $endStates)
                     ->orderByDesc('priority')
                     ->with('users:id,name')

--- a/src/Livewire/Widgets/MyTasks.php
+++ b/src/Livewire/Widgets/MyTasks.php
@@ -41,7 +41,7 @@ class MyTasks extends Component
                 'tasks' => auth()
                     ->user()
                     ->tasks()
-                    ->with('project:id,name')
+                    ->with(['project:id,name', 'model'])
                     ->whereNotIn('state', $endStates)
                     ->orderByDesc('priority')
                     ->orderByRaw('ISNULL(due_date), due_date ASC')


### PR DESCRIPTION
## Summary by Sourcery

Add navigable model references to task widgets by updating Blade views to include a link with the model's URL and label, and adjust Livewire components to eager-load the model relation.

New Features:
- Display a link to the task's associated model in both "My Tasks" and "My Responsible Tasks" widgets

Enhancements:
- Refactor the sub-value section in task widget templates to group the model link, due date badge, and user badges in a unified layout
- Eager-load the "model" relation in the MyTasks and MyResponsibleTasks Livewire components to support rendering model links