### PR TITLE
add stack for create order modals

### DIFF
--- a/resources/views/livewire/contact/orders.blade.php
+++ b/resources/views/livewire/contact/orders.blade.php
@@ -123,6 +123,7 @@
                         select="label:name|value:id"
                         :options="$languages"
                     />
+                    @stack('create-order-modal-fields')
                 </div>
             </div>
         </section>

--- a/resources/views/livewire/contact/orders.blade.php
+++ b/resources/views/livewire/contact/orders.blade.php
@@ -123,8 +123,8 @@
                         select="label:name|value:id"
                         :options="$languages"
                     />
-                    @stack('create-order-modal-fields')
                 </div>
+                @stack('create-order-modal-fields')
             </div>
         </section>
         <x-slot:footer>

--- a/resources/views/livewire/order/order-list.blade.php
+++ b/resources/views/livewire/order/order-list.blade.php
@@ -139,8 +139,8 @@
                         select="label:name|value:id"
                         :options="$languages"
                     />
-                    @stack('create-order-modal-fields')
                 </div>
+                @stack('create-order-modal-fields')
             </div>
         </section>
         <x-errors />

--- a/resources/views/livewire/order/order-list.blade.php
+++ b/resources/views/livewire/order/order-list.blade.php
@@ -139,6 +139,7 @@
                         select="label:name|value:id"
                         :options="$languages"
                     />
+                    @stack('create-order-modal-fields')
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Expose a reusable @stack('create-order-modal-fields') section in both contact and order create modals for extensible custom fields.