### PR TITLE
fix: handle potential null value in series iteration

### DIFF
--- a/src/Livewire/Widgets/OrderMediaChart.php
+++ b/src/Livewire/Widgets/OrderMediaChart.php
@@ -91,7 +91,7 @@ class OrderMediaChart extends LineChart implements HasWidgetOptions
     public function options(): array
     {
         $options = [];
-        foreach ($this->series as $series) {
+        foreach ($this->series ?? [] as $series) {
             if (data_get($series, 'collection')) {
                 $options[] = [
                     'label' => data_get($series, 'name'),

--- a/src/Livewire/Widgets/OrdersByTypeChart.php
+++ b/src/Livewire/Widgets/OrdersByTypeChart.php
@@ -95,7 +95,7 @@ class OrdersByTypeChart extends LineChart implements HasWidgetOptions
     public function options(): array
     {
         $options = [];
-        foreach ($this->series as $series) {
+        foreach ($this->series ?? [] as $series) {
             if (data_get($series, 'orderTypeId')) {
                 $options[] = [
                     'label' => data_get($series, 'name'),


### PR DESCRIPTION
## Summary by Sourcery

Prevent errors when iterating over potentially null series in chart widgets by defaulting to an empty array.

Bug Fixes:
- Guard series iteration against null values in OrderMediaChart options method
- Guard series iteration against null values in OrdersByTypeChart options method