### PR TITLE
Fix export() method signature to match parent class

### DIFF
--- a/src/Livewire/DataTables/BaseDataTable.php
+++ b/src/Livewire/DataTables/BaseDataTable.php
@@ -7,6 +7,7 @@ use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Http\Response;
 use Livewire\Attributes\Renderless;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use TeamNiftyGmbH\DataTable\DataTable;
 use TeamNiftyGmbH\DataTable\Traits\HasEloquentListeners;
 
@@ -15,7 +16,7 @@ abstract class BaseDataTable extends DataTable
     use Actions, HasEloquentListeners;
 
     #[Renderless]
-    public function export(array $columns = []): Response|BinaryFileResponse
+    public function export(array $columns = [], string $format = 'xlsx'): Response|BinaryFileResponse|StreamedResponse
     {
         ExportDataTableJob::dispatch(
             serialize($this),


### PR DESCRIPTION
## Problem
`BaseDataTable::export()` had an incompatible signature with `SupportsExporting::export()` in tall-datatables v2:

- **BaseDataTable**: `export(array $columns = []): Response|BinaryFileResponse`
- **Parent**: `export(array $columns = [], string $format = 'xlsx'): Response|BinaryFileResponse|StreamedResponse`

Missing `$format` parameter and `StreamedResponse` return type caused a PHP declaration error.

## Fix
Add `string $format = 'xlsx'` parameter and `StreamedResponse` return type to match parent signature.

## Summary by Sourcery

Bug Fixes:
- Add the missing format parameter and StreamedResponse return type to the BaseDataTable export method so its signature matches the parent contract.