### PR TITLE
fix: correct profit calculation in RevenuePurchasesProfitChart

### DIFF
--- a/src/Livewire/Widgets/RevenuePurchasesProfitChart.php
+++ b/src/Livewire/Widgets/RevenuePurchasesProfitChart.php
@@ -62,7 +62,7 @@ class RevenuePurchasesProfitChart extends LineChart implements HasWidgetOptions
 
         $profit = [];
         foreach ($revenue->getCombinedData() as $key => $value) {
-            $profit[$key] = (int) bcadd($value, data_get($purchasesData, $key, 0), 0);
+            $profit[$key] = (int) bcsub($value, data_get($purchasesData, $key, 0), 0);
         }
         $profit = Result::make(array_values($profit), array_keys($profit), null);
 
@@ -96,7 +96,7 @@ class RevenuePurchasesProfitChart extends LineChart implements HasWidgetOptions
                 'data' => $purchases->getData(),
             ],
             [
-                'name' => __('Profit'),
+                'name' => __('Gross Profit'),
                 'color' => 'indigo',
                 'data' => $profit->getData(),
             ],


### PR DESCRIPTION
## Summary by Sourcery

Correct the profit computation by subtracting purchases from revenue and update the chart series label accordingly

Bug Fixes:
- Fix profit calculation to subtract purchases from revenue instead of adding them

Enhancements:
- Rename the chart series from "Profit" to "Gross Profit"