### PR TITLE
fix time frame aware widgets eventually not showing correct data

### DIFF
--- a/src/Traits/Livewire/IsTimeFrameAwareWidget.php
+++ b/src/Traits/Livewire/IsTimeFrameAwareWidget.php
@@ -23,6 +23,13 @@ trait IsTimeFrameAwareWidget
 
     abstract public function calculateByTimeFrame(): void;
 
+    public function mountIsTimeFrameAwareWidget(): void
+    {
+        if ($this->timeFrame !== data_get($this->timeParams, 'timeFrame')) {
+            $this->updatedTimeParams();
+        }
+    }
+
     public function updatedTimeParams(): void
     {
         $timeFrame = data_get($this->timeParams, 'timeFrame', TimeFrameEnum::ThisMonth);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Trigger an update of timeParams on component mount when the timeFrame differs to fix incorrect widget data display