### PR TITLE
show only active users in permissions

### DIFF
--- a/src/Livewire/Settings/Permissions.php
+++ b/src/Livewire/Settings/Permissions.php
@@ -145,6 +145,7 @@ class Permissions extends RoleList
             [
                 'guards' => array_keys(config('auth.guards')),
                 'users' => resolve_static(User::class, 'query')
+                    ->where('is_active', true)
                     ->get(['id', 'name'])
                     ->toArray(),
             ]

--- a/tests/Livewire/Settings/PermissionsTest.php
+++ b/tests/Livewire/Settings/PermissionsTest.php
@@ -1,19 +1,9 @@
 <?php
 
 use FluxErp\Livewire\Settings\Permissions;
-use FluxErp\Models\User;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Permissions::class)
         ->assertOk();
-});
-
-test('show only active users', function (): void {
-    User::factory(2)->create(['is_active' => true]);
-    User::factory(1)->create(['is_active' => false]);
-
-    Livewire::test(Permissions::class)
-        ->assertOk()
-        ->assertCount('users', 2);
 });

--- a/tests/Livewire/Settings/PermissionsTest.php
+++ b/tests/Livewire/Settings/PermissionsTest.php
@@ -1,9 +1,19 @@
 <?php
 
 use FluxErp\Livewire\Settings\Permissions;
+use FluxErp\Models\User;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Permissions::class)
         ->assertOk();
+});
+
+test('show only active users', function (): void {
+    User::factory(2)->create(['active' => true]);
+    User::factory(1)->create(['active' => false]);
+
+    Livewire::test(Permissions::class)
+        ->assertOk()
+        ->assertCount('users', 2);
 });

--- a/tests/Livewire/Settings/PermissionsTest.php
+++ b/tests/Livewire/Settings/PermissionsTest.php
@@ -10,8 +10,8 @@ test('renders successfully', function (): void {
 });
 
 test('show only active users', function (): void {
-    User::factory(2)->create(['active' => true]);
-    User::factory(1)->create(['active' => false]);
+    User::factory(2)->create(['is_active' => true]);
+    User::factory(1)->create(['is_active' => false]);
 
     Livewire::test(Permissions::class)
         ->assertOk()


### PR DESCRIPTION
## Summary by Sourcery

Filter the permissions settings to display only active users.

Enhancements:
- Add a where clause to the Permissions component to only retrieve users with is_active set to true

Tests:
- Add a test to verify that only active users are counted and displayed in the Permissions view