### PR TITLE
Prefer order VAT rate over product default on position changes

### DIFF
--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -188,6 +188,7 @@ class ReplicateOrder extends FluxAction
                 $orderPosition['original_amount'],
                 $orderPosition['total_net_price'],
                 $orderPosition['total_gross_price'],
+                $orderPosition['vat_rate_id'],
             );
 
             if (! data_get($orderPosition, 'is_free_text')) {

--- a/src/Actions/OrderPosition/CreateOrderPosition.php
+++ b/src/Actions/OrderPosition/CreateOrderPosition.php
@@ -50,7 +50,7 @@ class CreateOrderPosition extends FluxAction
             ?? resolve_static(Tenant::class, 'default')?->getKey();
         $this->data['price_list_id'] ??= data_get($order, 'price_list_id')
             ?? resolve_static(PriceList::class, 'default')?->getKey();
-        $this->data['vat_rate_id'] = data_get($order, 'vat_rate_id') ?? data_get($this->data, 'vat_rate_id');
+        $this->data['vat_rate_id'] ??= data_get($order, 'vat_rate_id');
 
         if (is_int($this->getData('sort_number'))) {
             $currentHighestSortNumber = resolve_static(OrderPosition::class, 'query')

--- a/src/Actions/OrderPosition/UpdateOrderPosition.php
+++ b/src/Actions/OrderPosition/UpdateOrderPosition.php
@@ -38,7 +38,7 @@ class UpdateOrderPosition extends FluxAction
 
         $order = resolve_static(Order::class, 'query')
             ->whereKey(data_get($this->data, 'order_id', $orderPosition->order_id))
-            ->select(['id', 'tenant_id', 'price_list_id'])
+            ->select(['id', 'tenant_id', 'price_list_id', 'vat_rate_id'])
             ->first();
 
         $this->data['tenant_id'] ??= $order->tenant_id;
@@ -56,7 +56,7 @@ class UpdateOrderPosition extends FluxAction
                 ->first();
 
             $orderPosition->vat_rate_id = $orderPosition->isDirty('vat_rate_id') ?
-                $orderPosition->vat_rate_id : $product->vat_rate_id;
+                $orderPosition->vat_rate_id : ($order->vat_rate_id ?? $product->vat_rate_id);
             $orderPosition->name = $orderPosition->isDirty('name') ?
                 $orderPosition->name : $product->name;
             $orderPosition->description = $orderPosition->isDirty('description') ?

--- a/tests/Feature/Actions/OrderPosition/UpdateOrderPositionTest.php
+++ b/tests/Feature/Actions/OrderPosition/UpdateOrderPositionTest.php
@@ -1,0 +1,176 @@
+<?php
+
+use FluxErp\Actions\OrderPosition\CreateOrderPosition;
+use FluxErp\Actions\OrderPosition\UpdateOrderPosition;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\Price;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Product;
+use FluxErp\Models\VatRate;
+use FluxErp\Models\Warehouse;
+
+it('uses order vat rate instead of product vat rate when changing product', function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $contact = Contact::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $address = Address::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $domesticVatRate = VatRate::factory()->create([
+        'rate_percentage' => 0.19,
+        'name' => 'Voll',
+    ]);
+
+    $euVatRate = VatRate::factory()->create([
+        'rate_percentage' => 0,
+        'name' => 'EU-Land (Ohne MwSt)',
+    ]);
+
+    $priceList = PriceList::factory()->create(['is_net' => true]);
+    $currency = Currency::default();
+    $paymentType = PaymentType::default();
+
+    $orderType = OrderType::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+
+    $productA = Product::factory()->create([
+        'vat_rate_id' => $domesticVatRate->getKey(),
+    ]);
+
+    Price::factory()->create([
+        'product_id' => $productA->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'price' => 1000,
+    ]);
+
+    $productB = Product::factory()->create([
+        'vat_rate_id' => $domesticVatRate->getKey(),
+    ]);
+
+    Price::factory()->create([
+        'product_id' => $productB->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'price' => 2000,
+    ]);
+
+    // Order has EU vat rate (e.g. EU customer)
+    $order = Order::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => $contact->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'currency_id' => $currency->getKey(),
+        'vat_rate_id' => $euVatRate->getKey(),
+        'is_locked' => false,
+    ]);
+
+    // Position created with EU vat rate (from order)
+    $position = OrderPosition::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'order_id' => $order->getKey(),
+        'product_id' => $productA->getKey(),
+        'vat_rate_id' => $euVatRate->getKey(),
+        'amount' => 1,
+        'unit_net_price' => 1000,
+        'unit_gross_price' => 1000,
+        'total_net_price' => 1000,
+        'total_gross_price' => 1000,
+    ]);
+
+    // Change product without explicitly setting vat_rate_id
+    $result = UpdateOrderPosition::make([
+        'id' => $position->getKey(),
+        'product_id' => $productB->getKey(),
+    ])->validate()->execute();
+
+    // Should keep order's EU vat rate, NOT use productB's domestic vat rate
+    expect($result->vat_rate_id)->toBe($euVatRate->getKey());
+});
+
+it('allows explicit vat rate override on create even when order has vat rate', function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $contact = Contact::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $address = Address::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $domesticVatRate = VatRate::factory()->create([
+        'rate_percentage' => 0.19,
+        'name' => 'Voll',
+    ]);
+
+    $euVatRate = VatRate::factory()->create([
+        'rate_percentage' => 0,
+        'name' => 'EU-Land (Ohne MwSt)',
+    ]);
+
+    $priceList = PriceList::factory()->create(['is_net' => true]);
+    $currency = Currency::default();
+    $paymentType = PaymentType::default();
+
+    $orderType = OrderType::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+
+    $product = Product::factory()->create([
+        'vat_rate_id' => $domesticVatRate->getKey(),
+    ]);
+
+    Price::factory()->create([
+        'product_id' => $product->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'price' => 1000,
+    ]);
+
+    // Order has EU vat rate
+    $order = Order::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => $contact->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'currency_id' => $currency->getKey(),
+        'vat_rate_id' => $euVatRate->getKey(),
+        'is_locked' => false,
+    ]);
+
+    // Explicitly create position with domestic vat rate (manual override)
+    $position = CreateOrderPosition::make([
+        'order_id' => $order->getKey(),
+        'product_id' => $product->getKey(),
+        'vat_rate_id' => $domesticVatRate->getKey(),
+        'amount' => 1,
+    ])->validate()->execute();
+
+    // Should respect the explicitly provided vat rate
+    expect($position->vat_rate_id)->toBe($domesticVatRate->getKey());
+});


### PR DESCRIPTION
## Summary
- When changing the product on an order position, the order-level VAT rate now takes precedence over the product's default VAT rate
- Allow explicit manual VAT rate overrides on position creation even when the order has a VAT rate set
- Strip `vat_rate_id` from replicated position data so duplicated orders correctly inherit the new order's VAT rate

## Summary by Sourcery

Align order position VAT handling with order-level VAT configuration and support explicit overrides.

New Features:
- Allow explicit VAT rate overrides when creating order positions even if the parent order has a VAT rate set.

Bug Fixes:
- Ensure changing the product on an order position preserves the order-level VAT rate instead of reverting to the product's default VAT rate.
- Ensure replicated orders correctly inherit the new order's VAT rate on their positions instead of carrying over the original position VAT rate.

Tests:
- Add feature tests covering product change VAT precedence and explicit VAT override behavior for order positions.