### PR TITLE
Add tests for order position move and alternative flag preservation

### DIFF
--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -535,11 +535,7 @@ test('move position shifts sort numbers to avoid collision', function (): void {
 test('move position preserves is_alternative flag', function (): void {
     $orderPosition = $this->order->orderPositions->first();
 
-    DB::table('order_positions')
-        ->where('id', $orderPosition->getKey())
-        ->update(['is_alternative' => true]);
-
-    $orderPosition->refresh();
+    $orderPosition->update(['is_alternative' => true]);
     expect($orderPosition->is_alternative)->toBeTrue();
 
     Livewire::test(OrderPositions::class, ['order' => $this->orderForm])

--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -498,8 +498,8 @@ test('move position with parent', function (): void {
 });
 
 test('move position shifts sort numbers to avoid collision', function (): void {
-    $positions = OrderPosition::factory()->count(2)->create([
-        'order_id' => $this->order->id,
+    OrderPosition::factory()->count(2)->create([
+        'order_id' => $this->order->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'is_free_text' => false,
         'is_alternative' => false,

--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -497,6 +497,60 @@ test('move position with parent', function (): void {
     expect($updatedPosition->sort_number)->toEqual(1);
 });
 
+test('move position shifts sort numbers to avoid collision', function (): void {
+    $positions = OrderPosition::factory()->count(2)->create([
+        'order_id' => $this->order->id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $allPositions = $this->order->orderPositions()
+        ->whereNull('parent_id')
+        ->orderBy('sort_number')
+        ->get();
+
+    expect($allPositions)->toHaveCount(3);
+
+    $posA = $allPositions[0];
+    $posB = $allPositions[1];
+    $posC = $allPositions[2];
+
+    Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->call('movePosition', $posC, 1)
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $posA->refresh();
+    $posB->refresh();
+    $posC->refresh();
+
+    expect($posC->sort_number)->toEqual(1);
+
+    $sortNumbers = [$posA->sort_number, $posB->sort_number, $posC->sort_number];
+    sort($sortNumbers);
+    expect($sortNumbers)->toEqual([1, 2, 3]);
+});
+
+test('move position preserves is_alternative flag', function (): void {
+    $orderPosition = $this->order->orderPositions->first();
+
+    DB::table('order_positions')
+        ->where('id', $orderPosition->getKey())
+        ->update(['is_alternative' => true]);
+
+    $orderPosition->refresh();
+    expect($orderPosition->is_alternative)->toBeTrue();
+
+    Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->call('movePosition', $orderPosition, 2)
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $orderPosition->refresh();
+    expect($orderPosition->is_alternative)->toBeTrue();
+});
+
 test('quick add order position', function (): void {
     $orderPositionCount = $this->order->orderPositions()->count();
     $productPrice = $this->product->prices()->first();


### PR DESCRIPTION
## Summary
- Add test verifying sort number collision handling when moving positions within the same parent
- Add test verifying `is_alternative` flag is preserved after moving a position

These tests cover the fix for sort number collisions during position moves (already in main via SortableTrait) and confirm that the alternative flag is not affected by move operations.

## Summary by Sourcery

Add regression tests around moving order positions to ensure correct sort ordering and flag preservation.

Tests:
- Add a test verifying sort number reordering when moving a position to avoid collisions within the same parent.
- Add a test ensuring the is_alternative flag remains unchanged when an order position is moved.