### PR TITLE
remove uuid from purchase invoice positions when creating order

### DIFF
--- a/src/Actions/PurchaseInvoice/CreateOrderFromPurchaseInvoice.php
+++ b/src/Actions/PurchaseInvoice/CreateOrderFromPurchaseInvoice.php
@@ -54,6 +54,7 @@ class CreateOrderFromPurchaseInvoice extends FluxAction
         $order = CreateOrder::make($this->data)->validate()->execute();
 
         foreach (data_get($this->data, 'purchase_invoice_positions', []) as $position) {
+            data_forget($position, 'uuid');
             CreateOrderPosition::make(
                 array_merge(
                     $position,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Strip out the 'uuid' field from purchase invoice positions before creating order positions