### PR TITLE
fix tab button

### DIFF
--- a/src/Htmlables/TabButton.php
+++ b/src/Htmlables/TabButton.php
@@ -178,10 +178,10 @@ class TabButton implements Htmlable
         return $this;
     }
 
-    public function toHtml(): ?string
+    public function toHtml(): string
     {
         if (! $this->shouldRender || ! $this->userHasTabPermission(false)) {
-            return null;
+            return '';
         }
 
         $this->text = is_null($this->text) ? '' : $this->text;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Changed TabButton::toHtml return type to non-nullable string to prevent null values