### PR TITLE
add aborted OrderState

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -41,6 +41,7 @@
     "A list of all the price lists": "Liste aller Preislisten",
     "Abbreviation": "Abkürzung",
     "Abilities": "Fähigkeiten",
+    "aborted": "abgebrochen",
     "Accept": "Akzeptieren",
     "Accept all": "Alle akzeptieren",
     "Accept all assignments|All suggested transaction assignments will be accepted": "Alle Zuweisungen akzeptieren|Alle vorgeschlagenen Transaktionszuweisungen werden automatisch akzeptiert|Abbrechen|Akzeptieren",

--- a/src/States/Order/Aborted.php
+++ b/src/States/Order/Aborted.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FluxErp\States\Order;
+
+class Aborted extends OrderState
+{
+    public static bool $isEndState = true;
+
+    public static $name = 'aborted';
+
+    public function color(): string
+    {
+        return static::$color ?? 'red';
+    }
+}

--- a/src/States/Order/OrderState.php
+++ b/src/States/Order/OrderState.php
@@ -50,7 +50,8 @@ abstract class OrderState extends EndableState implements HasFrontendFormatter
                         InReview::class,
                     ],
                     Canceled::class,
-                ],                [
+                ],
+                [
                     [
                         Open::class,
                         InProgress::class,

--- a/src/States/Order/OrderState.php
+++ b/src/States/Order/OrderState.php
@@ -17,6 +17,7 @@ abstract class OrderState extends EndableState implements HasFrontendFormatter
             ->allowTransitions([
                 [
                     [
+                        Aborted::class,
                         Draft::class,
                         Canceled::class,
                     ],
@@ -49,6 +50,13 @@ abstract class OrderState extends EndableState implements HasFrontendFormatter
                         InReview::class,
                     ],
                     Canceled::class,
+                ],                [
+                    [
+                        Open::class,
+                        InProgress::class,
+                        InReview::class,
+                    ],
+                    Aborted::class,
                 ],
                 [
                     [


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new Aborted order state and integrate it into the order state machine transitions

New Features:
- Add Aborted state class with end-state flag, name 'aborted', and red color
- Update OrderState config to permit transitions to and from the new Aborted state