### PR TITLE
fix: update event detail access to use 'record.id' for consistency

### DIFF
--- a/resources/views/components/contact/accounting/discounts.blade.php
+++ b/resources/views/components/contact/accounting/discounts.blade.php
@@ -14,7 +14,7 @@
             showDetails($event) {
                 this.showDetail = false
                 const detailElement = $el.querySelector('#detail')
-                if ($event.detail.id === this.detailId) {
+                if ($event.detail.record.id === this.detailId) {
                     setTimeout(() => {
                         $el.querySelector('#detail-container').appendChild(
                             detailElement,
@@ -25,9 +25,9 @@
                     return
                 }
 
-                this.detailId = $event.detail.id
+                this.detailId = $event.detail.record.id
                 this.dataTableComponent.$wire
-                    .getDiscounts($event.detail.id)
+                    .getDiscounts($event.detail.record.id)
                     .then((response) => {
                         this.discounts = response
                         setTimeout(() => {

--- a/resources/views/livewire/mail/mail.blade.php
+++ b/resources/views/livewire/mail/mail.blade.php
@@ -178,7 +178,7 @@
     </section>
     <section
         class="grow"
-        x-on:data-table-row-clicked="$wire.showMail($event.detail.id)"
+        x-on:data-table-row-clicked="$wire.showMail($event.detail.record.id)"
     >
         @include('tall-datatables::livewire.data-table')
     </section>

--- a/resources/views/livewire/portal/order-detail.blade.php
+++ b/resources/views/livewire/portal/order-detail.blade.php
@@ -262,7 +262,7 @@
         <div class="space-y-8">
             <div
                 id="order-position-table"
-                x-on:data-table-row-clicked="$wire.selectPosition($event.detail.id)"
+                x-on:data-table-row-clicked="$wire.selectPosition($event.detail.record.id)"
             >
                 <livewire:portal.data-tables.order-position-list
                     :order-id="$order['id']"

--- a/resources/views/livewire/product/warehouse-list.blade.php
+++ b/resources/views/livewire/product/warehouse-list.blade.php
@@ -2,7 +2,7 @@
     <div class="gap-6 lg:flex">
         <div
             class="flex-1"
-            x-on:data-table-row-clicked="$wire.warehouseId = $event.detail.id;"
+            x-on:data-table-row-clicked="$wire.warehouseId = $event.detail.record.id;"
         >
             @include('tall-datatables::livewire.data-table')
         </div>

--- a/resources/views/livewire/settings/logs.blade.php
+++ b/resources/views/livewire/settings/logs.blade.php
@@ -3,7 +3,7 @@
         log: {},
     }"
     x-on:data-table-row-clicked="
-        $wire.loadLog($event.detail.id).then((result) => {
+        $wire.loadLog($event.detail.record.id).then((result) => {
             log = result
             $modalOpen('show-log-modal')
         })


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect event detail ID references by using record.id in various Livewire components