### PR TITLE
Fix 15 bugs found by action test audit

### DIFF
--- a/src/Actions/Contact/UpdateContact.php
+++ b/src/Actions/Contact/UpdateContact.php
@@ -122,7 +122,7 @@ class UpdateContact extends FluxAction
             : resolve_static(Contact::class, 'query')
                 ->whereKey($this->getData('id'))
                 ->value('payment_type_id');
-        if ($paymentTypeId || $this->getData('tenants')) {
+        if ($paymentTypeId && ($paymentTypeId || $this->getData('tenants'))) {
             $tenants = $this->getData('tenants') ?? resolve_static(ContactTenant::class, 'query')
                 ->where('contact_id', $this->getData('id'))
                 ->pluck('tenant_id')
@@ -140,7 +140,7 @@ class UpdateContact extends FluxAction
                         __(
                             'Payment type with id: \':paymentTypeId\' doesnt match with the associated tenants',
                             [
-                                'paymentTypeId' => $this->getData('payment_type_id'),
+                                'paymentTypeId' => $paymentTypeId,
                             ]
                         ),
                     ],

--- a/src/Actions/FluxAction.php
+++ b/src/Actions/FluxAction.php
@@ -6,6 +6,7 @@ use FluxErp\Models\Permission;
 use FluxErp\Rulesets\FluxRuleset;
 use FluxErp\Traits\Action\HasActionEvents;
 use FluxErp\Traits\Action\SupportsApiRequests;
+use FluxErp\Traits\Action\SupportsTesting;
 use FluxErp\Traits\Makeable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -20,7 +21,7 @@ use Throwable;
 
 abstract class FluxAction
 {
-    use Conditionable, HasActionEvents, Makeable, SupportsApiRequests;
+    use Conditionable, HasActionEvents, Makeable, SupportsApiRequests, SupportsTesting;
 
     protected static bool $hasPermission = true;
 

--- a/src/Actions/WorkTime/UpdateWorkTime.php
+++ b/src/Actions/WorkTime/UpdateWorkTime.php
@@ -84,13 +84,14 @@ class UpdateWorkTime extends FluxAction
                 });
         }
 
-        if ($this->data['is_locked']) {
-            $workTime->total_time_ms =
-                bcsub(
+        if ($this->getData('is_locked')) {
+            $workTime->total_time_ms = $workTime->ended_at
+                ? bcsub(
                     $workTime->started_at->diffInMilliseconds($workTime->ended_at),
                     $workTime->paused_time_ms ?? 0,
                     0
-                );
+                )
+                : 0;
 
             if ($workTime->is_pause) {
                 $workTime->total_time_ms = bcmul($workTime->total_time_ms, -1, 0);

--- a/src/Traits/Action/SupportsTesting.php
+++ b/src/Traits/Action/SupportsTesting.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace FluxErp\Traits\Action;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Assert;
+
+trait SupportsTesting
+{
+    public static function testCreate(array $data): Model
+    {
+        return static::make($data)
+            ->checkPermission()
+            ->validate()
+            ->execute();
+    }
+
+    public static function assertValidationErrors(array $data, array|string $expectedKeys): void
+    {
+        $keys = Arr::wrap($expectedKeys);
+
+        try {
+            static::make($data)->validate();
+            Assert::fail('Expected ValidationException was not thrown');
+        } catch (ValidationException $e) {
+            $errorKeys = array_keys($e->errors());
+
+            foreach ($keys as $key) {
+                Assert::assertContains(
+                    $key,
+                    $errorKeys,
+                    "Expected validation error for '{$key}' but got: " . implode(', ', $errorKeys)
+                );
+            }
+        }
+    }
+
+    public static function assertValidationPasses(array $data): static
+    {
+        try {
+            $action = static::make($data)->validate();
+        } catch (ValidationException $e) {
+            Assert::fail('Validation failed unexpectedly: ' . json_encode($e->errors()));
+        }
+
+        Assert::assertTrue(true);
+
+        return $action;
+    }
+}

--- a/tests/Browser/Orders/OrdersTest.php
+++ b/tests/Browser/Orders/OrdersTest.php
@@ -30,14 +30,22 @@ test('can create new order', function (): void {
 
     $page = visit(route('orders.orders'))
         ->assertRoute('orders.orders')
-        ->assertNoSmoke()
-        ->assertSee('New order')
-        ->click('New order')
-        ->assertSee('Order type')
-        ->click($this->tsSelect('order.order_type_id'))
+        ->assertNoSmoke();
+
+    // Wait for Livewire to fully hydrate before clicking
+    $page->assertPresent('[tall-datatable]');
+
+    $page->click('New order');
+
+    // assertSee('Order type') would match the DataTable column header,
+    // so wait for the actual select element inside the modal instead
+    waitForElement($page, 'div[x-data*="order.order_type_id"] button[x-ref="button"]', 15000);
+
+    $page->click($this->tsSelect('order.order_type_id'))
         ->assertSee($orderType->name)
-        ->click($this->tsSelectOption($orderType->name))
-        ->click($this->tsSelect('order.contact_id'))
+        ->click($this->tsSelectOption($orderType->name));
+
+    $page->click($this->tsSelect('order.contact_id'))
         ->assertSee($address->name)
         ->click($this->tsSelectOption($address->name))
         ->assertNoSmoke()

--- a/tests/Feature/Actions/AbsencePolicy/AbsencePolicyActionTest.php
+++ b/tests/Feature/Actions/AbsencePolicy/AbsencePolicyActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\AbsencePolicy\CreateAbsencePolicy;
+use FluxErp\Actions\AbsencePolicy\DeleteAbsencePolicy;
+use FluxErp\Actions\AbsencePolicy\UpdateAbsencePolicy;
+
+test('create absence policy', function (): void {
+    $policy = CreateAbsencePolicy::make(['name' => 'Standard Policy'])
+        ->validate()->execute();
+
+    expect($policy)->name->toBe('Standard Policy');
+});
+
+test('create absence policy requires name', function (): void {
+    CreateAbsencePolicy::assertValidationErrors([], 'name');
+});
+
+test('update absence policy', function (): void {
+    $policy = CreateAbsencePolicy::make(['name' => 'Original'])
+        ->validate()->execute();
+
+    $updated = UpdateAbsencePolicy::make([
+        'id' => $policy->getKey(),
+        'name' => 'Updated Policy',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Policy');
+});
+
+test('delete absence policy', function (): void {
+    $policy = CreateAbsencePolicy::make(['name' => 'Temp'])
+        ->validate()->execute();
+
+    expect(DeleteAbsencePolicy::make(['id' => $policy->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/AbsenceRequest/AbsenceRequestActionTest.php
+++ b/tests/Feature/Actions/AbsenceRequest/AbsenceRequestActionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use FluxErp\Actions\AbsenceRequest\CreateAbsenceRequest;
+use FluxErp\Actions\AbsenceRequest\DeleteAbsenceRequest;
+use FluxErp\Actions\AbsenceType\CreateAbsenceType;
+use FluxErp\Actions\Employee\CreateEmployee;
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+
+beforeEach(function (): void {
+    $wtm = CreateWorkTimeModel::make([
+        'name' => 'Standard',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    $this->employee = CreateEmployee::make([
+        'firstname' => 'John',
+        'lastname' => 'Doe',
+        'employment_date' => '2025-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $wtm->getKey(),
+    ])->validate()->execute();
+
+    $this->absenceType = CreateAbsenceType::make([
+        'name' => 'Vacation',
+        'code' => 'VAC',
+        'color' => '#00FF00',
+        'percentage_deduction' => 1.0,
+        'employee_can_create' => 'yes',
+        'affects_vacation' => true,
+        'affects_overtime' => false,
+        'affects_sick_leave' => false,
+    ])->validate()->execute();
+});
+
+test('create absence request', function (): void {
+    $request = CreateAbsenceRequest::make([
+        'absence_type_id' => $this->absenceType->getKey(),
+        'employee_id' => $this->employee->getKey(),
+        'day_part' => 'full_day',
+        'start_date' => '2026-07-01',
+        'end_date' => '2026-07-05',
+        'state' => 'pending',
+    ])->validate()->execute();
+
+    expect($request)
+        ->employee_id->toBe($this->employee->getKey())
+        ->absence_type_id->toBe($this->absenceType->getKey());
+});
+
+test('create absence request requires absence_type employee day_part dates', function (): void {
+    CreateAbsenceRequest::assertValidationErrors([], [
+        'absence_type_id', 'employee_id', 'day_part', 'start_date', 'end_date',
+    ]);
+});
+
+test('delete absence request', function (): void {
+    $request = CreateAbsenceRequest::make([
+        'absence_type_id' => $this->absenceType->getKey(),
+        'employee_id' => $this->employee->getKey(),
+        'day_part' => 'full_day',
+        'start_date' => '2026-08-01',
+        'end_date' => '2026-08-01',
+        'state' => 'pending',
+    ])->validate()->execute();
+
+    expect(DeleteAbsenceRequest::make(['id' => $request->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/AbsenceType/AbsenceTypeActionTest.php
+++ b/tests/Feature/Actions/AbsenceType/AbsenceTypeActionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use FluxErp\Actions\AbsenceType\CreateAbsenceType;
+use FluxErp\Actions\AbsenceType\DeleteAbsenceType;
+use FluxErp\Actions\AbsenceType\UpdateAbsenceType;
+
+test('create absence type', function (): void {
+    $type = CreateAbsenceType::make([
+        'name' => 'Vacation',
+        'code' => 'VAC',
+        'color' => '#00FF00',
+        'percentage_deduction' => 1.0,
+        'employee_can_create' => 'yes',
+        'affects_vacation' => true,
+        'affects_overtime' => false,
+        'affects_sick_leave' => false,
+    ])->validate()->execute();
+
+    expect($type)->name->toBe('Vacation');
+});
+
+test('create absence type requires name code color', function (): void {
+    CreateAbsenceType::assertValidationErrors([], ['name', 'code', 'color']);
+});
+
+test('update absence type', function (): void {
+    $type = CreateAbsenceType::make([
+        'name' => 'Sick',
+        'code' => 'SCK',
+        'color' => '#FF0000',
+        'percentage_deduction' => 1.0,
+        'employee_can_create' => 'no',
+        'affects_sick_leave' => true,
+        'affects_overtime' => false,
+        'affects_vacation' => false,
+    ])->validate()->execute();
+
+    $updated = UpdateAbsenceType::make([
+        'id' => $type->getKey(),
+        'name' => 'Sick Leave',
+        'employee_can_create' => 'no',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Sick Leave');
+});
+
+test('delete absence type', function (): void {
+    $type = CreateAbsenceType::make([
+        'name' => 'Temp',
+        'code' => 'TMP',
+        'color' => '#999999',
+        'percentage_deduction' => 0.5,
+        'employee_can_create' => 'yes',
+    ])->validate()->execute();
+
+    expect(DeleteAbsenceType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Address/AddressActionTest.php
+++ b/tests/Feature/Actions/Address/AddressActionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use FluxErp\Actions\Address\CreateAddress;
+use FluxErp\Actions\Address\DeleteAddress;
+use FluxErp\Actions\Address\UpdateAddress;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+});
+
+test('create address', function (): void {
+    $address = CreateAddress::make([
+        'contact_id' => $this->contact->getKey(),
+        'company' => 'Test GmbH',
+        'street' => 'Main Street 1',
+        'city' => 'Berlin',
+        'zip' => '10115',
+    ])->validate()->execute();
+
+    expect($address)
+        ->toBeInstanceOf(Address::class)
+        ->company->toBe('Test GmbH')
+        ->contact_id->toBe($this->contact->getKey());
+});
+
+test('first address becomes main address automatically', function (): void {
+    $address = CreateAddress::make([
+        'contact_id' => $this->contact->getKey(),
+        'company' => 'First Address',
+    ])->validate()->execute();
+
+    expect($address)
+        ->is_main_address->toBeTrue()
+        ->is_invoice_address->toBeTrue()
+        ->is_delivery_address->toBeTrue();
+});
+
+test('second address does not override main address flags', function (): void {
+    Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+        'is_delivery_address' => true,
+    ]);
+
+    $second = CreateAddress::make([
+        'contact_id' => $this->contact->getKey(),
+        'company' => 'Second Address',
+    ])->validate()->execute();
+
+    expect($second)
+        ->is_main_address->toBeFalse()
+        ->is_invoice_address->toBeFalse()
+        ->is_delivery_address->toBeFalse();
+});
+
+test('create address requires contact_id', function (): void {
+    CreateAddress::assertValidationErrors(
+        ['company' => 'Test'],
+        'contact_id'
+    );
+});
+
+test('create address strips email angle brackets', function (): void {
+    $address = CreateAddress::make([
+        'contact_id' => $this->contact->getKey(),
+        'email' => 'John Doe <john@example.com>',
+    ])->validate()->execute();
+
+    expect($address->email)->toBe('john@example.com');
+});
+
+test('update address', function (): void {
+    $address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+    ]);
+
+    $updated = UpdateAddress::make([
+        'id' => $address->getKey(),
+        'company' => 'Updated Corp',
+    ])->validate()->execute();
+
+    expect($updated->company)->toBe('Updated Corp');
+});
+
+test('delete address', function (): void {
+    $address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+    ]);
+
+    $result = DeleteAddress::make(['id' => $address->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/AddressType/AddressTypeActionTest.php
+++ b/tests/Feature/Actions/AddressType/AddressTypeActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\AddressType\CreateAddressType;
+use FluxErp\Actions\AddressType\DeleteAddressType;
+use FluxErp\Actions\AddressType\UpdateAddressType;
+use FluxErp\Models\AddressType;
+
+test('create address type', function (): void {
+    $type = CreateAddressType::make(['name' => 'Lieferadresse'])
+        ->validate()->execute();
+
+    expect($type)->toBeInstanceOf(AddressType::class)
+        ->name->toBe('Lieferadresse');
+});
+
+test('create address type requires name', function (): void {
+    CreateAddressType::assertValidationErrors([], 'name');
+});
+
+test('update address type', function (): void {
+    $type = AddressType::factory()->create();
+
+    $updated = UpdateAddressType::make([
+        'id' => $type->getKey(),
+        'name' => 'Rechnungsadresse',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Rechnungsadresse');
+});
+
+test('delete address type', function (): void {
+    $type = AddressType::factory()->create();
+
+    expect(DeleteAddressType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/AttributeTranslation/AttributeTranslationActionTest.php
+++ b/tests/Feature/Actions/AttributeTranslation/AttributeTranslationActionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use FluxErp\Actions\AttributeTranslation\DeleteAttributeTranslation;
+use FluxErp\Actions\AttributeTranslation\UpsertAttributeTranslation;
+use FluxErp\Models\Product;
+
+beforeEach(function (): void {
+    $this->product = Product::factory()->create();
+});
+
+test('upsert creates new attribute translation', function (): void {
+    $translation = UpsertAttributeTranslation::make([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $this->product->getKey(),
+        'attribute' => 'name',
+        'value' => 'Translated Name',
+    ])->validate()->execute();
+
+    expect($translation->value)->toBe('Translated Name');
+});
+
+test('upsert updates existing attribute translation', function (): void {
+    $first = UpsertAttributeTranslation::make([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $this->product->getKey(),
+        'attribute' => 'name',
+        'value' => 'First',
+    ])->validate()->execute();
+
+    $updated = UpsertAttributeTranslation::make([
+        'id' => $first->getKey(),
+        'value' => 'Updated',
+    ])->validate()->execute();
+
+    expect($updated->value)->toBe('Updated');
+});
+
+test('delete attribute translation', function (): void {
+    $translation = UpsertAttributeTranslation::make([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $this->product->getKey(),
+        'attribute' => 'description',
+        'value' => 'To delete',
+    ])->validate()->execute();
+
+    expect(DeleteAttributeTranslation::make(['id' => $translation->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/BankConnection/BankConnectionActionTest.php
+++ b/tests/Feature/Actions/BankConnection/BankConnectionActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\BankConnection\CreateBankConnection;
+use FluxErp\Actions\BankConnection\DeleteBankConnection;
+use FluxErp\Actions\BankConnection\UpdateBankConnection;
+use FluxErp\Models\BankConnection;
+
+test('create bank connection', function (): void {
+    $conn = CreateBankConnection::make(['name' => 'Business Account'])
+        ->validate()->execute();
+
+    expect($conn)->toBeInstanceOf(BankConnection::class)
+        ->name->toBe('Business Account');
+});
+
+test('create bank connection requires name', function (): void {
+    CreateBankConnection::assertValidationErrors([], 'name');
+});
+
+test('update bank connection', function (): void {
+    $conn = BankConnection::factory()->create();
+
+    $updated = UpdateBankConnection::make([
+        'id' => $conn->getKey(),
+        'name' => 'Savings Account',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Savings Account');
+});
+
+test('delete bank connection', function (): void {
+    $conn = BankConnection::factory()->create();
+
+    expect(DeleteBankConnection::make(['id' => $conn->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/BugCandidatesTest.php
+++ b/tests/Feature/Actions/BugCandidatesTest.php
@@ -1,95 +1,37 @@
 <?php
 
-use FluxErp\Actions\Task\CreateTask;
-use FluxErp\Models\Task;
+use FluxErp\Actions\Contact\UpdateContact;
+use FluxErp\Actions\WorkTime\CreateWorkTime;
+use FluxErp\Actions\WorkTime\UpdateWorkTime;
+use FluxErp\Models\Contact;
 
-// --- CreateTask ---
+// --- VERIFIED BUG: UpdateContact null payment_type + tenant change ---
 
-test('create task same-day with reversed times passes validation incorrectly', function (): void {
-    // BUG: CreateTask::validateData uses hardcoded 00:00:00 for start_time and 23:59:59 for due_time
-    // when times are not provided. This means a task with start_date=2026-04-01 and due_date=2026-04-01
-    // always passes, even if the actual start_time > due_time on the same day.
-    $task = CreateTask::make([
-        'name' => 'Same day reversed times',
-        'start_date' => '2026-04-01',
-        'start_time' => '18:00:00',
-        'due_date' => '2026-04-01',
-        'due_time' => '09:00:00',
+test('update contact tenant change with null payment_type does not fail', function (): void {
+    $contact = Contact::factory()->create(['payment_type_id' => null]);
+
+    $updated = UpdateContact::make([
+        'id' => $contact->getKey(),
+        'tenants' => [$this->dbTenant->getKey()],
     ])->validate()->execute();
 
-    expect($task)->toBeInstanceOf(Task::class);
-})->skip('Potential bug: same-day time validation ignores actual start_time/due_time');
+    expect($updated)->not->toBeNull();
+});
 
-// --- CreateAddress ---
+// --- VERIFIED BUG: UpdateWorkTime is_locked undefined key ---
 
-test('create address with malformed email angle brackets clears email silently', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: Str::between with < but no > returns empty string, silently clearing email');
+test('update work time without is_locked does not crash', function (): void {
+    $wt = CreateWorkTime::make([
+        'user_id' => $this->user->getKey(),
+        'name' => 'Test',
+        'started_at' => '2026-04-05 09:00:00',
+        'ended_at' => '2026-04-05 17:00:00',
+    ])->validate()->execute();
 
-// --- UpdateContact ---
+    $updated = UpdateWorkTime::make([
+        'id' => $wt->getKey(),
+        'description' => 'Updated without is_locked',
+    ])->validate()->execute();
 
-test('update contact error message uses wrong variable for payment_type_id', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: UpdateContact::validateData line ~143 uses getData instead of resolved $paymentTypeId');
-
-test('update contact tenant change with null payment_type always fails validation', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: null payment_type_id + tenant change triggers false validation error');
-
-// --- CreateOrder ---
-
-test('create order hardcodes 19% vat for shipping costs', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: CreateOrder line 41 hardcodes 0.19 shipping VAT regardless of actual rate');
-
-test('create order null contact causes runtime error on delivery_address_id', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: CreateOrder accesses $contact->delivery_address_id before null guard');
-
-test('create order keyBy address_id destroys address_type_id pivot data', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: keyBy(address_id) after unique() drops duplicate address_id with different address_type_id');
-
-// --- CreateOrderPosition ---
-
-test('create order position unconditionally overwrites vat_rate_id from order', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: uses = instead of ??= for vat_rate_id, ignoring caller-supplied value');
-
-test('create order position null contact on purchase order causes runtime error', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: $order->contact->expense_ledger_account_id crashes when contact_id is null');
-
-// --- UpdateAddress ---
-
-test('update address flag queries include current record causing flag loss', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: is_main/invoice/delivery_address checks dont exclude the current address');
-
-test('update address can_login validation skipped when can_login absent from payload', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: omitting can_login from payload bypasses email/password clearing protection');
-
-test('update address contact_id direct key access in address_types block', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: $this->data[contact_id] without ?? in address_types unique constraint');
-
-// --- UpdateWorkTime ---
-
-test('update work time is_locked direct array access without fallback', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: $this->data[is_locked] throws Undefined array key when is_locked not in payload');
-
-test('update work time locking with null ended_at crashes', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: started_at->diffInMilliseconds(null) when ended_at not set on model');
-
-test('update work time paused_time_ms uses now() instead of new ended_at', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: paused time delta calculated against now() not the requested ended_at');
-
-// --- UpdateProduct ---
-
-test('update product group bundle prices input silently deleted', function (): void {
-    $this->markTestSkipped('Needs fix');
-})->skip('Bug: prices created from input then immediately deleted by Group bundle block');
+    expect($updated->description)->toBe('Updated without is_locked');
+});

--- a/tests/Feature/Actions/BugCandidatesTest.php
+++ b/tests/Feature/Actions/BugCandidatesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use FluxErp\Actions\Task\CreateTask;
+use FluxErp\Models\Task;
+
+// --- CreateTask ---
+
+test('create task same-day with reversed times passes validation incorrectly', function (): void {
+    // BUG: CreateTask::validateData uses hardcoded 00:00:00 for start_time and 23:59:59 for due_time
+    // when times are not provided. This means a task with start_date=2026-04-01 and due_date=2026-04-01
+    // always passes, even if the actual start_time > due_time on the same day.
+    $task = CreateTask::make([
+        'name' => 'Same day reversed times',
+        'start_date' => '2026-04-01',
+        'start_time' => '18:00:00',
+        'due_date' => '2026-04-01',
+        'due_time' => '09:00:00',
+    ])->validate()->execute();
+
+    expect($task)->toBeInstanceOf(Task::class);
+})->skip('Potential bug: same-day time validation ignores actual start_time/due_time');
+
+// --- CreateAddress ---
+
+test('create address with malformed email angle brackets clears email silently', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: Str::between with < but no > returns empty string, silently clearing email');
+
+// --- UpdateContact ---
+
+test('update contact error message uses wrong variable for payment_type_id', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: UpdateContact::validateData line ~143 uses getData instead of resolved $paymentTypeId');
+
+test('update contact tenant change with null payment_type always fails validation', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: null payment_type_id + tenant change triggers false validation error');
+
+// --- CreateOrder ---
+
+test('create order hardcodes 19% vat for shipping costs', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: CreateOrder line 41 hardcodes 0.19 shipping VAT regardless of actual rate');
+
+test('create order null contact causes runtime error on delivery_address_id', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: CreateOrder accesses $contact->delivery_address_id before null guard');
+
+test('create order keyBy address_id destroys address_type_id pivot data', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: keyBy(address_id) after unique() drops duplicate address_id with different address_type_id');
+
+// --- CreateOrderPosition ---
+
+test('create order position unconditionally overwrites vat_rate_id from order', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: uses = instead of ??= for vat_rate_id, ignoring caller-supplied value');
+
+test('create order position null contact on purchase order causes runtime error', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: $order->contact->expense_ledger_account_id crashes when contact_id is null');
+
+// --- UpdateAddress ---
+
+test('update address flag queries include current record causing flag loss', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: is_main/invoice/delivery_address checks dont exclude the current address');
+
+test('update address can_login validation skipped when can_login absent from payload', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: omitting can_login from payload bypasses email/password clearing protection');
+
+test('update address contact_id direct key access in address_types block', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: $this->data[contact_id] without ?? in address_types unique constraint');
+
+// --- UpdateWorkTime ---
+
+test('update work time is_locked direct array access without fallback', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: $this->data[is_locked] throws Undefined array key when is_locked not in payload');
+
+test('update work time locking with null ended_at crashes', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: started_at->diffInMilliseconds(null) when ended_at not set on model');
+
+test('update work time paused_time_ms uses now() instead of new ended_at', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: paused time delta calculated against now() not the requested ended_at');
+
+// --- UpdateProduct ---
+
+test('update product group bundle prices input silently deleted', function (): void {
+    $this->markTestSkipped('Needs fix');
+})->skip('Bug: prices created from input then immediately deleted by Group bundle block');

--- a/tests/Feature/Actions/Calendar/CalendarActionTest.php
+++ b/tests/Feature/Actions/Calendar/CalendarActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use FluxErp\Actions\Calendar\CreateCalendar;
+use FluxErp\Actions\Calendar\DeleteCalendar;
+use FluxErp\Actions\Calendar\UpdateCalendar;
+use FluxErp\Models\Calendar;
+
+test('create calendar', function (): void {
+    $calendar = CreateCalendar::make([
+        'name' => 'Team Calendar',
+        'user_id' => $this->user->getKey(),
+    ])->validate()->execute();
+
+    expect($calendar)->toBeInstanceOf(Calendar::class)
+        ->name->toBe('Team Calendar');
+});
+
+test('create calendar requires name', function (): void {
+    CreateCalendar::assertValidationErrors([], 'name');
+});
+
+test('update calendar', function (): void {
+    $calendar = Calendar::factory()->create();
+
+    $updated = UpdateCalendar::make([
+        'id' => $calendar->getKey(),
+        'name' => 'Personal Calendar',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Personal Calendar');
+});
+
+test('delete calendar', function (): void {
+    $calendar = Calendar::factory()->create();
+
+    expect(DeleteCalendar::make(['id' => $calendar->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/CalendarEvent/CalendarEventActionTest.php
+++ b/tests/Feature/Actions/CalendarEvent/CalendarEventActionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use FluxErp\Actions\CalendarEvent\CreateCalendarEvent;
+use FluxErp\Models\Calendar;
+use FluxErp\Models\CalendarEvent;
+
+beforeEach(function (): void {
+    $this->calendar = Calendar::factory()->create();
+});
+
+test('create calendar event', function (): void {
+    $event = CreateCalendarEvent::make([
+        'calendar_id' => $this->calendar->getKey(),
+        'title' => 'Team Meeting',
+        'start' => '2026-04-10 09:00:00',
+        'end' => '2026-04-10 10:00:00',
+    ])->validate()->execute();
+
+    expect($event)->toBeInstanceOf(CalendarEvent::class)
+        ->title->toBe('Team Meeting');
+});
+
+test('create calendar event requires calendar_id title start end', function (): void {
+    CreateCalendarEvent::assertValidationErrors([], ['calendar_id', 'title', 'start', 'end']);
+});
+
+test('create calendar event end must be after start', function (): void {
+    CreateCalendarEvent::assertValidationErrors([
+        'calendar_id' => $this->calendar->getKey(),
+        'title' => 'Invalid',
+        'start' => '2026-04-10 10:00:00',
+        'end' => '2026-04-10 09:00:00',
+    ], 'end');
+});

--- a/tests/Feature/Actions/Cart/CartActionTest.php
+++ b/tests/Feature/Actions/Cart/CartActionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use FluxErp\Actions\Cart\CreateCart;
+use FluxErp\Actions\Cart\DeleteCart;
+use FluxErp\Actions\Cart\UpdateCart;
+use FluxErp\Models\Cart;
+use FluxErp\Models\PriceList;
+
+test('create cart', function (): void {
+    $cart = CreateCart::make([
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect($cart)->toBeInstanceOf(Cart::class);
+});
+
+test('update cart', function (): void {
+    $cart = CreateCart::make([
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    $updated = UpdateCart::make([
+        'id' => $cart->getKey(),
+        'name' => 'My Wishlist',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('My Wishlist');
+});
+
+test('delete cart', function (): void {
+    $cart = CreateCart::make([
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect(DeleteCart::make(['id' => $cart->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/CartItem/CartItemActionTest.php
+++ b/tests/Feature/Actions/CartItem/CartItemActionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use FluxErp\Actions\Cart\CreateCart;
+use FluxErp\Actions\CartItem\CreateCartItem;
+use FluxErp\Actions\CartItem\DeleteCartItem;
+use FluxErp\Actions\CartItem\UpdateCartItem;
+use FluxErp\Models\CartItem;
+use FluxErp\Models\PriceList;
+
+beforeEach(function (): void {
+    $this->cart = CreateCart::make([
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+    ])->validate()->execute();
+});
+
+test('create cart item', function (): void {
+    $item = CreateCartItem::make([
+        'cart_id' => $this->cart->getKey(),
+        'name' => 'Widget',
+        'price' => 29.99,
+        'vat_rate_id' => FluxErp\Models\VatRate::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect($item)->toBeInstanceOf(CartItem::class)
+        ->name->toBe('Widget');
+});
+
+test('create cart item requires cart_id and price', function (): void {
+    CreateCartItem::assertValidationErrors([], ['cart_id', 'price']);
+});
+
+test('update cart item', function (): void {
+    $item = CreateCartItem::make([
+        'cart_id' => $this->cart->getKey(),
+        'name' => 'Original',
+        'price' => 10.00,
+        'vat_rate_id' => FluxErp\Models\VatRate::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    $updated = UpdateCartItem::make([
+        'id' => $item->getKey(),
+        'amount' => 5,
+    ])->validate()->execute();
+
+    expect($updated)->not->toBeNull();
+});
+
+test('delete cart item', function (): void {
+    $item = CreateCartItem::make([
+        'cart_id' => $this->cart->getKey(),
+        'name' => 'Temp',
+        'price' => 5.00,
+        'vat_rate_id' => FluxErp\Models\VatRate::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect(DeleteCartItem::make(['id' => $item->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Category/CategoryActionTest.php
+++ b/tests/Feature/Actions/Category/CategoryActionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use FluxErp\Actions\Category\CreateCategory;
+use FluxErp\Actions\Category\DeleteCategory;
+use FluxErp\Actions\Category\UpdateCategory;
+use FluxErp\Models\Category;
+
+test('create category', function (): void {
+    $category = CreateCategory::make([
+        'name' => 'Electronics',
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+        'sort_number' => 1,
+    ])->validate()->execute();
+
+    expect($category)->toBeInstanceOf(Category::class)
+        ->name->toBe('Electronics');
+});
+
+test('create category requires name and model_type', function (): void {
+    CreateCategory::assertValidationErrors([], ['name', 'model_type']);
+});
+
+test('create category with parent', function (): void {
+    $parent = Category::factory()->create([
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+    ]);
+
+    $child = CreateCategory::make([
+        'name' => 'Laptops',
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+        'parent_id' => $parent->getKey(),
+    ])->validate()->execute();
+
+    expect($child->parent_id)->toBe($parent->getKey());
+});
+
+test('create category without sort_number succeeds', function (): void {
+    $category = CreateCategory::make([
+        'name' => 'Auto',
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+    ])->validate()->execute();
+
+    expect($category->sort_number)->toBeGreaterThanOrEqual(0);
+});
+
+test('update category', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+    ]);
+
+    $updated = UpdateCategory::make([
+        'id' => $category->getKey(),
+        'name' => 'Office Supplies',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Office Supplies');
+});
+
+test('delete category', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(FluxErp\Models\Product::class),
+    ]);
+
+    expect(DeleteCategory::make(['id' => $category->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Comment/CommentActionTest.php
+++ b/tests/Feature/Actions/Comment/CommentActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use FluxErp\Actions\Comment\CreateComment;
+use FluxErp\Actions\Comment\DeleteComment;
+use FluxErp\Actions\Comment\UpdateComment;
+use FluxErp\Models\Task;
+
+beforeEach(function (): void {
+    $this->task = Task::factory()->create();
+});
+
+test('create comment', function (): void {
+    $comment = CreateComment::make([
+        'model_type' => morph_alias(Task::class),
+        'model_id' => $this->task->getKey(),
+        'comment' => 'This is a test comment',
+    ])->validate()->execute();
+
+    expect($comment)
+        ->comment->toContain('test comment')
+        ->is_internal->toBeTruthy();
+});
+
+test('create comment defaults to internal', function (): void {
+    $comment = CreateComment::make([
+        'model_type' => morph_alias(Task::class),
+        'model_id' => $this->task->getKey(),
+        'comment' => 'Internal note',
+    ])->validate()->execute();
+
+    expect($comment->is_internal)->toBeTruthy();
+});
+
+test('create comment requires model_type model_id and comment', function (): void {
+    CreateComment::assertValidationErrors([], ['model_type', 'model_id', 'comment']);
+});
+
+test('update comment', function (): void {
+    $comment = CreateComment::make([
+        'model_type' => morph_alias(Task::class),
+        'model_id' => $this->task->getKey(),
+        'comment' => 'Original',
+        'is_internal' => true,
+        'is_sticky' => false,
+    ])->validate()->execute();
+
+    $updated = UpdateComment::make([
+        'id' => $comment->getKey(),
+        'comment' => 'Updated comment',
+        'is_internal' => true,
+        'is_sticky' => false,
+    ])->validate()->execute();
+
+    expect($updated->comment)->not->toBeNull();
+});
+
+test('delete comment', function (): void {
+    $comment = CreateComment::make([
+        'model_type' => morph_alias(Task::class),
+        'model_id' => $this->task->getKey(),
+        'comment' => 'To delete',
+        'is_internal' => true,
+        'is_sticky' => false,
+    ])->validate()->execute();
+
+    expect(DeleteComment::make(['id' => $comment->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Commission/CommissionActionTest.php
+++ b/tests/Feature/Actions/Commission/CommissionActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use FluxErp\Actions\Commission\CreateCommission;
+use FluxErp\Actions\Commission\DeleteCommission;
+use FluxErp\Actions\Commission\UpdateCommission;
+use FluxErp\Models\Commission;
+
+test('create commission with inline rate', function (): void {
+    $commission = CreateCommission::make([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => 0.05,
+        'total_net_price' => 1000.00,
+    ])->validate()->execute();
+
+    expect($commission)->toBeInstanceOf(Commission::class);
+});
+
+test('create commission requires user_id', function (): void {
+    CreateCommission::assertValidationErrors([
+        'commission_rate' => 0.05,
+        'total_net_price' => 500,
+    ], 'user_id');
+});
+
+test('update commission', function (): void {
+    $commission = CreateCommission::make([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => 0.05,
+        'total_net_price' => 1000.00,
+    ])->validate()->execute();
+
+    $updated = UpdateCommission::make([
+        'id' => $commission->getKey(),
+        'commission' => $commission->commission,
+    ])->validate()->execute();
+
+    expect($updated)->not->toBeNull();
+});
+
+test('delete commission', function (): void {
+    $commission = CreateCommission::make([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => 0.10,
+        'total_net_price' => 500.00,
+    ])->validate()->execute();
+
+    expect(DeleteCommission::make(['id' => $commission->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/CommissionRate/CommissionRateActionTest.php
+++ b/tests/Feature/Actions/CommissionRate/CommissionRateActionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use FluxErp\Actions\CommissionRate\CreateCommissionRate;
+use FluxErp\Actions\CommissionRate\DeleteCommissionRate;
+use FluxErp\Actions\CommissionRate\UpdateCommissionRate;
+use FluxErp\Models\CommissionRate;
+
+test('create commission rate', function (): void {
+    $rate = CreateCommissionRate::make([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => 0.05,
+    ])->validate()->execute();
+
+    expect($rate)->toBeInstanceOf(CommissionRate::class);
+});
+
+test('create commission rate requires user_id and rate', function (): void {
+    CreateCommissionRate::assertValidationErrors([], ['user_id', 'commission_rate']);
+});
+
+test('update commission rate', function (): void {
+    $rate = CommissionRate::factory()->create([
+        'user_id' => $this->user->getKey(),
+    ]);
+
+    $updated = UpdateCommissionRate::make([
+        'id' => $rate->getKey(),
+        'commission_rate' => 0.10,
+    ])->validate()->execute();
+
+    expect($updated->commission_rate)->toEqual(0.10);
+});
+
+test('delete commission rate', function (): void {
+    $rate = CommissionRate::factory()->create([
+        'user_id' => $this->user->getKey(),
+    ]);
+
+    expect(DeleteCommissionRate::make(['id' => $rate->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Communication/CommunicationActionTest.php
+++ b/tests/Feature/Actions/Communication/CommunicationActionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use FluxErp\Actions\Communication\CreateCommunication;
+use FluxErp\Actions\Communication\DeleteCommunication;
+use FluxErp\Actions\Communication\UpdateCommunication;
+use FluxErp\Models\Communication;
+
+test('create communication', function (): void {
+    $comm = CreateCommunication::make([
+        'communication_type_enum' => 'phone-call',
+    ])->validate()->execute();
+
+    expect($comm)->toBeInstanceOf(Communication::class);
+});
+
+test('update communication', function (): void {
+    $comm = Communication::factory()->create();
+
+    $updated = UpdateCommunication::make([
+        'id' => $comm->getKey(),
+        'subject' => 'Follow-up call',
+    ])->validate()->execute();
+
+    expect($updated->subject)->toBe('Follow-up call');
+});
+
+test('delete communication', function (): void {
+    $comm = Communication::factory()->create();
+
+    expect(DeleteCommunication::make(['id' => $comm->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Console/ConsoleActionTest.php
+++ b/tests/Feature/Actions/Console/ConsoleActionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use FluxErp\Actions\Console\RunCommand;
+
+test('run command requires command', function (): void {
+    RunCommand::assertValidationErrors([], 'command');
+});
+
+test('run command rejects nonexistent class', function (): void {
+    RunCommand::assertValidationErrors([
+        'command' => 'NonExistent\\Command\\Class',
+    ], 'command');
+});

--- a/tests/Feature/Actions/Contact/ContactActionTest.php
+++ b/tests/Feature/Actions/Contact/ContactActionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use FluxErp\Actions\Contact\CreateContact;
+use FluxErp\Actions\Contact\DeleteContact;
+use FluxErp\Actions\Contact\UpdateContact;
+use FluxErp\Models\Contact;
+use FluxErp\Models\PaymentType;
+
+test('create contact with defaults', function (): void {
+    $contact = CreateContact::make([])
+        ->validate()->execute();
+
+    expect($contact)
+        ->toBeInstanceOf(Contact::class)
+        ->customer_number->not->toBeNull()
+        ->payment_type_id->not->toBeNull()
+        ->price_list_id->not->toBeNull();
+});
+
+test('create contact with main address', function (): void {
+    $contact = CreateContact::make([
+        'main_address' => [
+            'company' => 'Test Corp',
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+        ],
+    ])->validate()->execute();
+
+    expect($contact->mainAddress)
+        ->not->toBeNull()
+        ->company->toBe('Test Corp');
+});
+
+test('create contact with tenant attachment', function (): void {
+    $contact = CreateContact::make([
+        'tenants' => [$this->dbTenant->getKey()],
+    ])->validate()->execute();
+
+    expect($contact->tenants)->toHaveCount(1);
+});
+
+test('create contact validates payment_type for tenant', function (): void {
+    $otherTenant = FluxErp\Models\Tenant::factory()->create();
+    $paymentType = PaymentType::factory()
+        ->hasAttached($otherTenant, relationship: 'tenants')
+        ->create();
+
+    CreateContact::assertValidationErrors([
+        'payment_type_id' => $paymentType->getKey(),
+        'tenants' => [$this->dbTenant->getKey()],
+    ], 'payment_type_id');
+});
+
+test('update contact', function (): void {
+    $contact = Contact::factory()->create();
+
+    $updated = UpdateContact::make([
+        'id' => $contact->getKey(),
+        'customer_number' => 'K-99999',
+    ])->validate()->execute();
+
+    expect($updated->customer_number)->toBe('K-99999');
+});
+
+test('update contact rejects duplicate customer_number', function (): void {
+    $contact1 = Contact::factory()->create(['customer_number' => 'K-11111']);
+    $contact2 = Contact::factory()->create();
+
+    UpdateContact::assertValidationErrors([
+        'id' => $contact2->getKey(),
+        'customer_number' => 'K-11111',
+    ], 'customer_number');
+});
+
+test('delete contact', function (): void {
+    $contact = Contact::factory()->create();
+
+    $result = DeleteContact::make(['id' => $contact->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+    expect(Contact::query()->whereKey($contact->getKey())->exists())->toBeFalse();
+});

--- a/tests/Feature/Actions/ContactBankConnection/ContactBankConnectionActionTest.php
+++ b/tests/Feature/Actions/ContactBankConnection/ContactBankConnectionActionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use FluxErp\Actions\ContactBankConnection\CreateContactBankConnection;
+use FluxErp\Actions\ContactBankConnection\DeleteContactBankConnection;
+use FluxErp\Actions\ContactBankConnection\UpdateContactBankConnection;
+use FluxErp\Models\Contact;
+use FluxErp\Models\ContactBankConnection;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+});
+
+test('create contact bank connection with iban', function (): void {
+    $conn = CreateContactBankConnection::make([
+        'contact_id' => $this->contact->getKey(),
+        'iban' => 'DE89370400440532013000',
+    ])->validate()->execute();
+
+    expect($conn)->toBeInstanceOf(ContactBankConnection::class)
+        ->iban->toBe('DE89370400440532013000');
+});
+
+test('update contact bank connection', function (): void {
+    $conn = ContactBankConnection::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+    ]);
+
+    $updated = UpdateContactBankConnection::make([
+        'id' => $conn->getKey(),
+        'account_holder' => 'John Doe',
+    ])->validate()->execute();
+
+    expect($updated->account_holder)->toBe('John Doe');
+});
+
+test('delete contact bank connection', function (): void {
+    $conn = ContactBankConnection::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+    ]);
+
+    expect(DeleteContactBankConnection::make(['id' => $conn->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/ContactOption/ContactOptionActionTest.php
+++ b/tests/Feature/Actions/ContactOption/ContactOptionActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use FluxErp\Actions\ContactOption\CreateContactOption;
+use FluxErp\Actions\ContactOption\DeleteContactOption;
+use FluxErp\Actions\ContactOption\UpdateContactOption;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create(['contact_id' => $this->contact->getKey()]);
+});
+
+test('create contact option', function (): void {
+    $option = CreateContactOption::make([
+        'address_id' => $this->address->getKey(),
+        'type' => 'phone',
+        'label' => 'Mobile',
+        'value' => '+49 123 456789',
+    ])->validate()->execute();
+
+    expect($option->value)->toBe('+49 123 456789');
+});
+
+test('create contact option requires address_id type label value', function (): void {
+    CreateContactOption::assertValidationErrors([], ['address_id', 'type', 'label', 'value']);
+});
+
+test('update contact option', function (): void {
+    $option = CreateContactOption::make([
+        'address_id' => $this->address->getKey(),
+        'type' => 'phone',
+        'label' => 'Mobile',
+        'value' => '+49 123 456789',
+    ])->validate()->execute();
+
+    $updated = UpdateContactOption::make([
+        'id' => $option->getKey(),
+        'value' => '+49 999 888777',
+    ])->validate()->execute();
+
+    expect($updated->value)->toBe('+49 999 888777');
+});
+
+test('delete contact option', function (): void {
+    $option = CreateContactOption::make([
+        'address_id' => $this->address->getKey(),
+        'type' => 'email',
+        'label' => 'Work',
+        'value' => 'test@example.com',
+    ])->validate()->execute();
+
+    expect(DeleteContactOption::make(['id' => $option->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Country/CountryActionTest.php
+++ b/tests/Feature/Actions/Country/CountryActionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use FluxErp\Actions\Country\CreateCountry;
+use FluxErp\Actions\Country\DeleteCountry;
+use FluxErp\Actions\Country\UpdateCountry;
+use FluxErp\Models\Country;
+use FluxErp\Models\Currency;
+
+test('create country', function (): void {
+    $currency = Currency::factory()->create();
+
+    $country = CreateCountry::make([
+        'name' => 'Germany',
+        'iso_alpha2' => 'DE',
+        'iso_alpha3' => 'DEU',
+        'iso_numeric' => '276',
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+        'is_eu_country' => true,
+    ])->validate()->execute();
+
+    expect($country)
+        ->toBeInstanceOf(Country::class)
+        ->name->toBe('Germany')
+        ->iso_alpha2->toBe('DE')
+        ->iso_numeric->toBe('276');
+});
+
+test('create country pads iso_numeric to 3 digits', function (): void {
+    $currency = Currency::factory()->create();
+
+    $country = CreateCountry::make([
+        'name' => 'Testland',
+        'iso_alpha2' => 'TL',
+        'iso_numeric' => '4',
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ])->validate()->execute();
+
+    expect($country->iso_numeric)->toBe('004');
+});
+
+test('create country rejects decimal iso_numeric', function (): void {
+    $currency = Currency::factory()->create();
+
+    expect(fn () => CreateCountry::make([
+        'name' => 'Testland',
+        'iso_alpha2' => 'TL',
+        'iso_numeric' => '1.5',
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ])->validate())->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('create country requires name', function (): void {
+    $currency = Currency::factory()->create();
+
+    CreateCountry::assertValidationErrors(
+        ['iso_alpha2' => 'XX', 'language_id' => $this->defaultLanguage->getKey(), 'currency_id' => $currency->getKey()],
+        'name'
+    );
+});
+
+test('create country requires unique iso_alpha2', function (): void {
+    $currency = Currency::factory()->create();
+    Country::factory()->create([
+        'iso_alpha2' => 'DE',
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ]);
+
+    CreateCountry::assertValidationErrors(
+        ['name' => 'Duplicate', 'iso_alpha2' => 'DE', 'language_id' => $this->defaultLanguage->getKey(), 'currency_id' => $currency->getKey()],
+        'iso_alpha2'
+    );
+});
+
+test('update country', function (): void {
+    $currency = Currency::factory()->create();
+    $country = Country::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ]);
+
+    $updated = UpdateCountry::make([
+        'id' => $country->getKey(),
+        'name' => 'Updated Name',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Name');
+});
+
+test('delete country', function (): void {
+    $currency = Currency::factory()->create();
+    $country = Country::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ]);
+
+    $result = DeleteCountry::make([
+        'id' => $country->getKey(),
+    ])->validate()->execute();
+
+    expect($result)->toBeTrue();
+    expect(Country::query()->whereKey($country->getKey())->exists())->toBeFalse();
+});
+
+test('delete country also deletes regions', function (): void {
+    $currency = Currency::factory()->create();
+    $country = Country::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ]);
+    $country->regions()->create(['name' => 'Bavaria']);
+
+    DeleteCountry::make(['id' => $country->getKey()])
+        ->validate()->execute();
+
+    expect($country->regions()->count())->toBe(0);
+});

--- a/tests/Feature/Actions/CountryRegion/CountryRegionActionTest.php
+++ b/tests/Feature/Actions/CountryRegion/CountryRegionActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use FluxErp\Actions\CountryRegion\CreateCountryRegion;
+use FluxErp\Actions\CountryRegion\DeleteCountryRegion;
+use FluxErp\Actions\CountryRegion\UpdateCountryRegion;
+use FluxErp\Models\Country;
+use FluxErp\Models\CountryRegion;
+use FluxErp\Models\Currency;
+
+beforeEach(function (): void {
+    $currency = Currency::factory()->create();
+    $this->country = Country::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'currency_id' => $currency->getKey(),
+    ]);
+});
+
+test('create country region', function (): void {
+    $region = CreateCountryRegion::make([
+        'country_id' => $this->country->getKey(),
+        'name' => 'Bavaria',
+    ])->validate()->execute();
+
+    expect($region)->toBeInstanceOf(CountryRegion::class)
+        ->name->toBe('Bavaria')
+        ->country_id->toBe($this->country->getKey());
+});
+
+test('create country region requires country_id and name', function (): void {
+    CreateCountryRegion::assertValidationErrors([], ['country_id', 'name']);
+});
+
+test('update country region', function (): void {
+    $region = CountryRegion::factory()->create(['country_id' => $this->country->getKey()]);
+
+    $updated = UpdateCountryRegion::make([
+        'id' => $region->getKey(),
+        'name' => 'Saxony',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Saxony');
+});
+
+test('delete country region', function (): void {
+    $region = CountryRegion::factory()->create(['country_id' => $this->country->getKey()]);
+
+    expect(DeleteCountryRegion::make(['id' => $region->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Currency/CurrencyActionTest.php
+++ b/tests/Feature/Actions/Currency/CurrencyActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Actions\Currency\CreateCurrency;
+use FluxErp\Actions\Currency\DeleteCurrency;
+use FluxErp\Actions\Currency\UpdateCurrency;
+use FluxErp\Models\Currency;
+
+test('create currency', function (): void {
+    $currency = CreateCurrency::make([
+        'name' => 'US Dollar',
+        'iso' => 'USD',
+        'symbol' => '$',
+    ])->validate()->execute();
+
+    expect($currency)
+        ->toBeInstanceOf(Currency::class)
+        ->name->toBe('US Dollar')
+        ->iso->toBe('USD')
+        ->symbol->toBe('$');
+});
+
+test('create currency requires name iso symbol', function (): void {
+    CreateCurrency::assertValidationErrors([], ['name', 'iso', 'symbol']);
+});
+
+test('update currency', function (): void {
+    $currency = Currency::factory()->create();
+
+    $updated = UpdateCurrency::make([
+        'id' => $currency->getKey(),
+        'name' => 'Updated Currency',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Currency');
+});
+
+test('delete currency', function (): void {
+    $currency = Currency::factory()->create();
+
+    $result = DeleteCurrency::make([
+        'id' => $currency->getKey(),
+    ])->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/DeviceToken/DeviceTokenActionTest.php
+++ b/tests/Feature/Actions/DeviceToken/DeviceTokenActionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use FluxErp\Actions\DeviceToken\CreateDeviceToken;
+use FluxErp\Actions\DeviceToken\DeleteDeviceToken;
+use FluxErp\Actions\DeviceToken\UpdateDeviceToken;
+
+test('create device token', function (): void {
+    $token = CreateDeviceToken::make([
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+        'device_id' => 'device-123',
+        'token' => 'fcm-token-abc',
+        'platform' => 'android',
+    ])->validate()->execute();
+
+    expect($token)
+        ->device_id->toBe('device-123')
+        ->platform->value->toBe('android');
+});
+
+test('create device token requires authenticatable device_id token platform', function (): void {
+    CreateDeviceToken::assertValidationErrors([], ['authenticatable_type', 'authenticatable_id', 'device_id', 'token', 'platform']);
+});
+
+test('update device token', function (): void {
+    $token = CreateDeviceToken::make([
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+        'device_id' => 'device-456',
+        'token' => 'old-token',
+        'platform' => 'ios',
+    ])->validate()->execute();
+
+    $updated = UpdateDeviceToken::make([
+        'id' => $token->getKey(),
+        'token' => 'new-token',
+    ])->validate()->execute();
+
+    expect($updated->token)->toBe('new-token');
+});
+
+test('delete device token', function (): void {
+    $token = CreateDeviceToken::make([
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+        'device_id' => 'device-789',
+        'token' => 'temp-token',
+        'platform' => 'web',
+    ])->validate()->execute();
+
+    expect(DeleteDeviceToken::make(['id' => $token->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Discount/DiscountActionTest.php
+++ b/tests/Feature/Actions/Discount/DiscountActionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use FluxErp\Actions\Discount\CreateDiscount;
+use FluxErp\Actions\Discount\DeleteDiscount;
+use FluxErp\Models\Discount;
+
+test('create discount fixed amount', function (): void {
+    $discount = CreateDiscount::make([
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => FluxErp\Models\Contact::factory()->create()->getKey(),
+        'discount' => 10.00,
+        'is_percentage' => false,
+    ])->validate()->execute();
+
+    expect($discount)
+        ->toBeInstanceOf(Discount::class)
+        ->discount->toEqual(10.00);
+});
+
+test('create discount percentage', function (): void {
+    $discount = CreateDiscount::make([
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => FluxErp\Models\Contact::factory()->create()->getKey(),
+        'discount' => 0.15,
+        'is_percentage' => true,
+    ])->validate()->execute();
+
+    expect($discount->is_percentage)->toBeTruthy();
+});
+
+test('percentage discount must be <= 1', function (): void {
+    CreateDiscount::assertValidationErrors([
+        'discount' => 1.5,
+        'is_percentage' => true,
+    ], 'discount');
+});
+
+test('create discount requires discount and is_percentage', function (): void {
+    CreateDiscount::assertValidationErrors([], ['discount', 'is_percentage']);
+});
+
+test('delete discount', function (): void {
+    $contact = FluxErp\Models\Contact::factory()->create();
+    $discount = CreateDiscount::make([
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => $contact->getKey(),
+        'discount' => 5.00,
+        'is_percentage' => false,
+    ])->validate()->execute();
+
+    expect(DeleteDiscount::make(['id' => $discount->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/DiscountGroup/DiscountGroupActionTest.php
+++ b/tests/Feature/Actions/DiscountGroup/DiscountGroupActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\DiscountGroup\CreateDiscountGroup;
+use FluxErp\Actions\DiscountGroup\DeleteDiscountGroup;
+use FluxErp\Actions\DiscountGroup\UpdateDiscountGroup;
+
+test('create discount group', function (): void {
+    $group = CreateDiscountGroup::make(['name' => 'VIP Discounts'])
+        ->validate()->execute();
+
+    expect($group)->name->toBe('VIP Discounts');
+});
+
+test('create discount group requires name', function (): void {
+    CreateDiscountGroup::assertValidationErrors([], 'name');
+});
+
+test('update discount group', function (): void {
+    $group = CreateDiscountGroup::make(['name' => 'Original'])
+        ->validate()->execute();
+
+    $updated = UpdateDiscountGroup::make([
+        'id' => $group->getKey(),
+        'name' => 'Premium',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Premium');
+});
+
+test('delete discount group', function (): void {
+    $group = CreateDiscountGroup::make(['name' => 'Temp'])
+        ->validate()->execute();
+
+    expect(DeleteDiscountGroup::make(['id' => $group->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/EmailTemplate/EmailTemplateActionTest.php
+++ b/tests/Feature/Actions/EmailTemplate/EmailTemplateActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\EmailTemplate\CreateEmailTemplate;
+use FluxErp\Actions\EmailTemplate\DeleteEmailTemplate;
+use FluxErp\Actions\EmailTemplate\UpdateEmailTemplate;
+use FluxErp\Models\EmailTemplate;
+
+test('create email template', function (): void {
+    $template = CreateEmailTemplate::make(['name' => 'Order Confirmation'])
+        ->validate()->execute();
+
+    expect($template)->toBeInstanceOf(EmailTemplate::class)
+        ->name->toBe('Order Confirmation');
+});
+
+test('create email template requires name', function (): void {
+    CreateEmailTemplate::assertValidationErrors([], 'name');
+});
+
+test('update email template', function (): void {
+    $template = EmailTemplate::factory()->create();
+
+    $updated = UpdateEmailTemplate::make([
+        'id' => $template->getKey(),
+        'name' => 'Shipping Notification',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Shipping Notification');
+});
+
+test('delete email template', function (): void {
+    $template = EmailTemplate::factory()->create();
+
+    expect(DeleteEmailTemplate::make(['id' => $template->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Employee/EmployeeActionTest.php
+++ b/tests/Feature/Actions/Employee/EmployeeActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use FluxErp\Actions\Employee\CreateEmployee;
+use FluxErp\Actions\Employee\DeleteEmployee;
+use FluxErp\Actions\Employee\UpdateEmployee;
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+
+beforeEach(function (): void {
+    $this->workTimeModel = CreateWorkTimeModel::make([
+        'name' => 'Standard',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+        'is_active' => true,
+    ])->validate()->execute();
+});
+
+test('create employee', function (): void {
+    $employee = CreateEmployee::make([
+        'firstname' => 'John',
+        'lastname' => 'Doe',
+        'employment_date' => '2026-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $this->workTimeModel->getKey(),
+    ])->validate()->execute();
+
+    expect($employee)
+        ->firstname->toBe('John')
+        ->lastname->toBe('Doe');
+});
+
+test('create employee requires firstname lastname employment_date', function (): void {
+    CreateEmployee::assertValidationErrors([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $this->workTimeModel->getKey(),
+    ], ['firstname', 'lastname', 'employment_date']);
+});
+
+test('update employee', function (): void {
+    $employee = CreateEmployee::make([
+        'firstname' => 'Jane',
+        'lastname' => 'Smith',
+        'employment_date' => '2026-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $this->workTimeModel->getKey(),
+    ])->validate()->execute();
+
+    $updated = UpdateEmployee::make([
+        'id' => $employee->getKey(),
+        'firstname' => 'Janet',
+    ])->validate()->execute();
+
+    expect($updated->firstname)->toBe('Janet');
+});
+
+test('delete employee', function (): void {
+    $employee = CreateEmployee::make([
+        'firstname' => 'Temp',
+        'lastname' => 'Worker',
+        'employment_date' => '2026-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $this->workTimeModel->getKey(),
+    ])->validate()->execute();
+
+    expect(DeleteEmployee::make(['id' => $employee->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/EmployeeBalanceAdjustment/EmployeeBalanceAdjustmentActionTest.php
+++ b/tests/Feature/Actions/EmployeeBalanceAdjustment/EmployeeBalanceAdjustmentActionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use FluxErp\Actions\Employee\CreateEmployee;
+use FluxErp\Actions\EmployeeBalanceAdjustment\CreateEmployeeBalanceAdjustment;
+use FluxErp\Actions\EmployeeBalanceAdjustment\DeleteEmployeeBalanceAdjustment;
+use FluxErp\Actions\EmployeeBalanceAdjustment\UpdateEmployeeBalanceAdjustment;
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+
+beforeEach(function (): void {
+    $wtm = CreateWorkTimeModel::make([
+        'name' => 'Standard',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    $this->employee = CreateEmployee::make([
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'employment_date' => '2026-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $wtm->getKey(),
+    ])->validate()->execute();
+});
+
+test('create employee balance adjustment', function (): void {
+    $adj = CreateEmployeeBalanceAdjustment::make([
+        'employee_id' => $this->employee->getKey(),
+        'type' => 'vacation',
+        'amount' => 5.0,
+        'effective_date' => '2026-06-01',
+        'reason' => 'correction',
+    ])->validate()->execute();
+
+    expect($adj)
+        ->employee_id->toBe($this->employee->getKey())
+        ->not->toBeNull();
+});
+
+test('create employee balance adjustment requires all fields', function (): void {
+    CreateEmployeeBalanceAdjustment::assertValidationErrors([], [
+        'employee_id', 'type', 'amount', 'effective_date', 'reason',
+    ]);
+});
+
+test('update employee balance adjustment', function (): void {
+    $adj = CreateEmployeeBalanceAdjustment::make([
+        'employee_id' => $this->employee->getKey(),
+        'type' => 'vacation',
+        'amount' => 3.0,
+        'effective_date' => '2026-06-01',
+        'reason' => 'carryover',
+    ])->validate()->execute();
+
+    $updated = UpdateEmployeeBalanceAdjustment::make([
+        'id' => $adj->getKey(),
+        'reason' => 'payout',
+    ])->validate()->execute();
+
+    expect($updated)->not->toBeNull();
+});
+
+test('delete employee balance adjustment', function (): void {
+    $adj = CreateEmployeeBalanceAdjustment::make([
+        'employee_id' => $this->employee->getKey(),
+        'type' => 'overtime',
+        'amount' => 10.0,
+        'effective_date' => '2026-07-01',
+        'reason' => 'other',
+    ])->validate()->execute();
+
+    expect(DeleteEmployeeBalanceAdjustment::make(['id' => $adj->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/EmployeeDay/EmployeeDayActionTest.php
+++ b/tests/Feature/Actions/EmployeeDay/EmployeeDayActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use FluxErp\Actions\Employee\CreateEmployee;
+use FluxErp\Actions\EmployeeDay\CreateEmployeeDay;
+use FluxErp\Actions\EmployeeDay\DeleteEmployeeDay;
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+
+beforeEach(function (): void {
+    $wtm = CreateWorkTimeModel::make([
+        'name' => 'Standard',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    $this->employee = CreateEmployee::make([
+        'firstname' => 'Test',
+        'lastname' => 'Worker',
+        'employment_date' => '2025-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $wtm->getKey(),
+    ])->validate()->execute();
+});
+
+test('create employee day', function (): void {
+    $day = CreateEmployeeDay::make([
+        'employee_id' => $this->employee->getKey(),
+        'date' => '2026-04-05',
+        'target_hours' => 8,
+        'actual_hours' => 0,
+    ])->validate()->execute();
+
+    expect($day)
+        ->employee_id->toBe($this->employee->getKey())
+        ->date->not->toBeNull();
+});
+
+test('create employee day requires employee_id and date', function (): void {
+    CreateEmployeeDay::assertValidationErrors([], ['employee_id', 'date']);
+});
+
+test('delete employee day', function (): void {
+    $day = CreateEmployeeDay::make([
+        'employee_id' => $this->employee->getKey(),
+        'date' => '2026-04-06',
+        'target_hours' => 8,
+        'actual_hours' => 0,
+    ])->validate()->execute();
+
+    expect(DeleteEmployeeDay::make(['id' => $day->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/EmployeeDepartment/EmployeeDepartmentActionTest.php
+++ b/tests/Feature/Actions/EmployeeDepartment/EmployeeDepartmentActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\EmployeeDepartment\CreateEmployeeDepartment;
+use FluxErp\Actions\EmployeeDepartment\DeleteEmployeeDepartment;
+use FluxErp\Actions\EmployeeDepartment\UpdateEmployeeDepartment;
+
+test('create employee department', function (): void {
+    $dept = CreateEmployeeDepartment::make(['name' => 'Engineering'])
+        ->validate()->execute();
+
+    expect($dept)->name->toBe('Engineering');
+});
+
+test('create employee department requires name', function (): void {
+    CreateEmployeeDepartment::assertValidationErrors([], 'name');
+});
+
+test('update employee department', function (): void {
+    $dept = CreateEmployeeDepartment::make(['name' => 'Engineering'])
+        ->validate()->execute();
+
+    $updated = UpdateEmployeeDepartment::make([
+        'id' => $dept->getKey(),
+        'name' => 'Product',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Product');
+});
+
+test('delete employee department', function (): void {
+    $dept = CreateEmployeeDepartment::make(['name' => 'Temp Dept'])
+        ->validate()->execute();
+
+    expect(DeleteEmployeeDepartment::make(['id' => $dept->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/EmployeeWorkTimeModel/EmployeeWorkTimeModelActionTest.php
+++ b/tests/Feature/Actions/EmployeeWorkTimeModel/EmployeeWorkTimeModelActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use FluxErp\Actions\Employee\CreateEmployee;
+use FluxErp\Actions\EmployeeWorkTimeModel\CreateEmployeeWorkTimeModel;
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+
+beforeEach(function (): void {
+    $this->wtm = CreateWorkTimeModel::make([
+        'name' => 'Standard',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    $this->employee = CreateEmployee::make([
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'employment_date' => '2026-01-01',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'work_time_model_id' => $this->wtm->getKey(),
+    ])->validate()->execute();
+});
+
+test('create employee work time model', function (): void {
+    $wtm2 = CreateWorkTimeModel::make([
+        'name' => 'Part Time',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 20,
+        'annual_vacation_days' => 15,
+        'overtime_compensation' => 'time_off',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    $ewtm = CreateEmployeeWorkTimeModel::make([
+        'employee_id' => $this->employee->getKey(),
+        'work_time_model_id' => $wtm2->getKey(),
+        'valid_from' => '2026-07-01',
+    ])->validate()->execute();
+
+    expect($ewtm)->employee_id->toBe($this->employee->getKey());
+});
+
+test('create employee work time model requires employee work_time_model valid_from', function (): void {
+    CreateEmployeeWorkTimeModel::assertValidationErrors([], [
+        'employee_id', 'work_time_model_id', 'valid_from',
+    ]);
+});
+
+test('create employee work time model requires fields', function (): void {
+    CreateEmployeeWorkTimeModel::assertValidationErrors([], [
+        'employee_id', 'work_time_model_id', 'valid_from',
+    ]);
+});

--- a/tests/Feature/Actions/EventSubscription/EventSubscriptionActionTest.php
+++ b/tests/Feature/Actions/EventSubscription/EventSubscriptionActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use FluxErp\Actions\EventSubscription\CreateEventSubscription;
+use FluxErp\Actions\EventSubscription\DeleteEventSubscription;
+use FluxErp\Actions\EventSubscription\UpdateEventSubscription;
+
+test('create event subscription', function (): void {
+    $sub = CreateEventSubscription::make([
+        'channel' => 'test-channel',
+        'event' => 'test-event',
+        'subscribable_type' => morph_alias($this->user::class),
+        'subscribable_id' => $this->user->getKey(),
+        'is_broadcast' => true,
+        'is_notifiable' => false,
+    ])->validate()->execute();
+
+    expect($sub)->channel->toBe('test-channel');
+});
+
+test('create event subscription requires channel event', function (): void {
+    CreateEventSubscription::assertValidationErrors([], ['channel', 'event']);
+});
+
+test('update event subscription', function (): void {
+    $sub = CreateEventSubscription::make([
+        'channel' => 'ch1',
+        'event' => 'ev1',
+        'subscribable_type' => morph_alias($this->user::class),
+        'subscribable_id' => $this->user->getKey(),
+        'is_broadcast' => true,
+        'is_notifiable' => false,
+    ])->validate()->execute();
+
+    $updated = UpdateEventSubscription::make([
+        'id' => $sub->getKey(),
+        'is_broadcast' => true,
+        'is_notifiable' => true,
+    ])->validate()->execute();
+
+    expect($updated->is_notifiable)->toBeTruthy();
+});
+
+test('delete event subscription', function (): void {
+    $sub = CreateEventSubscription::make([
+        'channel' => 'ch2',
+        'event' => 'ev2',
+        'subscribable_type' => morph_alias($this->user::class),
+        'subscribable_id' => $this->user->getKey(),
+        'is_broadcast' => true,
+        'is_notifiable' => false,
+    ])->validate()->execute();
+
+    expect(DeleteEventSubscription::make(['id' => $sub->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Holiday/HolidayActionTest.php
+++ b/tests/Feature/Actions/Holiday/HolidayActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use FluxErp\Actions\Holiday\CreateHoliday;
+use FluxErp\Actions\Holiday\DeleteHoliday;
+use FluxErp\Actions\Holiday\UpdateHoliday;
+
+test('create holiday with fixed date', function (): void {
+    $holiday = CreateHoliday::make([
+        'name' => 'New Year',
+        'date' => '2026-01-01',
+        'day_part' => 'full_day',
+        'is_recurring' => false,
+    ])->validate()->execute();
+
+    expect($holiday)->name->toBe('New Year');
+});
+
+test('create recurring holiday', function (): void {
+    $holiday = CreateHoliday::make([
+        'name' => 'Christmas',
+        'day' => 25,
+        'month' => 12,
+        'day_part' => 'full_day',
+        'is_recurring' => true,
+    ])->validate()->execute();
+
+    expect($holiday)
+        ->name->toBe('Christmas')
+        ->is_recurring->toBeTrue();
+});
+
+test('create holiday requires name', function (): void {
+    CreateHoliday::assertValidationErrors([], 'name');
+});
+
+test('update holiday', function (): void {
+    $holiday = CreateHoliday::make([
+        'name' => 'Original',
+        'date' => '2026-06-01',
+        'day_part' => 'full_day',
+        'is_recurring' => false,
+    ])->validate()->execute();
+
+    $updated = UpdateHoliday::make([
+        'id' => $holiday->getKey(),
+        'name' => 'Updated Holiday',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Holiday');
+});
+
+test('delete holiday', function (): void {
+    $holiday = CreateHoliday::make([
+        'name' => 'Temp',
+        'date' => '2026-12-31',
+        'day_part' => 'full_day',
+        'is_recurring' => false,
+    ])->validate()->execute();
+
+    expect(DeleteHoliday::make(['id' => $holiday->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Industry/IndustryActionTest.php
+++ b/tests/Feature/Actions/Industry/IndustryActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\Industry\CreateIndustry;
+use FluxErp\Actions\Industry\DeleteIndustry;
+use FluxErp\Actions\Industry\UpdateIndustry;
+use FluxErp\Models\Industry;
+
+test('create industry', function (): void {
+    $industry = CreateIndustry::make(['name' => 'Software'])
+        ->validate()->execute();
+
+    expect($industry)->toBeInstanceOf(Industry::class)
+        ->name->toBe('Software');
+});
+
+test('create industry requires name', function (): void {
+    CreateIndustry::assertValidationErrors([], 'name');
+});
+
+test('update industry', function (): void {
+    $industry = Industry::factory()->create();
+
+    $updated = UpdateIndustry::make([
+        'id' => $industry->getKey(),
+        'name' => 'Updated',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated');
+});
+
+test('delete industry', function (): void {
+    $industry = Industry::factory()->create();
+
+    expect(DeleteIndustry::make(['id' => $industry->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Language/LanguageActionTest.php
+++ b/tests/Feature/Actions/Language/LanguageActionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use FluxErp\Actions\Language\CreateLanguage;
+use FluxErp\Actions\Language\DeleteLanguage;
+use FluxErp\Actions\Language\UpdateLanguage;
+use FluxErp\Models\Language;
+
+test('create language', function (): void {
+    $language = CreateLanguage::make([
+        'name' => 'Französisch',
+        'iso_name' => 'French',
+        'language_code' => 'fr',
+    ])->validate()->execute();
+
+    expect($language)
+        ->toBeInstanceOf(Language::class)
+        ->name->toBe('Französisch')
+        ->language_code->toBe('fr');
+});
+
+test('create language requires name iso_name language_code', function (): void {
+    CreateLanguage::assertValidationErrors([], ['name', 'iso_name', 'language_code']);
+});
+
+test('update language', function (): void {
+    $language = Language::factory()->create();
+
+    $updated = UpdateLanguage::make([
+        'id' => $language->getKey(),
+        'name' => 'Aktualisiert',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Aktualisiert');
+});
+
+test('delete language', function (): void {
+    $language = Language::factory()->create();
+
+    $result = DeleteLanguage::make([
+        'id' => $language->getKey(),
+    ])->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/Lead/LeadActionTest.php
+++ b/tests/Feature/Actions/Lead/LeadActionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use FluxErp\Actions\Lead\CreateLead;
+use FluxErp\Actions\Lead\DeleteLead;
+use FluxErp\Actions\Lead\UpdateLead;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Lead;
+use FluxErp\Models\LeadState;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+    $this->leadState = LeadState::factory()->create([
+        'is_won' => false,
+        'is_lost' => false,
+    ]);
+});
+
+test('create lead', function (): void {
+    $lead = CreateLead::make([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+        'name' => 'Big Deal',
+    ])->validate()->execute();
+
+    expect($lead)->toBeInstanceOf(Lead::class)
+        ->name->toBe('Big Deal');
+});
+
+test('create lead requires address_id', function (): void {
+    CreateLead::assertValidationErrors(
+        ['name' => 'Test'],
+        'address_id'
+    );
+});
+
+test('update lead', function (): void {
+    $lead = Lead::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    $updated = UpdateLead::make([
+        'id' => $lead->getKey(),
+        'name' => 'Bigger Deal',
+        'start' => $lead->start ?? now()->toDateString(),
+        'end' => $lead->end ?? now()->addMonth()->toDateString(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Bigger Deal');
+});
+
+test('delete lead', function (): void {
+    $lead = Lead::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    expect(DeleteLead::make(['id' => $lead->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/LeadLossReason/LeadLossReasonActionTest.php
+++ b/tests/Feature/Actions/LeadLossReason/LeadLossReasonActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\LeadLossReason\CreateLeadLossReason;
+use FluxErp\Actions\LeadLossReason\DeleteLeadLossReason;
+use FluxErp\Actions\LeadLossReason\UpdateLeadLossReason;
+use FluxErp\Models\LeadLossReason;
+
+test('create lead loss reason', function (): void {
+    $reason = CreateLeadLossReason::make(['name' => 'Zu teuer'])
+        ->validate()->execute();
+
+    expect($reason)->toBeInstanceOf(LeadLossReason::class)
+        ->name->toBe('Zu teuer');
+});
+
+test('create lead loss reason requires name', function (): void {
+    CreateLeadLossReason::assertValidationErrors([], 'name');
+});
+
+test('update lead loss reason', function (): void {
+    $reason = LeadLossReason::factory()->create();
+
+    $updated = UpdateLeadLossReason::make([
+        'id' => $reason->getKey(),
+        'name' => 'Kein Bedarf',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Kein Bedarf');
+});
+
+test('delete lead loss reason', function (): void {
+    $reason = LeadLossReason::factory()->create();
+
+    expect(DeleteLeadLossReason::make(['id' => $reason->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/LeadState/LeadStateActionTest.php
+++ b/tests/Feature/Actions/LeadState/LeadStateActionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use FluxErp\Actions\LeadState\CreateLeadState;
+use FluxErp\Actions\LeadState\DeleteLeadState;
+use FluxErp\Actions\LeadState\UpdateLeadState;
+use FluxErp\Models\LeadState;
+
+test('create lead state', function (): void {
+    $state = CreateLeadState::make([
+        'name' => 'Qualified',
+        'probability_percentage' => 0.5,
+    ])->validate()->execute();
+
+    expect($state)->toBeInstanceOf(LeadState::class)
+        ->name->toBe('Qualified');
+});
+
+test('create lead state requires name', function (): void {
+    CreateLeadState::assertValidationErrors([], 'name');
+});
+
+test('is_won and is_lost are mutually exclusive', function (): void {
+    CreateLeadState::assertValidationErrors(
+        ['name' => 'Invalid', 'is_won' => true, 'is_lost' => true],
+        ['is_won', 'is_lost']
+    );
+});
+
+test('update lead state', function (): void {
+    $state = LeadState::factory()->create();
+
+    $updated = UpdateLeadState::make([
+        'id' => $state->getKey(),
+        'name' => 'Won',
+        'is_won' => true,
+        'is_default' => false,
+        'is_lost' => false,
+    ])->validate()->execute();
+
+    expect($updated)->name->toBe('Won');
+});
+
+test('delete lead state', function (): void {
+    $state = LeadState::factory()->create();
+
+    expect(DeleteLeadState::make(['id' => $state->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/LedgerAccount/LedgerAccountActionTest.php
+++ b/tests/Feature/Actions/LedgerAccount/LedgerAccountActionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use FluxErp\Actions\LedgerAccount\CreateLedgerAccount;
+use FluxErp\Actions\LedgerAccount\DeleteLedgerAccount;
+use FluxErp\Actions\LedgerAccount\UpdateLedgerAccount;
+use FluxErp\Enums\LedgerAccountTypeEnum;
+use FluxErp\Models\LedgerAccount;
+
+test('create ledger account', function (): void {
+    $account = CreateLedgerAccount::make([
+        'name' => 'Revenue',
+        'number' => '8000',
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Revenue->value,
+        'tenant_id' => $this->dbTenant->getKey(),
+    ])->validate()->execute();
+
+    expect($account)->toBeInstanceOf(LedgerAccount::class)
+        ->name->toBe('Revenue')
+        ->number->toBe('8000');
+});
+
+test('create ledger account auto-sets default tenant', function (): void {
+    $account = CreateLedgerAccount::make([
+        'name' => 'Costs',
+        'number' => '4000',
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Expense->value,
+    ])->validate()->execute();
+
+    expect($account->tenant_id)->toBe($this->dbTenant->getKey());
+});
+
+test('create ledger account requires name number and type', function (): void {
+    CreateLedgerAccount::assertValidationErrors([], ['name', 'number', 'ledger_account_type_enum']);
+});
+
+test('create ledger account rejects duplicate number per tenant and type', function (): void {
+    CreateLedgerAccount::make([
+        'name' => 'First',
+        'number' => '8000',
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Revenue->value,
+        'tenant_id' => $this->dbTenant->getKey(),
+    ])->validate()->execute();
+
+    CreateLedgerAccount::assertValidationErrors([
+        'name' => 'Duplicate',
+        'number' => '8000',
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Revenue->value,
+        'tenant_id' => $this->dbTenant->getKey(),
+    ], 'number');
+});
+
+test('update ledger account', function (): void {
+    $account = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $updated = UpdateLedgerAccount::make([
+        'id' => $account->getKey(),
+        'name' => 'Updated Account',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Account');
+});
+
+test('delete ledger account', function (): void {
+    $account = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    expect(DeleteLedgerAccount::make(['id' => $account->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Location/LocationActionTest.php
+++ b/tests/Feature/Actions/Location/LocationActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\Location\CreateLocation;
+use FluxErp\Actions\Location\DeleteLocation;
+use FluxErp\Actions\Location\UpdateLocation;
+
+test('create location', function (): void {
+    $location = CreateLocation::make(['name' => 'Office Berlin'])
+        ->validate()->execute();
+
+    expect($location)->name->toBe('Office Berlin');
+});
+
+test('create location requires name', function (): void {
+    CreateLocation::assertValidationErrors([], 'name');
+});
+
+test('update location', function (): void {
+    $location = CreateLocation::make(['name' => 'Office Berlin'])
+        ->validate()->execute();
+
+    $updated = UpdateLocation::make([
+        'id' => $location->getKey(),
+        'name' => 'Office Munich',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Office Munich');
+});
+
+test('delete location', function (): void {
+    $location = CreateLocation::make(['name' => 'Temp'])
+        ->validate()->execute();
+
+    expect(DeleteLocation::make(['id' => $location->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/MailAccount/MailAccountActionTest.php
+++ b/tests/Feature/Actions/MailAccount/MailAccountActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\MailAccount\CreateMailAccount;
+use FluxErp\Actions\MailAccount\DeleteMailAccount;
+use FluxErp\Actions\MailAccount\UpdateMailAccount;
+use FluxErp\Models\MailAccount;
+
+test('create mail account', function (): void {
+    $account = CreateMailAccount::make(['name' => 'Support Inbox'])
+        ->validate()->execute();
+
+    expect($account)->toBeInstanceOf(MailAccount::class)
+        ->name->toBe('Support Inbox');
+});
+
+test('create mail account requires name', function (): void {
+    CreateMailAccount::assertValidationErrors([], 'name');
+});
+
+test('update mail account', function (): void {
+    $account = MailAccount::factory()->create();
+
+    $updated = UpdateMailAccount::make([
+        'id' => $account->getKey(),
+        'name' => 'Sales Inbox',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Sales Inbox');
+});
+
+test('delete mail account', function (): void {
+    $account = MailAccount::factory()->create();
+
+    expect(DeleteMailAccount::make(['id' => $account->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/MailFolder/MailFolderActionTest.php
+++ b/tests/Feature/Actions/MailFolder/MailFolderActionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use FluxErp\Actions\MailFolder\CreateMailFolder;
+use FluxErp\Actions\MailFolder\DeleteMailFolder;
+use FluxErp\Actions\MailFolder\UpdateMailFolder;
+use FluxErp\Models\MailAccount;
+
+beforeEach(function (): void {
+    $this->mailAccount = MailAccount::factory()->create();
+});
+
+test('create mail folder', function (): void {
+    $folder = CreateMailFolder::make([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'name' => 'Inbox',
+        'slug' => 'inbox',
+    ])->validate()->execute();
+
+    expect($folder)->name->toBe('Inbox');
+});
+
+test('create mail folder requires mail_account_id name slug', function (): void {
+    CreateMailFolder::assertValidationErrors([], ['mail_account_id', 'name', 'slug']);
+});
+
+test('update mail folder', function (): void {
+    $folder = CreateMailFolder::make([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'name' => 'Original',
+        'slug' => 'original',
+    ])->validate()->execute();
+
+    $updated = UpdateMailFolder::make([
+        'id' => $folder->getKey(),
+        'name' => 'Archive',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Archive');
+});
+
+test('delete mail folder', function (): void {
+    $folder = CreateMailFolder::make([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'name' => 'Temp',
+        'slug' => 'temp',
+    ])->validate()->execute();
+
+    expect(DeleteMailFolder::make(['id' => $folder->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/MailMessage/MailMessageActionTest.php
+++ b/tests/Feature/Actions/MailMessage/MailMessageActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use FluxErp\Actions\MailFolder\CreateMailFolder;
+use FluxErp\Actions\MailMessage\CreateMailMessage;
+use FluxErp\Models\MailAccount;
+
+beforeEach(function (): void {
+    $this->mailAccount = MailAccount::factory()->create();
+    $this->mailFolder = CreateMailFolder::make([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'name' => 'Inbox',
+        'slug' => 'INBOX',
+    ])->validate()->execute();
+});
+
+test('create mail message', function (): void {
+    $message = CreateMailMessage::make([
+        'mail_folder_id' => $this->mailFolder->getKey(),
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'from' => 'test@example.com',
+        'subject' => 'Test Email',
+        'text_body' => 'Hello World',
+        'communication_type_enum' => 'mail',
+    ])->validate()->execute();
+
+    expect($message)->subject->toBe('Test Email');
+});

--- a/tests/Feature/Actions/Media/MediaActionTest.php
+++ b/tests/Feature/Actions/Media/MediaActionTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use FluxErp\Actions\Media\DeleteMedia;
+use FluxErp\Actions\Media\UpdateMedia;
+
+test('delete media requires id', function (): void {
+    DeleteMedia::assertValidationErrors([], 'id');
+});
+
+test('update media requires id', function (): void {
+    UpdateMedia::assertValidationErrors([], 'id');
+});

--- a/tests/Feature/Actions/MediaFolder/MediaFolderActionTest.php
+++ b/tests/Feature/Actions/MediaFolder/MediaFolderActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Actions\MediaFolder\CreateMediaFolder;
+use FluxErp\Actions\MediaFolder\DeleteMediaFolder;
+use FluxErp\Actions\MediaFolder\UpdateMediaFolder;
+
+test('create media folder', function (): void {
+    $folder = CreateMediaFolder::make([
+        'name' => 'Documents',
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => FluxErp\Models\Contact::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect($folder)->name->toBe('Documents');
+});
+
+test('create media folder requires name model_type model_id', function (): void {
+    CreateMediaFolder::assertValidationErrors([], ['name', 'model_type', 'model_id']);
+});
+
+test('update media folder', function (): void {
+    $folder = CreateMediaFolder::make([
+        'name' => 'Original',
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => FluxErp\Models\Contact::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    $updated = UpdateMediaFolder::make([
+        'id' => $folder->getKey(),
+        'name' => 'Invoices',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Invoices');
+});
+
+test('delete media folder', function (): void {
+    $folder = CreateMediaFolder::make([
+        'name' => 'Temp',
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => FluxErp\Models\Contact::factory()->create()->getKey(),
+    ])->validate()->execute();
+
+    expect(DeleteMediaFolder::make(['id' => $folder->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/NotificationSetting/NotificationSettingActionTest.php
+++ b/tests/Feature/Actions/NotificationSetting/NotificationSettingActionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use FluxErp\Actions\NotificationSetting\UpdateNotificationSetting;
+
+test('update notification setting', function (): void {
+    $result = UpdateNotificationSetting::make([
+        'notification_type' => 'FluxErp\\Notifications\\CommentCreatedNotification',
+        'channel' => 'database',
+        'is_active' => true,
+    ])->validate()->execute();
+
+    expect($result)->not->toBeNull();
+});
+
+test('update notification setting requires notification_type and channel', function (): void {
+    UpdateNotificationSetting::assertValidationErrors([], ['notification_type', 'channel']);
+});

--- a/tests/Feature/Actions/Order/OrderActionTest.php
+++ b/tests/Feature/Actions/Order/OrderActionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use FluxErp\Actions\Order\CreateOrder;
+use FluxErp\Actions\Order\DeleteOrder;
+use FluxErp\Actions\Order\UpdateOrder;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Warehouse;
+
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $this->orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $this->paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $this->priceList = PriceList::factory()->create();
+    $this->currency = Currency::factory()->create();
+});
+
+test('create order', function (): void {
+    $order = CreateOrder::make([
+        'contact_id' => $this->contact->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'order_type_id' => $this->orderType->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ])->validate()->execute();
+
+    expect($order)
+        ->toBeInstanceOf(Order::class)
+        ->order_number->not->toBeNull()
+        ->contact_id->toBe($this->contact->getKey());
+});
+
+test('create order requires contact and address', function (): void {
+    CreateOrder::assertValidationErrors([
+        'order_type_id' => $this->orderType->getKey(),
+    ], ['contact_id', 'address_invoice_id']);
+});
+
+test('update order', function (): void {
+    $order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => false,
+    ]);
+
+    $updated = UpdateOrder::make([
+        'id' => $order->getKey(),
+        'header' => 'Updated header text',
+    ])->validate()->execute();
+
+    expect($updated->header)->toBe('Updated header text');
+});
+
+test('update locked order fails', function (): void {
+    $order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+    ]);
+
+    UpdateOrder::assertValidationErrors([
+        'id' => $order->getKey(),
+        'header' => 'Should fail',
+    ], 'is_locked');
+});
+
+test('delete order', function (): void {
+    $order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => false,
+    ]);
+
+    $result = DeleteOrder::make(['id' => $order->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});
+
+test('delete locked order fails', function (): void {
+    $order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+    ]);
+
+    DeleteOrder::assertValidationErrors([
+        'id' => $order->getKey(),
+    ], 'is_locked');
+});

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use FluxErp\Actions\OrderPosition\CreateOrderPosition;
+use FluxErp\Actions\OrderPosition\DeleteOrderPosition;
+use FluxErp\Actions\OrderPosition\UpdateOrderPosition;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\VatRate;
+use FluxErp\Models\Warehouse;
+
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => false,
+    ]);
+    $this->vatRate = VatRate::factory()->create();
+});
+
+test('create order position with name', function (): void {
+    $position = CreateOrderPosition::make([
+        'order_id' => $this->order->getKey(),
+        'name' => 'Custom Position',
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+        'unit_price' => 50.00,
+    ])->validate()->execute();
+
+    expect($position)
+        ->toBeInstanceOf(OrderPosition::class)
+        ->name->toBe('Custom Position');
+});
+
+test('create order position requires order_id', function (): void {
+    CreateOrderPosition::assertValidationErrors(
+        ['name' => 'Test'],
+        'order_id'
+    );
+});
+
+test('update order position', function (): void {
+    $position = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $updated = UpdateOrderPosition::make([
+        'id' => $position->getKey(),
+        'name' => 'Updated Position',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Position');
+});
+
+test('delete order position', function (): void {
+    $position = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $result = DeleteOrderPosition::make(['id' => $position->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/OrderTransaction/OrderTransactionActionTest.php
+++ b/tests/Feature/Actions/OrderTransaction/OrderTransactionActionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use FluxErp\Actions\OrderTransaction\CreateOrderTransaction;
+use FluxErp\Actions\OrderTransaction\DeleteOrderTransaction;
+use FluxErp\Actions\OrderTransaction\UpdateOrderTransaction;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\Pivots\OrderTransaction;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Transaction;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+    $this->transaction = Transaction::factory()->create();
+});
+
+test('create order transaction', function (): void {
+    $ot = CreateOrderTransaction::make([
+        'transaction_id' => $this->transaction->getKey(),
+        'order_id' => $this->order->getKey(),
+        'amount' => 100.00,
+    ])->validate()->execute();
+
+    expect($ot)->toBeInstanceOf(OrderTransaction::class);
+});
+
+test('create order transaction requires transaction_id order_id amount', function (): void {
+    CreateOrderTransaction::assertValidationErrors([], ['transaction_id', 'order_id', 'amount']);
+});
+
+test('update order transaction', function (): void {
+    $ot = OrderTransaction::factory()->create([
+        'transaction_id' => $this->transaction->getKey(),
+        'order_id' => $this->order->getKey(),
+    ]);
+
+    $updated = UpdateOrderTransaction::make([
+        'pivot_id' => $ot->getKey(),
+        'amount' => 200.00,
+    ])->validate()->execute();
+
+    expect($updated->amount)->toEqual(200.00);
+});
+
+test('delete order transaction', function (): void {
+    $ot = OrderTransaction::factory()->create([
+        'transaction_id' => $this->transaction->getKey(),
+        'order_id' => $this->order->getKey(),
+    ]);
+
+    expect(DeleteOrderTransaction::make(['pivot_id' => $ot->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/OrderType/OrderTypeActionTest.php
+++ b/tests/Feature/Actions/OrderType/OrderTypeActionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use FluxErp\Actions\OrderType\CreateOrderType;
+use FluxErp\Actions\OrderType\DeleteOrderType;
+use FluxErp\Actions\OrderType\UpdateOrderType;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\OrderType;
+
+test('create order type', function (): void {
+    $type = CreateOrderType::make([
+        'name' => 'Invoice',
+        'order_type_enum' => OrderTypeEnum::Order->value,
+    ])->validate()->execute();
+
+    expect($type)->toBeInstanceOf(OrderType::class)
+        ->name->toBe('Invoice');
+});
+
+test('create order type requires name and enum', function (): void {
+    CreateOrderType::assertValidationErrors([], ['name', 'order_type_enum']);
+});
+
+test('update order type', function (): void {
+    $type = OrderType::factory()->create();
+
+    $updated = UpdateOrderType::make([
+        'id' => $type->getKey(),
+        'name' => 'Credit Note',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Credit Note');
+});
+
+test('delete order type', function (): void {
+    $type = OrderType::factory()->create();
+
+    expect(DeleteOrderType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PaymentReminder/PaymentReminderActionTest.php
+++ b/tests/Feature/Actions/PaymentReminder/PaymentReminderActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use FluxErp\Actions\PaymentReminder\CreatePaymentReminder;
+use FluxErp\Actions\PaymentReminder\DeletePaymentReminder;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-001',
+    ]);
+});
+
+test('create payment reminder for locked order', function (): void {
+    $reminder = CreatePaymentReminder::make([
+        'order_id' => $this->order->getKey(),
+        'reminder_level' => 1,
+    ])->validate()->execute();
+
+    expect($reminder)->order_id->toBe($this->order->getKey());
+});
+
+test('create payment reminder requires order_id', function (): void {
+    CreatePaymentReminder::assertValidationErrors([], 'order_id');
+});
+
+test('create payment reminder fails for unlocked order', function (): void {
+    $this->order->update(['is_locked' => false]);
+
+    CreatePaymentReminder::assertValidationErrors([
+        'order_id' => $this->order->getKey(),
+    ], 'order_id');
+});
+
+test('delete payment reminder', function (): void {
+    $reminder = CreatePaymentReminder::make([
+        'order_id' => $this->order->getKey(),
+        'reminder_level' => 1,
+    ])->validate()->execute();
+
+    expect(DeletePaymentReminder::make(['id' => $reminder->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PaymentReminderText/PaymentReminderTextActionTest.php
+++ b/tests/Feature/Actions/PaymentReminderText/PaymentReminderTextActionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use FluxErp\Actions\PaymentReminderText\CreatePaymentReminderText;
+use FluxErp\Actions\PaymentReminderText\DeletePaymentReminderText;
+use FluxErp\Actions\PaymentReminderText\UpdatePaymentReminderText;
+use FluxErp\Models\PaymentReminderText;
+
+test('create payment reminder text', function (): void {
+    $text = CreatePaymentReminderText::make([
+        'reminder_level' => 1,
+        'reminder_subject' => 'Payment Overdue',
+        'reminder_body' => 'Please pay your invoice.',
+    ])->validate()->execute();
+
+    expect($text)->toBeInstanceOf(PaymentReminderText::class);
+});
+
+test('update payment reminder text', function (): void {
+    $text = PaymentReminderText::factory()->create();
+
+    $updated = UpdatePaymentReminderText::make([
+        'id' => $text->getKey(),
+        'reminder_level' => $text->reminder_level,
+        'reminder_subject' => 'Updated Subject',
+    ])->validate()->execute();
+
+    expect($updated->reminder_subject)->toBe('Updated Subject');
+});
+
+test('delete payment reminder text', function (): void {
+    $text = PaymentReminderText::factory()->create();
+
+    expect(DeletePaymentReminderText::make(['id' => $text->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PaymentRun/PaymentRunActionTest.php
+++ b/tests/Feature/Actions/PaymentRun/PaymentRunActionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use FluxErp\Actions\PaymentRun\CreatePaymentRun;
+use FluxErp\Actions\PaymentRun\DeletePaymentRun;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\BankConnection;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+
+test('create payment run', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    $run = CreatePaymentRun::make([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'payment_run_type_enum' => 'money_transfer',
+        'iban' => 'DE89370400440532013000',
+        'orders' => [
+            ['order_id' => $order->getKey(), 'amount' => 100.00],
+        ],
+    ])->validate()->execute();
+
+    expect($run)->bank_connection_id->toBe($bankConnection->getKey());
+});
+
+test('create payment run requires orders and payment_run_type_enum', function (): void {
+    CreatePaymentRun::assertValidationErrors([], ['orders', 'payment_run_type_enum']);
+});
+
+test('delete payment run', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    $run = CreatePaymentRun::make([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'payment_run_type_enum' => 'direct_debit',
+        'iban' => 'DE89370400440532013000',
+        'orders' => [
+            ['order_id' => $order->getKey(), 'amount' => 50.00],
+        ],
+    ])->validate()->execute();
+
+    expect(DeletePaymentRun::make(['id' => $run->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PaymentType/PaymentTypeActionTest.php
+++ b/tests/Feature/Actions/PaymentType/PaymentTypeActionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use FluxErp\Actions\PaymentType\CreatePaymentType;
+use FluxErp\Actions\PaymentType\DeletePaymentType;
+use FluxErp\Actions\PaymentType\UpdatePaymentType;
+use FluxErp\Models\PaymentType;
+
+test('create payment type', function (): void {
+    $type = CreatePaymentType::make([
+        'name' => 'Wire Transfer',
+        'tenants' => [$this->dbTenant->getKey()],
+    ])->validate()->execute();
+
+    expect($type)->toBeInstanceOf(PaymentType::class)
+        ->name->toBe('Wire Transfer');
+    expect($type->tenants)->toHaveCount(1);
+});
+
+test('create payment type auto-attaches default tenant', function (): void {
+    $type = CreatePaymentType::make([
+        'name' => 'Cash',
+    ])->validate()->execute();
+
+    expect($type->tenants)->not->toBeEmpty();
+});
+
+test('create payment type requires name', function (): void {
+    CreatePaymentType::assertValidationErrors([], 'name');
+});
+
+test('update payment type', function (): void {
+    $type = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $updated = UpdatePaymentType::make([
+        'id' => $type->getKey(),
+        'name' => 'Direct Debit',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Direct Debit');
+});
+
+test('delete payment type', function (): void {
+    $type = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    expect(DeletePaymentType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Permission/PermissionActionTest.php
+++ b/tests/Feature/Actions/Permission/PermissionActionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use FluxErp\Actions\Permission\CreatePermission;
+use FluxErp\Actions\Permission\DeletePermission;
+use FluxErp\Models\Permission;
+use Illuminate\Validation\ValidationException;
+
+test('create permission', function (): void {
+    $permission = CreatePermission::make([
+        'name' => 'edit-posts',
+        'guard_name' => 'web',
+    ])->validate()->execute();
+
+    expect($permission)->name->toBe('edit-posts');
+});
+
+test('create permission requires name', function (): void {
+    CreatePermission::assertValidationErrors([], 'name');
+});
+
+test('delete permission', function (): void {
+    $permission = CreatePermission::make([
+        'name' => 'temp-perm',
+        'guard_name' => 'web',
+    ])->validate()->execute();
+
+    expect(DeletePermission::make(['id' => $permission->getKey()])
+        ->validate()->execute())->toBeTrue();
+});
+
+test('cannot delete locked permission', function (): void {
+    $permission = Permission::query()->create([
+        'name' => 'locked-perm',
+        'guard_name' => 'web',
+        'is_locked' => true,
+    ]);
+
+    expect(fn () => DeletePermission::make(['id' => $permission->getKey()])
+        ->validate()->execute()
+    )->toThrow(ValidationException::class);
+});

--- a/tests/Feature/Actions/Plugins/PluginsActionTest.php
+++ b/tests/Feature/Actions/Plugins/PluginsActionTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use FluxErp\Actions\Plugins\Install;
+use FluxErp\Actions\Plugins\Uninstall;
+
+test('install plugin requires packages', function (): void {
+    Install::assertValidationErrors([], 'packages');
+});
+
+test('uninstall plugin requires packages', function (): void {
+    Uninstall::assertValidationErrors([], 'packages');
+});

--- a/tests/Feature/Actions/Price/PriceActionTest.php
+++ b/tests/Feature/Actions/Price/PriceActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use FluxErp\Actions\Price\CreatePrice;
+use FluxErp\Actions\Price\DeletePrice;
+use FluxErp\Actions\Price\UpdatePrice;
+use FluxErp\Models\Price;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Product;
+
+beforeEach(function (): void {
+    $this->product = Product::factory()->create();
+    $this->priceList = PriceList::factory()->create();
+});
+
+test('create price', function (): void {
+    $price = CreatePrice::make([
+        'product_id' => $this->product->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'price' => 99.99,
+    ])->validate()->execute();
+
+    expect($price)->toBeInstanceOf(Price::class)
+        ->price->toEqual(99.99);
+});
+
+test('create price requires product price_list and price', function (): void {
+    CreatePrice::assertValidationErrors([], ['product_id', 'price_list_id', 'price']);
+});
+
+test('update price', function (): void {
+    $price = Price::factory()->create([
+        'product_id' => $this->product->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+    ]);
+
+    $updated = UpdatePrice::make([
+        'id' => $price->getKey(),
+        'price' => 149.99,
+    ])->validate()->execute();
+
+    expect($updated->price)->toEqual(149.99);
+});
+
+test('delete price', function (): void {
+    $price = Price::factory()->create([
+        'product_id' => $this->product->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+    ]);
+
+    expect(DeletePrice::make(['id' => $price->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PriceList/PriceListActionTest.php
+++ b/tests/Feature/Actions/PriceList/PriceListActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use FluxErp\Actions\PriceList\CreatePriceList;
+use FluxErp\Actions\PriceList\DeletePriceList;
+use FluxErp\Actions\PriceList\UpdatePriceList;
+use FluxErp\Models\PriceList;
+
+test('create price list', function (): void {
+    $list = CreatePriceList::make([
+        'name' => 'Retail',
+        'price_list_code' => 'RET',
+        'is_net' => true,
+        'rounding_method_enum' => 'none',
+    ])->validate()->execute();
+
+    expect($list)->toBeInstanceOf(PriceList::class)
+        ->name->toBe('Retail')
+        ->price_list_code->toBe('RET');
+});
+
+test('create price list requires name code and is_net', function (): void {
+    CreatePriceList::assertValidationErrors([], ['name', 'price_list_code', 'is_net']);
+});
+
+test('update price list', function (): void {
+    $list = CreatePriceList::make([
+        'name' => 'Original',
+        'price_list_code' => 'ORI',
+        'is_net' => true,
+        'rounding_method_enum' => 'none',
+    ])->validate()->execute();
+
+    $updated = UpdatePriceList::make([
+        'id' => $list->getKey(),
+        'name' => 'Wholesale',
+        'rounding_method_enum' => 'none',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Wholesale');
+});
+
+test('delete price list', function (): void {
+    $list = CreatePriceList::make([
+        'name' => 'Temp',
+        'price_list_code' => 'TMP',
+        'is_net' => true,
+        'rounding_method_enum' => 'none',
+    ])->validate()->execute();
+
+    expect(DeletePriceList::make(['id' => $list->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PrintJob/PrintJobActionTest.php
+++ b/tests/Feature/Actions/PrintJob/PrintJobActionTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use FluxErp\Actions\PrintJob\CreatePrintJob;
+
+test('create print job requires printer_id and media_id', function (): void {
+    CreatePrintJob::assertValidationErrors([], ['printer_id', 'media_id']);
+});

--- a/tests/Feature/Actions/Printer/PrinterActionTest.php
+++ b/tests/Feature/Actions/Printer/PrinterActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Actions\Printer\CreatePrinter;
+use FluxErp\Actions\Printer\DeletePrinter;
+use FluxErp\Actions\Printer\UpdatePrinter;
+
+test('create printer', function (): void {
+    $printer = CreatePrinter::make([
+        'name' => 'Office Printer',
+        'spooler_name' => 'hp-laserjet',
+        'media_sizes' => ['A4', 'A3'],
+    ])->validate()->execute();
+
+    expect($printer)->name->toBe('Office Printer');
+});
+
+test('create printer requires name spooler_name media_sizes', function (): void {
+    CreatePrinter::assertValidationErrors([], ['name', 'spooler_name', 'media_sizes']);
+});
+
+test('update printer', function (): void {
+    $printer = CreatePrinter::make([
+        'name' => 'Original',
+        'spooler_name' => 'old-spooler',
+        'media_sizes' => ['A4'],
+    ])->validate()->execute();
+
+    $updated = UpdatePrinter::make([
+        'id' => $printer->getKey(),
+        'name' => 'New Printer',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('New Printer');
+});
+
+test('delete printer', function (): void {
+    $printer = CreatePrinter::make([
+        'name' => 'Temp',
+        'spooler_name' => 'temp-spooler',
+        'media_sizes' => ['A4'],
+    ])->validate()->execute();
+
+    expect(DeletePrinter::make(['id' => $printer->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PrinterUser/PrinterUserActionTest.php
+++ b/tests/Feature/Actions/PrinterUser/PrinterUserActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use FluxErp\Actions\Printer\CreatePrinter;
+use FluxErp\Actions\PrinterUser\CreatePrinterUser;
+use FluxErp\Actions\PrinterUser\DeletePrinterUser;
+
+beforeEach(function (): void {
+    $this->printer = CreatePrinter::make([
+        'name' => 'Test Printer',
+        'spooler_name' => 'test-spooler',
+        'media_sizes' => ['A4'],
+    ])->validate()->execute();
+});
+
+test('create printer user', function (): void {
+    $pu = CreatePrinterUser::make([
+        'printer_id' => $this->printer->getKey(),
+        'user_id' => $this->user->getKey(),
+    ])->validate()->execute();
+
+    expect($pu)
+        ->printer_id->toBe($this->printer->getKey())
+        ->user_id->toBe($this->user->getKey());
+});
+
+test('create printer user requires printer_id and user_id', function (): void {
+    CreatePrinterUser::assertValidationErrors([], ['printer_id', 'user_id']);
+});
+
+test('delete printer user', function (): void {
+    $pu = CreatePrinterUser::make([
+        'printer_id' => $this->printer->getKey(),
+        'user_id' => $this->user->getKey(),
+    ])->validate()->execute();
+
+    expect(DeletePrinterUser::make(['pivot_id' => $pu->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Product/ProductActionTest.php
+++ b/tests/Feature/Actions/Product/ProductActionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use FluxErp\Actions\Product\CreateProduct;
+use FluxErp\Actions\Product\DeleteProduct;
+use FluxErp\Actions\Product\UpdateProduct;
+use FluxErp\Models\Product;
+
+test('create product with defaults', function (): void {
+    $product = CreateProduct::make([
+        'name' => 'Test Widget',
+    ])->validate()->execute();
+
+    expect($product)
+        ->toBeInstanceOf(Product::class)
+        ->name->toBe('Test Widget')
+        ->vat_rate_id->not->toBeNull();
+});
+
+test('create product requires name', function (): void {
+    CreateProduct::assertValidationErrors([], 'name');
+});
+
+test('update product', function (): void {
+    $product = Product::factory()->create();
+
+    $updated = UpdateProduct::make([
+        'id' => $product->getKey(),
+        'name' => 'Updated Widget',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Widget');
+});
+
+test('update product detects parent-child cycle', function (): void {
+    $parent = Product::factory()->create();
+    $child = Product::factory()->create(['parent_id' => $parent->getKey()]);
+
+    UpdateProduct::assertValidationErrors([
+        'id' => $parent->getKey(),
+        'parent_id' => $child->getKey(),
+    ], 'parent_id');
+});
+
+test('delete product', function (): void {
+    $product = Product::factory()->create();
+
+    $result = DeleteProduct::make(['id' => $product->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});
+
+test('delete product with children fails', function (): void {
+    $parent = Product::factory()->create();
+    Product::factory()->create(['parent_id' => $parent->getKey()]);
+
+    expect(fn () => DeleteProduct::make(['id' => $parent->getKey()])
+        ->validate()->execute()
+    )->toThrow(Illuminate\Validation\ValidationException::class);
+});

--- a/tests/Feature/Actions/ProductCrossSelling/ProductCrossSellingActionTest.php
+++ b/tests/Feature/Actions/ProductCrossSelling/ProductCrossSellingActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use FluxErp\Actions\ProductCrossSelling\CreateProductCrossSelling;
+use FluxErp\Actions\ProductCrossSelling\DeleteProductCrossSelling;
+use FluxErp\Actions\ProductCrossSelling\UpdateProductCrossSelling;
+use FluxErp\Models\Product;
+
+beforeEach(function (): void {
+    $this->product = Product::factory()->create();
+});
+
+test('create product cross selling', function (): void {
+    $cs = CreateProductCrossSelling::make([
+        'product_id' => $this->product->getKey(),
+        'name' => 'Also bought',
+    ])->validate()->execute();
+
+    expect($cs)->name->toBe('Also bought');
+});
+
+test('create product cross selling requires product_id and name', function (): void {
+    CreateProductCrossSelling::assertValidationErrors([], ['product_id', 'name']);
+});
+
+test('update product cross selling', function (): void {
+    $cs = CreateProductCrossSelling::make([
+        'product_id' => $this->product->getKey(),
+        'name' => 'Original',
+    ])->validate()->execute();
+
+    $updated = UpdateProductCrossSelling::make([
+        'id' => $cs->getKey(),
+        'name' => 'Frequently paired',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Frequently paired');
+});
+
+test('delete product cross selling', function (): void {
+    $cs = CreateProductCrossSelling::make([
+        'product_id' => $this->product->getKey(),
+        'name' => 'Temp',
+    ])->validate()->execute();
+
+    expect(DeleteProductCrossSelling::make(['id' => $cs->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/ProductOption/ProductOptionActionTest.php
+++ b/tests/Feature/Actions/ProductOption/ProductOptionActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use FluxErp\Actions\ProductOption\CreateProductOption;
+use FluxErp\Actions\ProductOption\DeleteProductOption;
+use FluxErp\Actions\ProductOption\UpdateProductOption;
+use FluxErp\Models\ProductOption;
+use FluxErp\Models\ProductOptionGroup;
+
+beforeEach(function (): void {
+    $this->group = ProductOptionGroup::factory()->create();
+});
+
+test('create product option', function (): void {
+    $option = CreateProductOption::make([
+        'product_option_group_id' => $this->group->getKey(),
+        'name' => 'Red',
+    ])->validate()->execute();
+
+    expect($option)->toBeInstanceOf(ProductOption::class)
+        ->name->toBe('Red');
+});
+
+test('create product option requires group and name', function (): void {
+    CreateProductOption::assertValidationErrors([], ['product_option_group_id', 'name']);
+});
+
+test('update product option', function (): void {
+    $option = ProductOption::factory()->create([
+        'product_option_group_id' => $this->group->getKey(),
+    ]);
+
+    $updated = UpdateProductOption::make([
+        'id' => $option->getKey(),
+        'name' => 'Blue',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Blue');
+});
+
+test('delete product option', function (): void {
+    $option = ProductOption::factory()->create([
+        'product_option_group_id' => $this->group->getKey(),
+    ]);
+
+    expect(DeleteProductOption::make(['id' => $option->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/ProductOptionGroup/ProductOptionGroupActionTest.php
+++ b/tests/Feature/Actions/ProductOptionGroup/ProductOptionGroupActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\ProductOptionGroup\CreateProductOptionGroup;
+use FluxErp\Actions\ProductOptionGroup\DeleteProductOptionGroup;
+use FluxErp\Actions\ProductOptionGroup\UpdateProductOptionGroup;
+use FluxErp\Models\ProductOptionGroup;
+
+test('create product option group', function (): void {
+    $group = CreateProductOptionGroup::make(['name' => 'Color'])
+        ->validate()->execute();
+
+    expect($group)->toBeInstanceOf(ProductOptionGroup::class)
+        ->name->toBe('Color');
+});
+
+test('create product option group requires name', function (): void {
+    CreateProductOptionGroup::assertValidationErrors([], 'name');
+});
+
+test('update product option group', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+
+    $updated = UpdateProductOptionGroup::make([
+        'id' => $group->getKey(),
+        'name' => 'Size',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Size');
+});
+
+test('delete product option group', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+
+    expect(DeleteProductOptionGroup::make(['id' => $group->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/ProductProperty/ProductPropertyActionTest.php
+++ b/tests/Feature/Actions/ProductProperty/ProductPropertyActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use FluxErp\Actions\ProductProperty\CreateProductProperty;
+use FluxErp\Actions\ProductProperty\DeleteProductProperty;
+use FluxErp\Actions\ProductProperty\UpdateProductProperty;
+use FluxErp\Models\ProductProperty;
+
+test('create product property', function (): void {
+    $prop = CreateProductProperty::make([
+        'name' => 'Weight',
+        'property_type_enum' => 'text',
+    ])->validate()->execute();
+
+    expect($prop)->toBeInstanceOf(ProductProperty::class)
+        ->name->toBe('Weight');
+});
+
+test('create product property requires name and type', function (): void {
+    CreateProductProperty::assertValidationErrors([], ['name', 'property_type_enum']);
+});
+
+test('update product property', function (): void {
+    $prop = ProductProperty::factory()->create();
+
+    $updated = UpdateProductProperty::make([
+        'id' => $prop->getKey(),
+        'name' => 'Dimensions',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Dimensions');
+});
+
+test('delete product property', function (): void {
+    $prop = ProductProperty::factory()->create();
+
+    expect(DeleteProductProperty::make(['id' => $prop->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/ProductPropertyGroup/ProductPropertyGroupActionTest.php
+++ b/tests/Feature/Actions/ProductPropertyGroup/ProductPropertyGroupActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\ProductPropertyGroup\CreateProductPropertyGroup;
+use FluxErp\Actions\ProductPropertyGroup\DeleteProductPropertyGroup;
+use FluxErp\Actions\ProductPropertyGroup\UpdateProductPropertyGroup;
+
+test('create product property group', function (): void {
+    $group = CreateProductPropertyGroup::make(['name' => 'Physical'])
+        ->validate()->execute();
+
+    expect($group)->name->toBe('Physical');
+});
+
+test('create product property group requires name', function (): void {
+    CreateProductPropertyGroup::assertValidationErrors([], 'name');
+});
+
+test('update product property group', function (): void {
+    $group = CreateProductPropertyGroup::make(['name' => 'Original'])
+        ->validate()->execute();
+
+    $updated = UpdateProductPropertyGroup::make([
+        'id' => $group->getKey(),
+        'name' => 'Technical',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Technical');
+});
+
+test('delete product property group', function (): void {
+    $group = CreateProductPropertyGroup::make(['name' => 'Temp'])
+        ->validate()->execute();
+
+    expect(DeleteProductPropertyGroup::make(['id' => $group->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Project/ProjectActionTest.php
+++ b/tests/Feature/Actions/Project/ProjectActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Actions\Project\CreateProject;
+use FluxErp\Actions\Project\DeleteProject;
+use FluxErp\Actions\Project\UpdateProject;
+use FluxErp\Models\Project;
+
+test('create project', function (): void {
+    $project = CreateProject::make([
+        'name' => 'Website Redesign',
+        'tenant_id' => $this->dbTenant->getKey(),
+    ])->validate()->execute();
+
+    expect($project)->toBeInstanceOf(Project::class)
+        ->name->toBe('Website Redesign');
+});
+
+test('create project requires name', function (): void {
+    CreateProject::assertValidationErrors(
+        ['tenant_id' => $this->dbTenant->getKey()],
+        'name'
+    );
+});
+
+test('update project', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $updated = UpdateProject::make([
+        'id' => $project->getKey(),
+        'name' => 'App Rewrite',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('App Rewrite');
+});
+
+test('delete project', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    expect(DeleteProject::make(['id' => $project->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PurchaseInvoice/PurchaseInvoiceActionTest.php
+++ b/tests/Feature/Actions/PurchaseInvoice/PurchaseInvoiceActionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use FluxErp\Actions\PurchaseInvoice\DeletePurchaseInvoice;
+use FluxErp\Actions\PurchaseInvoice\UpdatePurchaseInvoice;
+use FluxErp\Models\PurchaseInvoice;
+
+test('update purchase invoice', function (): void {
+    $pi = PurchaseInvoice::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $updated = UpdatePurchaseInvoice::make([
+        'id' => $pi->getKey(),
+        'invoice_number' => 'PI-2026-001',
+    ])->validate()->execute();
+
+    expect($updated->invoice_number)->toBe('PI-2026-001');
+});
+
+test('delete purchase invoice', function (): void {
+    $pi = PurchaseInvoice::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $result = DeletePurchaseInvoice::make(['id' => $pi->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/PurchaseInvoicePosition/PurchaseInvoicePositionActionTest.php
+++ b/tests/Feature/Actions/PurchaseInvoicePosition/PurchaseInvoicePositionActionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use FluxErp\Actions\PurchaseInvoicePosition\CreatePurchaseInvoicePosition;
+use FluxErp\Actions\PurchaseInvoicePosition\DeletePurchaseInvoicePosition;
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\PurchaseInvoice;
+use FluxErp\Models\VatRate;
+
+beforeEach(function (): void {
+    $this->purchaseInvoice = PurchaseInvoice::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+    $this->ledgerAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+    $this->vatRate = VatRate::factory()->create();
+});
+
+test('create purchase invoice position', function (): void {
+    $position = CreatePurchaseInvoicePosition::make([
+        'purchase_invoice_id' => $this->purchaseInvoice->getKey(),
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'name' => 'Office Supplies',
+        'amount' => 1,
+        'unit_price' => 100.00,
+        'total_price' => 100.00,
+    ])->validate()->execute();
+
+    expect($position)->name->toBe('Office Supplies');
+});
+
+test('create purchase invoice position requires purchase_invoice_id', function (): void {
+    CreatePurchaseInvoicePosition::assertValidationErrors([], 'purchase_invoice_id');
+});
+
+test('delete purchase invoice position', function (): void {
+    $position = CreatePurchaseInvoicePosition::make([
+        'purchase_invoice_id' => $this->purchaseInvoice->getKey(),
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'name' => 'Temp',
+        'amount' => 1,
+        'unit_price' => 50.00,
+        'total_price' => 50.00,
+    ])->validate()->execute();
+
+    expect(DeletePurchaseInvoicePosition::make(['id' => $position->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/PushSubscription/PushSubscriptionActionTest.php
+++ b/tests/Feature/Actions/PushSubscription/PushSubscriptionActionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use FluxErp\Actions\PushSubscription\UpsertPushSubscription;
+
+test('upsert push subscription', function (): void {
+    $sub = UpsertPushSubscription::make([
+        'endpoint' => 'https://fcm.googleapis.com/fcm/send/test-endpoint',
+        'keys' => [
+            'p256dh' => 'test-p256dh-key',
+            'auth' => 'test-auth-key',
+        ],
+    ])->validate()->execute();
+
+    expect($sub)->endpoint->toBe('https://fcm.googleapis.com/fcm/send/test-endpoint');
+});
+
+test('upsert push subscription requires endpoint and keys', function (): void {
+    UpsertPushSubscription::assertValidationErrors([], ['endpoint', 'keys']);
+});

--- a/tests/Feature/Actions/RecordOrigin/RecordOriginActionTest.php
+++ b/tests/Feature/Actions/RecordOrigin/RecordOriginActionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use FluxErp\Actions\RecordOrigin\CreateRecordOrigin;
+use FluxErp\Actions\RecordOrigin\DeleteRecordOrigin;
+use FluxErp\Actions\RecordOrigin\UpdateRecordOrigin;
+use FluxErp\Models\RecordOrigin;
+
+test('create record origin', function (): void {
+    $origin = CreateRecordOrigin::make([
+        'name' => 'Webshop',
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+    ])->validate()->execute();
+
+    expect($origin)->toBeInstanceOf(RecordOrigin::class)
+        ->name->toBe('Webshop');
+});
+
+test('create record origin requires name and model_type', function (): void {
+    CreateRecordOrigin::assertValidationErrors([], ['name', 'model_type']);
+});
+
+test('update record origin', function (): void {
+    $origin = RecordOrigin::factory()->create([
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+    ]);
+
+    $updated = UpdateRecordOrigin::make([
+        'id' => $origin->getKey(),
+        'name' => 'Phone',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Phone');
+});
+
+test('delete record origin', function (): void {
+    $origin = RecordOrigin::factory()->create([
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+    ]);
+
+    expect(DeleteRecordOrigin::make(['id' => $origin->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Role/RoleActionTest.php
+++ b/tests/Feature/Actions/Role/RoleActionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use FluxErp\Actions\Role\CreateRole;
+use FluxErp\Actions\Role\DeleteRole;
+use FluxErp\Actions\Role\UpdateRole;
+use FluxErp\Models\Role;
+use Illuminate\Validation\ValidationException;
+
+test('create role', function (): void {
+    $role = CreateRole::make([
+        'name' => 'Editor',
+        'guard_name' => 'web',
+    ])->validate()->execute();
+
+    expect($role)
+        ->toBeInstanceOf(Role::class)
+        ->name->toBe('Editor');
+});
+
+test('create role requires name', function (): void {
+    CreateRole::assertValidationErrors([], 'name');
+});
+
+test('update role', function (): void {
+    $role = Role::factory()->create(['guard_name' => 'web']);
+
+    $updated = UpdateRole::make([
+        'id' => $role->getKey(),
+        'name' => 'Admin',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Admin');
+});
+
+test('delete role', function (): void {
+    $role = Role::factory()->create(['guard_name' => 'web']);
+
+    expect(DeleteRole::make(['id' => $role->getKey()])
+        ->validate()->execute())->toBeTrue();
+});
+
+test('cannot delete super admin role', function (): void {
+    $role = Role::factory()->create(['name' => 'Super Admin', 'guard_name' => 'web']);
+
+    expect(fn () => DeleteRole::make(['id' => $role->getKey()])
+        ->validate()->execute()
+    )->toThrow(ValidationException::class);
+});

--- a/tests/Feature/Actions/Schedule/ScheduleActionTest.php
+++ b/tests/Feature/Actions/Schedule/ScheduleActionTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use FluxErp\Actions\Schedule\CreateSchedule;
+
+test('create schedule requires name and cron', function (): void {
+    CreateSchedule::assertValidationErrors([], ['name', 'cron']);
+});

--- a/tests/Feature/Actions/SepaMandate/SepaMandateActionTest.php
+++ b/tests/Feature/Actions/SepaMandate/SepaMandateActionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use FluxErp\Actions\SepaMandate\CreateSepaMandate;
+use FluxErp\Actions\SepaMandate\DeleteSepaMandate;
+use FluxErp\Actions\SepaMandate\UpdateSepaMandate;
+use FluxErp\Models\Contact;
+
+test('create sepa mandate', function (): void {
+    $contact = Contact::factory()->create();
+
+    $mandate = CreateSepaMandate::make([
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sepa_mandate_type_enum' => 'BASIC',
+    ])->validate()->execute();
+
+    expect($mandate)->contact_id->toBe($contact->getKey());
+});
+
+test('create sepa mandate requires contact_id tenant_id type', function (): void {
+    CreateSepaMandate::assertValidationErrors([], ['contact_id', 'tenant_id', 'sepa_mandate_type_enum']);
+});
+
+test('update sepa mandate', function (): void {
+    $contact = Contact::factory()->create();
+    $mandate = CreateSepaMandate::make([
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sepa_mandate_type_enum' => 'BASIC',
+    ])->validate()->execute();
+
+    $updated = UpdateSepaMandate::make([
+        'id' => $mandate->getKey(),
+        'signed_date' => '2026-04-01',
+    ])->validate()->execute();
+
+    expect($updated->signed_date)->not->toBeNull();
+});
+
+test('delete sepa mandate', function (): void {
+    $contact = Contact::factory()->create();
+    $mandate = CreateSepaMandate::make([
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sepa_mandate_type_enum' => 'BASIC',
+    ])->validate()->execute();
+
+    expect(DeleteSepaMandate::make(['id' => $mandate->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/SerialNumber/SerialNumberActionTest.php
+++ b/tests/Feature/Actions/SerialNumber/SerialNumberActionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use FluxErp\Actions\SerialNumber\CreateSerialNumber;
+use FluxErp\Actions\SerialNumber\DeleteSerialNumber;
+use FluxErp\Actions\SerialNumber\UpdateSerialNumber;
+use FluxErp\Models\SerialNumber;
+
+test('create serial number', function (): void {
+    $sn = CreateSerialNumber::make([
+        'serial_number' => 'SN-2026-001',
+    ])->validate()->execute();
+
+    expect($sn)->toBeInstanceOf(SerialNumber::class)
+        ->serial_number->toBe('SN-2026-001');
+});
+
+test('create serial number requires serial_number', function (): void {
+    CreateSerialNumber::assertValidationErrors([], 'serial_number');
+});
+
+test('update serial number', function (): void {
+    $sn = SerialNumber::factory()->create();
+
+    $updated = UpdateSerialNumber::make([
+        'id' => $sn->getKey(),
+        'serial_number' => 'SN-UPDATED',
+    ])->validate()->execute();
+
+    expect($updated->serial_number)->toBe('SN-UPDATED');
+});
+
+test('delete serial number', function (): void {
+    $sn = SerialNumber::factory()->create();
+
+    expect(DeleteSerialNumber::make(['id' => $sn->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/SerialNumberRange/SerialNumberRangeActionTest.php
+++ b/tests/Feature/Actions/SerialNumberRange/SerialNumberRangeActionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use FluxErp\Actions\SerialNumberRange\CreateSerialNumberRange;
+use FluxErp\Actions\SerialNumberRange\DeleteSerialNumberRange;
+use FluxErp\Actions\SerialNumberRange\UpdateSerialNumberRange;
+
+test('create serial number range', function (): void {
+    $range = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+        'type' => 'order_number',
+        'start_number' => 1000,
+    ])->validate()->execute();
+
+    expect($range)
+        ->type->toBe('order_number')
+        ->current_number->toBe(999); // start_number is decremented
+});
+
+test('create serial number range requires tenant model_type and type', function (): void {
+    CreateSerialNumberRange::assertValidationErrors([], ['tenant_id', 'model_type', 'type']);
+});
+
+test('update serial number range', function (): void {
+    $range = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+        'type' => 'order_number',
+        'start_number' => 1000,
+    ])->validate()->execute();
+
+    $updated = UpdateSerialNumberRange::make([
+        'id' => $range->getKey(),
+        'prefix' => 'ORD-',
+    ])->validate()->execute();
+
+    expect($updated->prefix)->toBe('ORD-');
+});
+
+test('delete serial number range', function (): void {
+    $range = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(FluxErp\Models\Order::class),
+        'type' => 'temp_number',
+        'start_number' => 1,
+    ])->validate()->execute();
+
+    expect(DeleteSerialNumberRange::make(['id' => $range->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Setting/SettingActionTest.php
+++ b/tests/Feature/Actions/Setting/SettingActionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use FluxErp\Actions\Setting\UpdateSetting;
+use FluxErp\Settings\CoreSettings;
+
+test('update setting', function (): void {
+    $result = UpdateSetting::make([
+        'settings_class' => CoreSettings::class,
+        'formal_salutation' => true,
+    ])->validate()->execute();
+
+    expect($result)->toBeInstanceOf(FluxErp\Settings\FluxSettings::class);
+});
+
+test('update setting requires settings_class', function (): void {
+    UpdateSetting::assertValidationErrors([], 'settings_class');
+});

--- a/tests/Feature/Actions/StockPosting/StockPostingActionTest.php
+++ b/tests/Feature/Actions/StockPosting/StockPostingActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\StockPosting\CreateStockPosting;
+use FluxErp\Actions\StockPosting\DeleteStockPosting;
+use FluxErp\Models\Product;
+use FluxErp\Models\StockPosting;
+use FluxErp\Models\Warehouse;
+
+beforeEach(function (): void {
+    $this->warehouse = Warehouse::factory()->create();
+    $this->product = Product::factory()->create();
+});
+
+test('create stock posting', function (): void {
+    $posting = CreateStockPosting::make([
+        'warehouse_id' => $this->warehouse->getKey(),
+        'product_id' => $this->product->getKey(),
+        'posting' => 10,
+    ])->validate()->execute();
+
+    expect($posting)->toBeInstanceOf(StockPosting::class);
+});
+
+test('create stock posting requires warehouse product and posting', function (): void {
+    CreateStockPosting::assertValidationErrors([], ['warehouse_id', 'product_id', 'posting']);
+});
+
+test('delete stock posting', function (): void {
+    $posting = StockPosting::factory()->create([
+        'warehouse_id' => $this->warehouse->getKey(),
+        'product_id' => $this->product->getKey(),
+    ]);
+
+    expect(DeleteStockPosting::make(['id' => $posting->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Tag/TagActionTest.php
+++ b/tests/Feature/Actions/Tag/TagActionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use FluxErp\Actions\Tag\CreateTag;
+use FluxErp\Actions\Tag\DeleteTag;
+use FluxErp\Actions\Tag\UpdateTag;
+use FluxErp\Models\Tag;
+use Illuminate\Validation\ValidationException;
+
+test('create tag', function (): void {
+    $tag = CreateTag::make([
+        'name' => 'VIP',
+        'type' => morph_alias(FluxErp\Models\Contact::class),
+    ])->validate()->execute();
+
+    expect($tag)->toBeInstanceOf(Tag::class)
+        ->name->toBe('VIP');
+});
+
+test('create tag requires name', function (): void {
+    CreateTag::assertValidationErrors([], 'name');
+});
+
+test('create duplicate tag name+type fails', function (): void {
+    Tag::factory()->create(['name' => 'VIP', 'type' => 'contact']);
+
+    expect(fn () => CreateTag::make([
+        'name' => 'VIP',
+        'type' => 'contact',
+    ])->validate())->toThrow(ValidationException::class);
+});
+
+test('update tag', function (): void {
+    $tag = Tag::factory()->create();
+
+    $updated = UpdateTag::make([
+        'id' => $tag->getKey(),
+        'name' => 'Premium',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Premium');
+});
+
+test('delete tag', function (): void {
+    $tag = Tag::factory()->create();
+
+    expect(DeleteTag::make(['id' => $tag->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Target/TargetActionTest.php
+++ b/tests/Feature/Actions/Target/TargetActionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use FluxErp\Actions\Target\CreateTarget;
+use FluxErp\Actions\Target\DeleteTarget;
+use FluxErp\Actions\Target\UpdateTarget;
+
+test('create target for order positions', function (): void {
+    $target = CreateTarget::make([
+        'name' => 'Monthly Revenue',
+        'target_value' => 50000,
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'model_type' => morph_alias(FluxErp\Models\OrderPosition::class),
+        'timeframe_column' => 'created_at',
+        'aggregate_type' => 'sum',
+        'aggregate_column' => 'total_net_price',
+        'owner_column' => 'created_by',
+    ])->validate()->execute();
+
+    expect($target)->name->toBe('Monthly Revenue');
+});
+
+test('create target requires all fields', function (): void {
+    CreateTarget::assertValidationErrors([], [
+        'name', 'target_value', 'start_date', 'end_date', 'model_type',
+        'timeframe_column', 'aggregate_type', 'aggregate_column',
+    ]);
+});
+
+test('create target rejects invalid timeframe column', function (): void {
+    expect(fn () => CreateTarget::make([
+        'name' => 'Bad Target',
+        'target_value' => 100,
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-12-31',
+        'model_type' => morph_alias(FluxErp\Models\OrderPosition::class),
+        'timeframe_column' => 'nonexistent_column',
+        'aggregate_type' => 'sum',
+        'aggregate_column' => 'total_net_price',
+    ])->validate())->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('update target', function (): void {
+    $target = CreateTarget::make([
+        'name' => 'Original',
+        'target_value' => 10000,
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-06-30',
+        'model_type' => morph_alias(FluxErp\Models\OrderPosition::class),
+        'timeframe_column' => 'created_at',
+        'aggregate_type' => 'count',
+        'aggregate_column' => 'id',
+        'owner_column' => 'created_by',
+    ])->validate()->execute();
+
+    $updated = UpdateTarget::make([
+        'id' => $target->getKey(),
+        'name' => 'Updated Target',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-06-30',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Target');
+});
+
+test('delete target', function (): void {
+    $target = CreateTarget::make([
+        'name' => 'Temp',
+        'target_value' => 1000,
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-03-31',
+        'model_type' => morph_alias(FluxErp\Models\OrderPosition::class),
+        'timeframe_column' => 'created_at',
+        'aggregate_type' => 'sum',
+        'aggregate_column' => 'amount',
+        'owner_column' => 'created_by',
+    ])->validate()->execute();
+
+    expect(DeleteTarget::make(['id' => $target->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Task/TaskActionTest.php
+++ b/tests/Feature/Actions/Task/TaskActionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use FluxErp\Actions\Task\CreateTask;
+use FluxErp\Actions\Task\DeleteTask;
+use FluxErp\Actions\Task\UpdateTask;
+use FluxErp\Models\Task;
+
+test('create task', function (): void {
+    $task = CreateTask::make([
+        'name' => 'Implement feature X',
+    ])->validate()->execute();
+
+    expect($task)
+        ->toBeInstanceOf(Task::class)
+        ->name->toBe('Implement feature X');
+});
+
+test('create task with dates', function (): void {
+    $task = CreateTask::make([
+        'name' => 'Deadline task',
+        'start_date' => '2026-04-01',
+        'due_date' => '2026-04-30',
+    ])->validate()->execute();
+
+    expect($task)
+        ->start_date->not->toBeNull()
+        ->due_date->not->toBeNull();
+});
+
+test('create task due_date must be after start_date', function (): void {
+    CreateTask::assertValidationErrors([
+        'name' => 'Invalid dates',
+        'start_date' => '2026-04-30',
+        'due_date' => '2026-04-01',
+    ], 'due_date');
+});
+
+test('create task with user assignment', function (): void {
+    $task = CreateTask::make([
+        'name' => 'Assigned task',
+        'users' => [$this->user->getKey()],
+    ])->validate()->execute();
+
+    expect($task->users)->toHaveCount(1);
+});
+
+test('update task', function (): void {
+    $task = Task::factory()->create();
+
+    $updated = UpdateTask::make([
+        'id' => $task->getKey(),
+        'name' => 'Updated task name',
+        'start_date' => $task->start_date,
+        'due_date' => $task->due_date,
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated task name');
+});
+
+test('delete task', function (): void {
+    $task = Task::factory()->create();
+
+    $result = DeleteTask::make(['id' => $task->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/Tenant/TenantActionTest.php
+++ b/tests/Feature/Actions/Tenant/TenantActionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use FluxErp\Actions\Tenant\CreateTenant;
+use FluxErp\Actions\Tenant\DeleteTenant;
+use FluxErp\Actions\Tenant\UpdateTenant;
+use FluxErp\Models\Tenant;
+
+test('create tenant', function (): void {
+    $tenant = CreateTenant::make([
+        'name' => 'Acme Inc.',
+        'tenant_code' => 'ACME',
+    ])->validate()->execute();
+
+    expect($tenant)->toBeInstanceOf(Tenant::class)
+        ->name->toBe('Acme Inc.');
+});
+
+test('update tenant', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    $updated = UpdateTenant::make([
+        'id' => $tenant->getKey(),
+        'name' => 'Updated Tenant',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Updated Tenant');
+});
+
+test('delete tenant', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    expect(DeleteTenant::make(['id' => $tenant->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Ticket/TicketActionTest.php
+++ b/tests/Feature/Actions/Ticket/TicketActionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use FluxErp\Actions\Ticket\CreateTicket;
+use FluxErp\Actions\Ticket\DeleteTicket;
+use FluxErp\Actions\Ticket\UpdateTicket;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\TicketType;
+
+beforeEach(function (): void {
+    $this->ticketType = TicketType::factory()->create();
+});
+
+test('create ticket', function (): void {
+    $ticket = CreateTicket::make([
+        'title' => 'Login broken',
+        'description' => 'Users cannot log in',
+        'ticket_type_id' => $this->ticketType->getKey(),
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+    ])->validate()->execute();
+
+    expect($ticket)
+        ->toBeInstanceOf(Ticket::class)
+        ->title->toBe('Login broken')
+        ->ticket_number->not->toBeNull();
+});
+
+test('create ticket auto generates ticket number', function (): void {
+    $ticket = CreateTicket::make([
+        'title' => 'Auto number test',
+        'description' => 'Testing auto number generation',
+        'ticket_type_id' => $this->ticketType->getKey(),
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+    ])->validate()->execute();
+
+    expect($ticket->ticket_number)->not->toBeEmpty();
+});
+
+test('update ticket', function (): void {
+    $ticket = Ticket::factory()->create([
+        'ticket_type_id' => $this->ticketType->getKey(),
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+    ]);
+
+    $updated = UpdateTicket::make([
+        'id' => $ticket->getKey(),
+        'title' => 'Updated title',
+    ])->validate()->execute();
+
+    expect($updated->title)->toBe('Updated title');
+});
+
+test('delete ticket', function (): void {
+    $ticket = Ticket::factory()->create([
+        'ticket_type_id' => $this->ticketType->getKey(),
+        'authenticatable_type' => morph_alias($this->user::class),
+        'authenticatable_id' => $this->user->getKey(),
+    ]);
+
+    $result = DeleteTicket::make(['id' => $ticket->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});

--- a/tests/Feature/Actions/TicketType/TicketTypeActionTest.php
+++ b/tests/Feature/Actions/TicketType/TicketTypeActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\TicketType\CreateTicketType;
+use FluxErp\Actions\TicketType\DeleteTicketType;
+use FluxErp\Actions\TicketType\UpdateTicketType;
+use FluxErp\Models\TicketType;
+
+test('create ticket type', function (): void {
+    $type = CreateTicketType::make(['name' => 'Bug Report'])
+        ->validate()->execute();
+
+    expect($type)->toBeInstanceOf(TicketType::class)
+        ->name->toBe('Bug Report');
+});
+
+test('create ticket type requires name', function (): void {
+    CreateTicketType::assertValidationErrors([], 'name');
+});
+
+test('update ticket type', function (): void {
+    $type = TicketType::factory()->create();
+
+    $updated = UpdateTicketType::make([
+        'id' => $type->getKey(),
+        'name' => 'Feature Request',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Feature Request');
+});
+
+test('delete ticket type', function (): void {
+    $type = TicketType::factory()->create();
+
+    expect(DeleteTicketType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Token/TokenActionTest.php
+++ b/tests/Feature/Actions/Token/TokenActionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use FluxErp\Actions\Token\CreateToken;
+use FluxErp\Actions\Token\DeleteToken;
+
+test('create token', function (): void {
+    $token = CreateToken::make([
+        'name' => 'API Token',
+        'abilities' => ['*'],
+    ])->validate()->execute();
+
+    expect($token)
+        ->name->toBe('API Token')
+        ->plain_text_token->not->toBeNull();
+});
+
+test('create token requires name', function (): void {
+    CreateToken::assertValidationErrors([], 'name');
+});
+
+test('delete token', function (): void {
+    $created = CreateToken::make([
+        'name' => 'to-delete',
+        'abilities' => ['*'],
+    ])->validate()->execute();
+
+    expect(DeleteToken::make(['id' => $created->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Transaction/TransactionActionTest.php
+++ b/tests/Feature/Actions/Transaction/TransactionActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use FluxErp\Actions\Transaction\CreateTransaction;
+use FluxErp\Actions\Transaction\DeleteTransaction;
+use FluxErp\Actions\Transaction\UpdateTransaction;
+use FluxErp\Models\BankConnection;
+use FluxErp\Models\Transaction;
+
+beforeEach(function (): void {
+    $this->bankConnection = BankConnection::factory()->create();
+});
+
+test('create transaction', function (): void {
+    $tx = CreateTransaction::make([
+        'bank_connection_id' => $this->bankConnection->getKey(),
+        'value_date' => '2026-04-01',
+        'booking_date' => '2026-04-01',
+        'amount' => 500.00,
+    ])->validate()->execute();
+
+    expect($tx)->toBeInstanceOf(Transaction::class);
+});
+
+test('create transaction requires bank_connection or contact_bank_connection', function (): void {
+    CreateTransaction::assertValidationErrors([
+        'value_date' => '2026-04-01',
+        'booking_date' => '2026-04-01',
+        'amount' => 100,
+    ], 'bank_connection_id');
+});
+
+test('update transaction', function (): void {
+    $tx = Transaction::factory()->create([
+        'bank_connection_id' => $this->bankConnection->getKey(),
+    ]);
+
+    $updated = UpdateTransaction::make([
+        'id' => $tx->getKey(),
+        'purpose' => 'Invoice payment',
+    ])->validate()->execute();
+
+    expect($updated->purpose)->toBe('Invoice payment');
+});
+
+test('delete transaction', function (): void {
+    $tx = Transaction::factory()->create([
+        'bank_connection_id' => $this->bankConnection->getKey(),
+    ]);
+
+    expect(DeleteTransaction::make(['id' => $tx->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Unit/UnitActionTest.php
+++ b/tests/Feature/Actions/Unit/UnitActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use FluxErp\Actions\Unit\CreateUnit;
+use FluxErp\Actions\Unit\DeleteUnit;
+use FluxErp\Actions\Unit\UpdateUnit;
+use FluxErp\Models\Unit;
+
+test('create unit', function (): void {
+    $unit = CreateUnit::make([
+        'name' => 'Kilogramm',
+        'abbreviation' => 'kg',
+    ])->validate()->execute();
+
+    expect($unit)
+        ->toBeInstanceOf(Unit::class)
+        ->name->toBe('Kilogramm')
+        ->abbreviation->toBe('kg');
+});
+
+test('create unit requires name', function (): void {
+    CreateUnit::assertValidationErrors(
+        ['abbreviation' => 'kg'],
+        'name'
+    );
+});
+
+test('create unit requires abbreviation', function (): void {
+    CreateUnit::assertValidationErrors(
+        ['name' => 'Kilogramm'],
+        'abbreviation'
+    );
+});
+
+test('update unit', function (): void {
+    $unit = Unit::factory()->create();
+
+    $updated = UpdateUnit::make([
+        'id' => $unit->getKey(),
+        'name' => 'Meter',
+    ])->validate()->execute();
+
+    expect($updated)
+        ->toBeInstanceOf(Unit::class)
+        ->name->toBe('Meter');
+});
+
+test('update unit requires id', function (): void {
+    UpdateUnit::assertValidationErrors(
+        ['name' => 'Meter'],
+        'id'
+    );
+});
+
+test('delete unit', function (): void {
+    $unit = Unit::factory()->create();
+
+    $result = DeleteUnit::make([
+        'id' => $unit->getKey(),
+    ])->validate()->execute();
+
+    expect($result)->toBeTrue();
+    expect(Unit::query()->whereKey($unit->getKey())->exists())->toBeFalse();
+});
+
+test('delete unit with invalid id fails validation', function (): void {
+    DeleteUnit::assertValidationErrors(
+        ['id' => 999999],
+        'id'
+    );
+});

--- a/tests/Feature/Actions/User/UserActionTest.php
+++ b/tests/Feature/Actions/User/UserActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use FluxErp\Actions\User\CreateUser;
+use FluxErp\Actions\User\DeleteUser;
+use FluxErp\Actions\User\UpdateUser;
+use FluxErp\Models\User;
+
+test('create user', function (): void {
+    $user = CreateUser::make([
+        'email' => 'new@example.com',
+        'firstname' => 'New',
+        'lastname' => 'User',
+        'user_code' => 'NU001',
+        'password' => 'Secret123!',
+        'language_id' => $this->defaultLanguage->getKey(),
+    ])->validate()->execute();
+
+    expect($user)
+        ->toBeInstanceOf(User::class)
+        ->email->toBe('new@example.com')
+        ->is_active->toBeTruthy();
+});
+
+test('create user requires email password and user_code', function (): void {
+    CreateUser::assertValidationErrors(
+        ['firstname' => 'Test'],
+        ['email', 'password', 'user_code']
+    );
+});
+
+test('update user', function (): void {
+    $user = User::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    $updated = UpdateUser::make([
+        'id' => $user->getKey(),
+        'firstname' => 'Updated',
+    ])->validate()->execute();
+
+    expect($updated->firstname)->toBe('Updated');
+});
+
+test('update user deactivation deletes tokens', function (): void {
+    $user = User::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_active' => true,
+    ]);
+    $user->createToken('test-token');
+
+    UpdateUser::make([
+        'id' => $user->getKey(),
+        'is_active' => false,
+    ])->validate()->execute();
+
+    expect($user->fresh()->tokens)->toHaveCount(0);
+});
+
+test('delete user', function (): void {
+    $user = User::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    $result = DeleteUser::make(['id' => $user->getKey()])
+        ->validate()->execute();
+
+    expect($result)->toBeTrue();
+});
+
+test('cannot delete self', function (): void {
+    DeleteUser::assertValidationErrors([
+        'id' => $this->user->getKey(),
+    ], 'id');
+});

--- a/tests/Feature/Actions/VacationBlackout/VacationBlackoutActionTest.php
+++ b/tests/Feature/Actions/VacationBlackout/VacationBlackoutActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Actions\VacationBlackout\CreateVacationBlackout;
+use FluxErp\Actions\VacationBlackout\DeleteVacationBlackout;
+use FluxErp\Actions\VacationBlackout\UpdateVacationBlackout;
+
+test('create vacation blackout', function (): void {
+    $blackout = CreateVacationBlackout::make([
+        'name' => 'Christmas Freeze',
+        'start_date' => '2026-12-20',
+        'end_date' => '2026-12-31',
+    ])->validate()->execute();
+
+    expect($blackout)->name->toBe('Christmas Freeze');
+});
+
+test('create vacation blackout requires name start and end', function (): void {
+    CreateVacationBlackout::assertValidationErrors([], ['name', 'start_date', 'end_date']);
+});
+
+test('update vacation blackout', function (): void {
+    $blackout = CreateVacationBlackout::make([
+        'name' => 'Original',
+        'start_date' => '2026-07-01',
+        'end_date' => '2026-07-15',
+    ])->validate()->execute();
+
+    $updated = UpdateVacationBlackout::make([
+        'id' => $blackout->getKey(),
+        'name' => 'Summer Freeze',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Summer Freeze');
+});
+
+test('delete vacation blackout', function (): void {
+    $blackout = CreateVacationBlackout::make([
+        'name' => 'Temp',
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-01-02',
+    ])->validate()->execute();
+
+    expect(DeleteVacationBlackout::make(['id' => $blackout->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/VacationCarryoverRule/VacationCarryoverRuleActionTest.php
+++ b/tests/Feature/Actions/VacationCarryoverRule/VacationCarryoverRuleActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\VacationCarryoverRule\CreateVacationCarryoverRule;
+use FluxErp\Actions\VacationCarryoverRule\DeleteVacationCarryoverRule;
+use FluxErp\Actions\VacationCarryoverRule\UpdateVacationCarryoverRule;
+
+test('create vacation carryover rule', function (): void {
+    $rule = CreateVacationCarryoverRule::make(['name' => 'Standard'])
+        ->validate()->execute();
+
+    expect($rule)->name->toBe('Standard');
+});
+
+test('create vacation carryover rule requires name', function (): void {
+    CreateVacationCarryoverRule::assertValidationErrors([], 'name');
+});
+
+test('update vacation carryover rule', function (): void {
+    $rule = CreateVacationCarryoverRule::make(['name' => 'Standard'])
+        ->validate()->execute();
+
+    $updated = UpdateVacationCarryoverRule::make([
+        'id' => $rule->getKey(),
+        'name' => 'Extended',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Extended');
+});
+
+test('delete vacation carryover rule', function (): void {
+    $rule = CreateVacationCarryoverRule::make(['name' => 'Temp'])
+        ->validate()->execute();
+
+    expect(DeleteVacationCarryoverRule::make(['id' => $rule->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/VatRate/VatRateActionTest.php
+++ b/tests/Feature/Actions/VatRate/VatRateActionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use FluxErp\Actions\VatRate\CreateVatRate;
+use FluxErp\Actions\VatRate\DeleteVatRate;
+use FluxErp\Actions\VatRate\UpdateVatRate;
+use FluxErp\Models\VatRate;
+
+test('create vat rate', function (): void {
+    $vat = CreateVatRate::make([
+        'name' => 'Reduced',
+        'rate_percentage' => 0.07,
+    ])->validate()->execute();
+
+    expect($vat)->toBeInstanceOf(VatRate::class)
+        ->name->toBe('Reduced')
+        ->rate_percentage->toEqual(0.07);
+});
+
+test('create vat rate requires name and rate_percentage', function (): void {
+    CreateVatRate::assertValidationErrors([], ['name', 'rate_percentage']);
+});
+
+test('update vat rate', function (): void {
+    $vat = VatRate::factory()->create();
+
+    $updated = UpdateVatRate::make([
+        'id' => $vat->getKey(),
+        'name' => 'Full Rate',
+        'rate_percentage' => 0.19,
+    ])->validate()->execute();
+
+    expect($updated)
+        ->name->toBe('Full Rate')
+        ->rate_percentage->toEqual(0.19);
+});
+
+test('delete vat rate', function (): void {
+    $vat = VatRate::factory()->create();
+
+    expect(DeleteVatRate::make(['id' => $vat->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/Warehouse/WarehouseActionTest.php
+++ b/tests/Feature/Actions/Warehouse/WarehouseActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Actions\Warehouse\CreateWarehouse;
+use FluxErp\Actions\Warehouse\DeleteWarehouse;
+use FluxErp\Actions\Warehouse\UpdateWarehouse;
+use FluxErp\Models\Warehouse;
+
+test('create warehouse', function (): void {
+    $warehouse = CreateWarehouse::make(['name' => 'Hauptlager'])
+        ->validate()->execute();
+
+    expect($warehouse)->toBeInstanceOf(Warehouse::class)
+        ->name->toBe('Hauptlager');
+});
+
+test('create warehouse requires name', function (): void {
+    CreateWarehouse::assertValidationErrors([], 'name');
+});
+
+test('update warehouse', function (): void {
+    $warehouse = Warehouse::factory()->create();
+
+    $updated = UpdateWarehouse::make([
+        'id' => $warehouse->getKey(),
+        'name' => 'Nebenlager',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Nebenlager');
+});
+
+test('delete warehouse', function (): void {
+    $warehouse = Warehouse::factory()->create();
+
+    expect(DeleteWarehouse::make(['id' => $warehouse->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/WorkTime/WorkTimeActionTest.php
+++ b/tests/Feature/Actions/WorkTime/WorkTimeActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use FluxErp\Actions\WorkTime\CreateWorkTime;
+use FluxErp\Actions\WorkTime\DeleteWorkTime;
+use FluxErp\Actions\WorkTime\UpdateWorkTime;
+use FluxErp\Models\WorkTime;
+
+test('create work time with time range', function (): void {
+    $wt = CreateWorkTime::make([
+        'user_id' => $this->user->getKey(),
+        'name' => 'Development',
+        'started_at' => '2026-04-05 08:00:00',
+        'ended_at' => '2026-04-05 16:00:00',
+    ])->validate()->execute();
+
+    expect($wt)->toBeInstanceOf(WorkTime::class);
+});
+
+test('create daily work time', function (): void {
+    $wt = CreateWorkTime::make([
+        'user_id' => $this->user->getKey(),
+        'is_daily_work_time' => true,
+    ])->validate()->execute();
+
+    expect($wt->is_daily_work_time)->toBeTruthy();
+});
+
+test('update work time', function (): void {
+    $wt = CreateWorkTime::make([
+        'user_id' => $this->user->getKey(),
+        'name' => 'Original',
+        'started_at' => '2026-04-05 09:00:00',
+        'ended_at' => '2026-04-05 17:00:00',
+    ])->validate()->execute();
+
+    $updated = UpdateWorkTime::make([
+        'id' => $wt->getKey(),
+        'description' => 'Updated description',
+        'is_locked' => false,
+    ])->validate()->execute();
+
+    expect($updated->description)->toBe('Updated description');
+});
+
+test('delete work time', function (): void {
+    $wt = CreateWorkTime::make([
+        'user_id' => $this->user->getKey(),
+        'name' => 'Temp',
+        'started_at' => '2026-04-05 10:00:00',
+        'ended_at' => '2026-04-05 11:00:00',
+    ])->validate()->execute();
+
+    expect(DeleteWorkTime::make(['id' => $wt->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/WorkTimeModel/WorkTimeModelActionTest.php
+++ b/tests/Feature/Actions/WorkTimeModel/WorkTimeModelActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use FluxErp\Actions\WorkTimeModel\CreateWorkTimeModel;
+use FluxErp\Actions\WorkTimeModel\DeleteWorkTimeModel;
+use FluxErp\Actions\WorkTimeModel\UpdateWorkTimeModel;
+
+test('create work time model', function (): void {
+    $model = CreateWorkTimeModel::make([
+        'name' => '40h Week',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+    ])->validate()->execute();
+
+    expect($model)->name->toBe('40h Week');
+});
+
+test('create work time model requires name and hours', function (): void {
+    CreateWorkTimeModel::assertValidationErrors([], ['name', 'weekly_hours']);
+});
+
+test('update work time model', function (): void {
+    $model = CreateWorkTimeModel::make([
+        'name' => '40h Week',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'payment',
+    ])->validate()->execute();
+
+    $updated = UpdateWorkTimeModel::make([
+        'id' => $model->getKey(),
+        'name' => '35h Week',
+        'weekly_hours' => 35,
+    ])->validate()->execute();
+
+    expect($updated)->name->toBe('35h Week');
+});
+
+test('delete work time model', function (): void {
+    $model = CreateWorkTimeModel::make([
+        'name' => 'Temp',
+        'cycle_weeks' => 1,
+        'weekly_hours' => 40,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => 'none',
+    ])->validate()->execute();
+
+    expect(DeleteWorkTimeModel::make(['id' => $model->getKey()])
+        ->validate()->execute())->toBeTrue();
+});

--- a/tests/Feature/Actions/WorkTimeType/WorkTimeTypeActionTest.php
+++ b/tests/Feature/Actions/WorkTimeType/WorkTimeTypeActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use FluxErp\Actions\WorkTimeType\CreateWorkTimeType;
+use FluxErp\Actions\WorkTimeType\DeleteWorkTimeType;
+use FluxErp\Actions\WorkTimeType\UpdateWorkTimeType;
+use FluxErp\Models\WorkTimeType;
+
+test('create work time type', function (): void {
+    $type = CreateWorkTimeType::make([
+        'name' => 'Entwicklung',
+        'is_billable' => true,
+    ])->validate()->execute();
+
+    expect($type)->toBeInstanceOf(WorkTimeType::class)
+        ->name->toBe('Entwicklung');
+});
+
+test('create work time type requires name', function (): void {
+    CreateWorkTimeType::assertValidationErrors([], 'name');
+});
+
+test('update work time type', function (): void {
+    $type = WorkTimeType::factory()->create();
+
+    $updated = UpdateWorkTimeType::make([
+        'id' => $type->getKey(),
+        'name' => 'Support',
+    ])->validate()->execute();
+
+    expect($updated->name)->toBe('Support');
+});
+
+test('delete work time type', function (): void {
+    $type = WorkTimeType::factory()->create();
+
+    expect(DeleteWorkTimeType::make(['id' => $type->getKey()])
+        ->validate()->execute())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
Fixes 15 bugs discovered during the action test audit (based on `feature/action-tests`).

## Fixes

### Runtime Errors (5)
- **CreateOrder**: `$contact->delivery_address_id` accessed before null guard — moved guard up
- **CreateOrderPosition**: `$order->contact->expense_ledger_account_id` crashes on null — added null-safe operator
- **UpdateAddress**: `$this->data['contact_id']` undefined key in address_types — added null-coalesce
- **UpdateWorkTime**: `$this->data['is_locked']` undefined key — use `data_get()`
- **UpdateWorkTime**: `ended_at` null when locking — guard with null check, default to 0

### Security (1)
- **UpdateAddress**: `can_login` validation bypassed when absent from payload — fallback to model value

### Wrong Behavior (9)
- **CreateTask**: same-day time validation ignored actual `start_time`/`due_time` — use provided times
- **CreateAddress/UpdateAddress**: `Str::between` silently cleared plain emails — only extract when `<` present
- **UpdateContact**: error message showed wrong payment_type_id — use resolved variable
- **UpdateContact**: null `payment_type_id` + tenant change triggered false error — skip when null
- **CreateOrder**: `keyBy('address_id')` destroyed `address_type_id` pivot — use `mapWithKeys`
- **CreateOrderPosition**: unconditional `vat_rate_id` overwrite — use `??=` to respect caller
- **UpdateAddress**: flag queries included current record — added `whereKeyNot`
- **UpdateWorkTime**: `paused_time_ms` delta used `now()` — use new `ended_at`
- **UpdateProduct**: Group bundle prices silently deleted after creation — skip prices block for Group

### Still Open (1 skipped)
- **CreateOrder**: hardcoded 19% VAT for shipping — needs business decision on where to source the rate

## Summary by Sourcery

Fix multiple action-layer bugs around validation, null handling, and email parsing, and add regression tests for the previously identified bug candidates.

Bug Fixes:
- Ensure CreateTask validates same-day tasks using provided start and due times, failing when the due time precedes the start time.
- Preserve plain email addresses in CreateAddress and UpdateAddress while still extracting emails from angle-bracket formats only when present.
- Prevent UpdateContact validation from failing on tenant changes when payment_type_id is null and fix the payment type mismatch error message to reference the resolved ID.
- Avoid crashes and respect caller-provided values in CreateOrder, CreateOrderPosition, UpdateWorkTime, and address flag handling when related entities or fields are missing or null.
- Ensure UpdateAddress flag queries exclude the current record and correctly enforce unique address types per contact.
- Prevent UpdateProduct from deleting prices for group bundle products by skipping the standard prices block for those bundles.

Tests:
- Convert previously skipped bug candidate tests into active regression tests covering task validation, address email parsing, contact/payment handling, order creation, order positions, work time updates, and the known shipping VAT limitation.