### PR TITLE
add-missing-bank-connection-relations

### DIFF
--- a/src/Models/BankConnection.php
+++ b/src/Models/BankConnection.php
@@ -37,13 +37,13 @@ class BankConnection extends FluxModel
         return $this->belongsToMany(Client::class, 'bank_connection_client');
     }
 
-    public function ledgerAccount(): BelongsTo
-    {
-        return $this->belongsTo(LedgerAccount::class);
-    }
-
     public function currency(): BelongsTo
     {
         return $this->belongsTo(Currency::class);
+    }
+
+    public function ledgerAccount(): BelongsTo
+    {
+        return $this->belongsTo(LedgerAccount::class);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add missing belongsTo relations for Currency and LedgerAccount on the BankConnection model

New Features:
- Define currency() belongsTo relationship on BankConnection
- Define ledgerAccount() belongsTo relationship on BankConnection