### PR TITLE
update OrdersByTypeChart to retrieve order type names along with IDs

### DIFF
--- a/src/Livewire/Widgets/OrdersByTypeChart.php
+++ b/src/Livewire/Widgets/OrdersByTypeChart.php
@@ -40,7 +40,10 @@ class OrdersByTypeChart extends LineChart implements HasWidgetOptions
     {
         $orderTypes = resolve_static(OrderType::class, 'query')
             ->where('is_active', true)
-            ->get('id');
+            ->get([
+                'id',
+                'name',
+            ]);
 
         $this->series = [];
         $metrics = [];


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include the name field when querying active order types for the chart