### PR TITLE
Add "Assign to me" functionality and update task form with authenticated user

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -328,6 +328,7 @@
     "Assign order": "Auftrag zuweisen",
     "Assign product": "Produkt zuordnen",
     "Assign serial number": "Seriennummer zuordnen",
+    "Assign to me": "Mir zuweisen",
     "Assign users": "Benutzer zuordnen",
     "Assigned": "Zugewiesen",
     "Assigned To": "Zugewiesen an",

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -232,7 +232,8 @@
                             ]"
                         />
                         <x-button
-                            x-bind:class="$wire.ticket.users?.includes({{ auth()->id() }}) && 'hidden'"
+                            x-cloak
+                            x-show="! $wire.ticket.users?.includes({{ auth()->id() }})"
                             class="w-full"
                             color="secondary"
                             loading="assignToMe"

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -232,6 +232,7 @@
                             ]"
                         />
                         <x-button
+                            x-bind:class="$wire.ticket.users?.includes({{ auth()->id() }}) && 'hidden'"
                             class="w-full"
                             color="secondary"
                             loading="assignToMe"

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -213,7 +213,7 @@
                             :disabled="$ticket->id && ! resolve_static(\FluxErp\Actions\Ticket\UpdateTicket::class, 'canPerformAction', [false])"
                             multiple
                             :label="__('Assigned')"
-                            wire:model.live="ticket.users"
+                            wire:model="ticket.users"
                             select="label:label|value:id"
                             unfiltered
                             :request="[
@@ -230,6 +230,13 @@
                                     ],
                                 ],
                             ]"
+                        />
+                        <x-button
+                            class="w-full"
+                            color="secondary"
+                            loading="assignToMe"
+                            :text="__('Assign to me')"
+                            wire:click="assignToMe"
                         />
                         <div>
                             <div class="mb-1 flex items-center justify-between">

--- a/src/Livewire/Forms/TaskForm.php
+++ b/src/Livewire/Forms/TaskForm.php
@@ -76,6 +76,14 @@ class TaskForm extends FluxForm
         parent::fill($values);
     }
 
+    public function reset(...$properties): void
+    {
+        parent::reset(...$properties);
+
+        $this->responsible_user_id ??= auth()?->id();
+        $this->users = $this->users ?: array_filter([auth()?->id()]);
+    }
+
     protected function getActions(): array
     {
         return [

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -69,7 +69,7 @@ class ProjectTaskList extends BaseTaskList
         $this->editForm($id);
 
         $this->task->project_id = $this->projectId;
-        $this->task->users = $task->users()->pluck('users.id')->toArray();
+
         $this->task->additionalColumns = array_intersect_key(
             $task->toArray(),
             array_fill_keys(

--- a/src/Livewire/Task/TaskList.php
+++ b/src/Livewire/Task/TaskList.php
@@ -76,8 +76,6 @@ class TaskList extends BaseTaskList
             resolve_static(Task::class, 'additionalColumnsQuery')->pluck('name')?->toArray() ?? [],
             null
         );
-        $this->task->responsible_user_id ??= auth()?->id();
-        $this->task->users = array_filter([auth()?->id()]);
 
         $this->js(<<<'JS'
             $modalOpen('new-task-modal');

--- a/src/Livewire/Ticket/Ticket.php
+++ b/src/Livewire/Ticket/Ticket.php
@@ -45,6 +45,13 @@ class Ticket extends Component
     }
 
     #[Renderless]
+    public function assignToMe(): void
+    {
+        $this->ticket->users = array_merge($this->ticket->users, [auth()->id()]);
+        $this->save();
+    }
+
+    #[Renderless]
     public function delete(): void
     {
         try {

--- a/src/Livewire/Ticket/Ticket.php
+++ b/src/Livewire/Ticket/Ticket.php
@@ -47,7 +47,7 @@ class Ticket extends Component
     #[Renderless]
     public function assignToMe(): void
     {
-        $this->ticket->users = array_merge($this->ticket->users, [auth()->id()]);
+        $this->ticket->users = array_unique(array_merge($this->ticket->users, [auth()->id()]));
         $this->save();
     }
 

--- a/tests/Livewire/Project/ProjectTaskListTest.php
+++ b/tests/Livewire/Project/ProjectTaskListTest.php
@@ -2,13 +2,30 @@
 
 use FluxErp\Livewire\Project\ProjectTaskList;
 use FluxErp\Models\Project;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
-test('renders successfully', function (): void {
+test('can add new task', function (): void {
     $project = Project::factory()->create([
         'client_id' => $this->dbClient->id,
     ]);
 
     Livewire::test(ProjectTaskList::class, ['projectId' => $project->id])
-        ->assertOk();
+        ->assertOk()
+        ->call('edit')
+        ->assertExecutesJs("\$modalOpen('task-form-modal');")
+        ->assertSet('task.project_id', $project->id)
+        ->assertSet('task.responsible_user_id', $this->user->getKey())
+        ->assertSet('task.users', [$this->user->getKey()])
+        ->set('task.name', $uuid = Str::uuid()->toString())
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'name' => $uuid,
+        'project_id' => $project->id,
+        'responsible_user_id' => $this->user->getKey(),
+        'state' => 'open',
+    ]);
 });


### PR DESCRIPTION
## Summary by Sourcery

Implement self-assignment support by adding an "Assign to me" action on tickets and pre-populating task forms with the current user, while streamlining default assignment logic and updating relevant tests.

New Features:
- Add "Assign to me" button in the ticket UI for users to self-assign tickets
- Automatically prefill the task creation form with the authenticated user as responsible and in the user list

Enhancements:
- Consolidate default user assignment logic into TaskForm reset and remove redundant code from TaskList
- Update binding directive in ticket component from wire:model.live to wire:model

Tests:
- Expand ProjectTaskList test to cover new task creation with default authenticated user assignment and verify database persistence