### PR TITLE
Fix memory exhaustion when printing invoices with ZUGFeRD

### DIFF
--- a/src/Jobs/CreateDocumentsJob.php
+++ b/src/Jobs/CreateDocumentsJob.php
@@ -121,7 +121,11 @@ class CreateDocumentsJob implements ShouldQueue
                             $media = $file->attachToModel($item);
                         }
 
-                        if (! $media && $isDownload) {
+                        if (is_null($media) && $item instanceof HasMedia) {
+                            $media = $item->getMedia($layout)->last();
+                        }
+
+                        if (! $media && $isDownload && $file->pdf) {
                             $previewFiles[] = [
                                 'output' => $file->pdf->output(),
                                 'file_name' => Str::finish($file->getFileName(), '.pdf'),

--- a/src/View/Printing/PrintableView.php
+++ b/src/View/Printing/PrintableView.php
@@ -28,7 +28,7 @@ abstract class PrintableView extends Component
 
     private static ?string $layout = 'flux::layouts.printing';
 
-    public PDF $pdf;
+    public ?PDF $pdf = null;
 
     public bool $preview = false;
 
@@ -80,9 +80,11 @@ abstract class PrintableView extends Component
             return null;
         }
 
-        $resource = fopen('php://memory', 'rb+');
+        $resource = fopen('php://temp', 'rb+');
         fwrite($resource, $this->pdf->output());
         rewind($resource);
+
+        $this->pdf = null;
 
         $data = [
             'model_type' => $model->getMorphClass(),

--- a/src/View/Printing/PrintableView.php
+++ b/src/View/Printing/PrintableView.php
@@ -80,6 +80,10 @@ abstract class PrintableView extends Component
             return null;
         }
 
+        if (is_null($this->pdf)) {
+            return null;
+        }
+
         $resource = fopen('php://temp', 'rb+');
         fwrite($resource, $this->pdf->output());
         rewind($resource);


### PR DESCRIPTION
## Summary
- Use `php://temp` instead of `php://memory` in `attachToModel()` to avoid holding large PDFs entirely in RAM (spills to disk above 2MB)
- Null out the DomPDF object after writing output to stream, freeing memory before `UploadMedia` triggers `MediaHasBeenAddedEvent` listeners
- Make `$pdf` property nullable to support cleanup

## Summary by Sourcery

Prevent memory exhaustion when generating and attaching invoice PDFs with ZUGFeRD.

Bug Fixes:
- Stream generated PDFs via php://temp instead of php://memory to avoid holding large documents entirely in RAM.
- Release the DomPDF instance after writing the PDF to the stream to free memory before media upload event handling.

Enhancements:
- Allow the PrintableView PDF property to be nullable to support explicit cleanup after PDF generation.