### PR TITLE
fix: update unit price label to reflect net/gross based on order position

### DIFF
--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -121,10 +121,21 @@
                         <x-input
                             :prefix="data_get($order->currency, 'symbol')"
                             type="number"
-                            :label="__('Unit price :type', ['type' => ($orderPosition->is_net ?? true) ? __('net') : __('gross')])"
                             wire:model="orderPosition.unit_price"
                             x-on:change="$el.value = parseNumber($el.value)"
-                        />
+                        >
+                            <x-slot:label>
+                                <x-label for="orderPosition.unit_price">
+                                    <span
+                                        x-text="
+                                            $wire.orderPosition.is_net
+                                                ? '{{ __('Unit price :type', ['type' => __('net')]) }}'
+                                                : '{{ __('Unit price :type', ['type' => __('gross')]) }}'
+                                        "
+                                    ></span>
+                                </x-label>
+                            </x-slot>
+                        </x-input>
                         <x-input
                             :prefix="data_get($order->currency, 'symbol')"
                             type="number"


### PR DESCRIPTION
## Summary by Sourcery

Update the unit price input field to dynamically reflect net or gross pricing by leveraging a label slot with Livewire bindings

Bug Fixes:
- Make the unit price label reactive so it correctly toggles between “net” and “gross” based on the order position’s is_net property

Enhancements:
- Switch the x-input component to use a label slot with x-text for dynamic updating instead of a static label attribute