### PR TITLE
fix search in permissions

### DIFF
--- a/src/Livewire/Settings/UserEdit.php
+++ b/src/Livewire/Settings/UserEdit.php
@@ -62,7 +62,6 @@ class UserEdit extends Component
                 )
                     ->query(fn ($query) => $query->where('guard_name', '!=', 'address'))
                     ->paginate(pageName: 'permissionsPage'),
-
                 'clients' => resolve_static(Client::class, 'query')
                     ->get(['id', 'name', 'client_code']),
                 'roles' => resolve_static(Role::class, 'query')


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use Permission::search with a query callback to exclude the ‘address’ guard and restore proper pagination for permissions lookup