### PR TITLE
fix: update order footer to correctly render discounts and add head discount translation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -889,6 +889,7 @@
     "Has Sensitive Reminder": "Sensibel mahnen",
     "Has taken place": "Hat stattgefunden",
     "Has Valid Certificate": "Gültiges Zertifikat",
+    "Head discount": "Kopfrabatt",
     "Header": "Kopfzeile",
     "Header Discount": "Kopfzeilenrabatt",
     "Height": "Höhe",

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -188,7 +188,7 @@
                     </tr>
                 @endforeach
 
-                @if ($model->discounts->isNotEmpty() && bccomp($model->total_position_discount_percentage ?? '0', '0', 10) !== 0 && bccomp($model->total_discount_percentage ?? '0', '0', 10) !== 0)
+                @if ($model->discounts->isNotEmpty() && bccomp($model->total_position_discount_percentage ?? 0, 0) !== 0 && bccomp($model->total_discount_percentage ?? 0, 0) !== 0)
                     <tr>
                         <td class="text-right">
                             <span>{{ __('Total discount') }}</span>

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -188,20 +188,6 @@
                     </tr>
                 @endforeach
 
-                @if ($model->discounts->isNotEmpty() && bccomp($model->total_position_discount_percentage ?? 0, 0) !== 0 && bccomp($model->total_discount_percentage ?? 0, 0) !== 0)
-                    <tr>
-                        <td class="text-right">
-                            <span>{{ __('Total discount') }}</span>
-                            <span>
-                                {{ Number::percentage(bcmul($model->total_discount_percentage ?? 0, 100)) }}
-                            </span>
-                        </td>
-                        <td class="w-0 whitespace-nowrap pl-12 text-right">
-                            {{ Number::currency(bcmul($model->total_discount_flat ?? 0, -1)) }}
-                        </td>
-                    </tr>
-                @endif
-
                 <tr class="border-b"></tr>
             @endif
 

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -138,7 +138,7 @@
                 </td>
             </tr>
             @section('total.discounts')
-            @if (bccomp($model->total_base_net_price ?? '0', $model->total_net_price ?? '0', 10) !== 0)
+            @if (bccomp($model->total_base_net_price ?? 0, $model->total_net_price ?? 0) !== 0)
                 <tr>
                     <td class="text-right">
                         {{ __('Sum net without discount') }}

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -138,7 +138,7 @@
                 </td>
             </tr>
             @section('total.discounts')
-            @if ($model->discounts->isNotEmpty())
+            @if (bccomp($model->total_base_net_price ?? '0', $model->total_net_price ?? '0', 10) !== 0)
                 <tr>
                     <td class="text-right">
                         {{ __('Sum net without discount') }}
@@ -147,10 +147,37 @@
                         {{ Number::currency($model->total_base_net_price) }}
                     </td>
                 </tr>
+
+                @if (bccomp($model->total_position_discount_percentage ?? 0, 0) !== 0)
+                    <tr>
+                        <td class="text-right">
+                            <span>{{ __('Position discounts') }}</span>
+                            <span>
+                                {{ Number::percentage(bcmul($model->total_position_discount_percentage ?? 0, 100)) }}
+                            </span>
+                        </td>
+                        <td class="w-0 whitespace-nowrap pl-12 text-right">
+                            {{ Number::currency(bcmul($model->total_position_discount_flat ?? 0, -1)) }}
+                        </td>
+                    </tr>
+                    @if ($model->discounts->isNotEmpty())
+                        <tr>
+                            <td class="text-right">
+                                {{ __('Sum net discounted') }}
+                            </td>
+                            <td class="w-0 whitespace-nowrap pl-12 text-right">
+                                {{ Number::currency($model->total_base_discounted_net_price ?? 0) }}
+                            </td>
+                        </tr>
+                    @endif
+                @endif
+
                 @foreach ($model->discounts as $discount)
                     <tr>
                         <td class="text-right">
-                            <span>{{ data_get($discount, 'name') }}</span>
+                            <span>
+                                {{ data_get($discount, 'name', __('Head discount')) }}
+                            </span>
                             <span>
                                 {{ Number::percentage(bcmul(data_get($discount, 'discount_percentage', 0), 100)) }}
                             </span>
@@ -160,6 +187,20 @@
                         </td>
                     </tr>
                 @endforeach
+
+                @if ($model->discounts->isNotEmpty() && bccomp($model->total_position_discount_percentage ?? '0', '0', 10) !== 0 && bccomp($model->total_discount_percentage ?? '0', '0', 10) !== 0)
+                    <tr>
+                        <td class="text-right">
+                            <span>{{ __('Total discount') }}</span>
+                            <span>
+                                {{ Number::percentage(bcmul($model->total_discount_percentage ?? 0, 100)) }}
+                            </span>
+                        </td>
+                        <td class="w-0 whitespace-nowrap pl-12 text-right">
+                            {{ Number::currency(bcmul($model->total_discount_flat ?? 0, -1)) }}
+                        </td>
+                    </tr>
+                @endif
 
                 <tr class="border-b"></tr>
             @endif


### PR DESCRIPTION
## Summary by Sourcery

Revise order footer discount section to correctly trigger on net price differences and provide detailed discount breakdowns with translation support

Enhancements:
- Use net price comparison instead of discount list emptiness to show discount section
- Add position discounts row and conditional "Sum net discounted" row for detailed breakdown
- Introduce a total discount row summarizing overall discount percentage and amount
- Provide fallback translatable label for head discounts

Documentation:
- Add German translation for head discount label