### PR TITLE
fix: update MatchTransactionsWithOrderJob to retrieve contact_id valu…

### DIFF
--- a/src/Jobs/Accounting/MatchTransactionsWithOrderJob.php
+++ b/src/Jobs/Accounting/MatchTransactionsWithOrderJob.php
@@ -96,7 +96,8 @@ class MatchTransactionsWithOrderJob implements Repeatable, ShouldQueue
                     'JSON_CONTAINS(LOWER(search_aliases), LOWER(?))',
                     [json_encode($transaction->counterpart_name)]
                 )
-                ->sole('contact_id');
+                ->sole('contact_id')
+                ->value('contact_id');
         } catch (ModelNotFoundException|MultipleRecordsFoundException) {
         }
 


### PR DESCRIPTION
…e directly

## Summary by Sourcery

Bug Fixes:
- Chain ->value('contact_id') after sole() to properly fetch the contact_id field.