### PR TITLE
add missing lead relations in Lead and Order models

### DIFF
--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -23,6 +23,7 @@ use FluxErp\Traits\Scout\Searchable;
 use FluxErp\Traits\SoftDeletes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
@@ -193,6 +194,11 @@ class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDat
     public function leadState(): BelongsTo
     {
         return $this->belongsTo(LeadState::class);
+    }
+
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
     }
 
     public function recalculateWeightedGrossProfit(): void

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -775,6 +775,11 @@ class Order extends FluxModel implements HasMedia, InteractsWithDataTables, IsSu
         return $this->belongsTo(Language::class);
     }
 
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Lead::class);
+    }
+
     public function newCollection(array $models = []): Collection
     {
         return app(OrderCollection::class, ['items' => $models]);


### PR DESCRIPTION
## Summary by Sourcery

Add missing Eloquent relationships between Lead and Order models

New Features:
- Add orders() HasMany relation to Lead model
- Add lead() BelongsTo relation to Order model