### PR TITLE
Fix child order position list showing empty table

### DIFF
--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -128,8 +128,12 @@
                     <div class="space-y-2">
                         @forelse($replicateOrder->order_positions as $index => $position)
                             @if(data_get($position, "is_free_text"))
-                                <div class="flex items-center justify-between rounded bg-gray-100 px-3 py-2 font-semibold dark:bg-secondary-700">
-                                    <span>{{ data_get($position, "name") }}</span>
+                                <div
+                                    class="dark:bg-secondary-700 flex items-center justify-between rounded bg-gray-100 px-3 py-2 font-semibold"
+                                >
+                                    <span
+                                        >{{ data_get($position, "name") }}</span
+                                    >
                                     <x-button
                                         color="red"
                                         icon="trash"

--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -127,59 +127,71 @@
                     </h3>
                     <div class="space-y-2">
                         @forelse($replicateOrder->order_positions as $index => $position)
-                            <x-flux::list-item :item="[]">
-                                <x-slot:value>
-                                    <div
-                                        class="flex w-full items-start justify-between"
-                                    >
-                                        <div class="flex-1">
-                                            <span>
-                                                {{ data_get($position, "name") }}
-                                            </span>
-                                            <div
-                                                class="text-sm text-gray-600 dark:text-gray-400"
-                                            >
-                                                {!! data_get($position, "description") !!}
-                                            </div>
-                                        </div>
-                                        <div class="ml-4 text-right">
-                                            <div class="font-semibold">
-                                                <span
-                                                    x-text="calculatePositionTotal($wire.replicateOrder.order_positions?.[{{ $index }}] || {}).toLocaleString(document.documentElement.lang, {minimumFractionDigits: 2, maximumFractionDigits: 2})"
-                                                ></span>
-                                                {{ data_get($parentOrder, "currency.symbol") }}
-                                            </div>
-                                            <div
-                                                class="text-sm text-gray-600 dark:text-gray-400"
-                                            >
-                                                {{ Number::currency(data_get($position, "is_net") ? data_get($position, "unit_net_price") : data_get($position, "unit_gross_price"), data_get($parentOrder, "currency.iso")) }}
-                                                @if(data_get($position, "unit_abbreviation"))
-                                                    / {{ data_get($position, "unit_abbreviation") }}
-                                                @endif
-                                            </div>
-                                            @if(data_get($position, "discount_percentage") && bccomp(data_get($position, "discount_percentage"), 0) === 1)
-                                                <div
-                                                    class="text-sm text-red-500"
-                                                >
-                                                    -{{ Number::percentage(bcmul(data_get($position, "discount_percentage") ?? 0, 100), 2) }} {{ __("Discount") }}
-                                                </div>
-                                            @endif
-                                        </div>
-                                    </div>
-                                </x-slot:value>
-                                <x-slot:actions>
-                                    <x-number
-                                        wire:model.number="replicateOrder.order_positions.{{ $index }}.amount"
-                                        min="0"
-                                        :max="data_get($position, 'amount', 0)"
-                                    />
+                            @if(data_get($position, "is_free_text"))
+                                <div class="flex items-center justify-between rounded bg-gray-100 px-3 py-2 font-semibold dark:bg-secondary-700">
+                                    <span>{{ data_get($position, "name") }}</span>
                                     <x-button
                                         color="red"
                                         icon="trash"
+                                        sm
                                         wire:click="removePosition({{ $index }})"
                                     />
-                                </x-slot:actions>
-                            </x-flux::list-item>
+                                </div>
+                            @else
+                                <x-flux::list-item :item="[]">
+                                    <x-slot:value>
+                                        <div
+                                            class="flex w-full items-start justify-between"
+                                        >
+                                            <div class="flex-1">
+                                                <span>
+                                                    {{ data_get($position, "name") }}
+                                                </span>
+                                                <div
+                                                    class="text-sm text-gray-600 dark:text-gray-400"
+                                                >
+                                                    {!! data_get($position, "description") !!}
+                                                </div>
+                                            </div>
+                                            <div class="ml-4 text-right">
+                                                <div class="font-semibold">
+                                                    <span
+                                                        x-text="calculatePositionTotal($wire.replicateOrder.order_positions?.[{{ $index }}] || {}).toLocaleString(document.documentElement.lang, {minimumFractionDigits: 2, maximumFractionDigits: 2})"
+                                                    ></span>
+                                                    {{ data_get($parentOrder, "currency.symbol") }}
+                                                </div>
+                                                <div
+                                                    class="text-sm text-gray-600 dark:text-gray-400"
+                                                >
+                                                    {{ Number::currency(data_get($position, "is_net") ? data_get($position, "unit_net_price") : data_get($position, "unit_gross_price"), data_get($parentOrder, "currency.iso")) }}
+                                                    @if(data_get($position, "unit_abbreviation"))
+                                                        / {{ data_get($position, "unit_abbreviation") }}
+                                                    @endif
+                                                </div>
+                                                @if(data_get($position, "discount_percentage") && bccomp(data_get($position, "discount_percentage"), 0) === 1)
+                                                    <div
+                                                        class="text-sm text-red-500"
+                                                    >
+                                                        -{{ Number::percentage(bcmul(data_get($position, "discount_percentage") ?? 0, 100), 2) }} {{ __("Discount") }}
+                                                    </div>
+                                                @endif
+                                            </div>
+                                        </div>
+                                    </x-slot:value>
+                                    <x-slot:actions>
+                                        <x-number
+                                            wire:model.number="replicateOrder.order_positions.{{ $index }}.amount"
+                                            min="0"
+                                            :max="data_get($position, 'amount', 0)"
+                                        />
+                                        <x-button
+                                            color="red"
+                                            icon="trash"
+                                            wire:click="removePosition({{ $index }})"
+                                        />
+                                    </x-slot:actions>
+                                </x-flux::list-item>
+                            @endif
                         @empty
                             <div class="py-8 text-center text-gray-500">
                                 {{ __("No positions selected") }}

--- a/src/Livewire/Order/CreateChildOrder.php
+++ b/src/Livewire/Order/CreateChildOrder.php
@@ -103,8 +103,26 @@ class CreateChildOrder extends Component
 
     public function removePosition(int $index): void
     {
+        $position = $this->replicateOrder->order_positions[$index] ?? null;
         unset($this->replicateOrder->order_positions[$index]);
+
+        // If removing a block, also remove all descendants recursively
+        if ($position && data_get($position, 'is_free_text')) {
+            $positionId = data_get($position, 'id');
+            $descendantIds = resolve_static(OrderPosition::class, 'query')
+                ->whereKey($positionId)
+                ->first()
+                ?->descendantKeys() ?? [];
+
+            $this->replicateOrder->order_positions = array_filter(
+                $this->replicateOrder->order_positions,
+                fn ($p) => ! in_array(data_get($p, 'id'), $descendantIds)
+            );
+        }
+
         $this->replicateOrder->order_positions = array_values($this->replicateOrder->order_positions);
+
+        $this->dispatchAlreadyTakenPositions();
     }
 
     #[Renderless]
@@ -138,12 +156,44 @@ class CreateChildOrder extends Component
     public function takeOrderPositions(): void
     {
         $takeAllWithPercentage = $this->percentage && $this->percentage > 0;
+        $positionIds = [];
 
         if ($takeAllWithPercentage) {
             $this->replicateOrder->order_positions = [];
         } else {
             $alreadySelectedIds = array_column($this->replicateOrder->order_positions, 'id');
-            $positionIds = array_diff($this->selectedPositions, $alreadySelectedIds, ['*']);
+
+            // Resolve wildcard '*' to all available position IDs
+            if (in_array('*', $this->selectedPositions)) {
+                $this->selectedPositions = resolve_static(OrderPosition::class, 'query')
+                    ->where('order_id', $this->orderId)
+                    ->pluck('id')
+                    ->toArray();
+            }
+
+            // Auto-include all ancestor blocks via single CTE query per selected position
+            $selectedWithParents = collect($this->selectedPositions);
+            $selectedPositions = resolve_static(OrderPosition::class, 'query')
+                ->whereKey($this->selectedPositions)
+                ->whereNotNull('parent_id')
+                ->get();
+
+            $allAncestorIds = $selectedPositions
+                ->flatMap(fn (OrderPosition $pos) => $pos->ancestorKeys())
+                ->unique();
+
+            if ($allAncestorIds->isNotEmpty()) {
+                $selectedWithParents = $selectedWithParents->merge($allAncestorIds);
+
+                // Add free text siblings in ancestor blocks
+                $freeTextSiblings = resolve_static(OrderPosition::class, 'query')
+                    ->whereIn('parent_id', $allAncestorIds)
+                    ->where('is_free_text', true)
+                    ->pluck('id');
+                $selectedWithParents = $selectedWithParents->merge($freeTextSiblings);
+            }
+
+            $positionIds = array_diff($selectedWithParents->unique()->toArray(), $alreadySelectedIds);
 
             if (! $positionIds) {
                 $this->selectedPositions = [];
@@ -169,8 +219,14 @@ class CreateChildOrder extends Component
             )
         );
 
+        $realPositionIds = array_column($maxAmounts, 'id');
+        $freeTextIds = resolve_static(OrderPosition::class, 'query')
+            ->whereKey($positionIds)
+            ->where('is_free_text', true)
+            ->pluck('id')
+            ->toArray();
+
         $orderPositions = resolve_static(OrderPosition::class, 'query')
-            ->whereKey(array_column($maxAmounts, 'id'))
             ->with(['product.unit:id,abbreviation'])
             ->select([
                 'id',
@@ -183,27 +239,39 @@ class CreateChildOrder extends Component
                 'total_gross_price',
                 'discount_percentage',
                 'is_net',
+                'is_free_text',
             ])
-            ->get()
-            ->map(function (OrderPosition $position) use ($maxAmounts): OrderPosition {
-                $position->setRelation(
-                    'maxAmount',
-                    data_get(
-                        array_find(
-                            $maxAmounts,
-                            fn (array $value): bool => data_get($value, 'id') === $position->getKey()
-                        ),
-                        'signed_amount'
-                    )
-                );
-
-                return $position;
-            });
+            ->whereKey(array_merge($realPositionIds, $freeTextIds))
+            ->get();
 
         foreach ($orderPositions as $orderPosition) {
+            if ($orderPosition->is_free_text) {
+                $this->replicateOrder->order_positions[] = [
+                    'id' => $orderPosition->getKey(),
+                    'amount' => 0,
+                    'name' => $orderPosition->name,
+                    'description' => $orderPosition->description,
+                    'unit_net_price' => 0,
+                    'unit_gross_price' => 0,
+                    'total_net_price' => 0,
+                    'total_gross_price' => 0,
+                    'discount_percentage' => 0,
+                    'is_net' => $orderPosition->is_net,
+                    'is_free_text' => true,
+                    'unit_abbreviation' => null,
+                ];
+
+                continue;
+            }
+
+            $amount = data_get(
+                array_find($maxAmounts, fn (array $v) => data_get($v, 'id') === $orderPosition->getKey()),
+                'signed_amount'
+            );
+
             $amount = $takeAllWithPercentage
-                ? bcround(bcmul($orderPosition->maxAmount, bcdiv($this->percentage, 100)), 2)
-                : $orderPosition->maxAmount;
+                ? bcround(bcmul($amount, bcdiv($this->percentage, 100)), 2)
+                : $amount;
 
             if (bccomp($amount, 0) === 1) {
                 $this->replicateOrder->order_positions[] = [
@@ -222,10 +290,49 @@ class CreateChildOrder extends Component
             }
         }
 
+        $this->sortPositionsByTreeOrder();
+
         if ($takeAllWithPercentage) {
             $this->percentage = null;
         }
 
         $this->selectedPositions = [];
+
+        $this->dispatchAlreadyTakenPositions();
+    }
+
+    protected function dispatchAlreadyTakenPositions(): void
+    {
+        // Exclude block headers so blocks stay visible on the left
+        // while they still have remaining children
+        $takenIds = collect($this->replicateOrder->order_positions)->pluck('id');
+        $blockIds = resolve_static(OrderPosition::class, 'query')
+            ->whereKey($takenIds)
+            ->where('is_free_text', true)
+            ->whereHas('children')
+            ->pluck('id');
+
+        $this->dispatch(
+            'updateAlreadyTakenPositions',
+            alreadyTakenPositions: $takenIds->diff($blockIds)->values()->toArray()
+        );
+    }
+
+    protected function sortPositionsByTreeOrder(): void
+    {
+        $treeOrder = to_flat_tree(
+            resolve_static(OrderPosition::class, 'familyTree')
+                ->where('order_id', $this->orderId)
+                ->whereNull('parent_id')
+                ->get()
+                ->toArray()
+        );
+        $orderMap = array_flip(array_column($treeOrder, 'id'));
+
+        usort(
+            $this->replicateOrder->order_positions,
+            fn ($left, $right) => data_get($orderMap, data_get($left, 'id'), PHP_INT_MAX)
+                <=> data_get($orderMap, data_get($right, 'id'), PHP_INT_MAX)
+        );
     }
 }

--- a/src/Livewire/Order/ReplicateOrderPositionList.php
+++ b/src/Livewire/Order/ReplicateOrderPositionList.php
@@ -3,14 +3,17 @@
 namespace FluxErp\Livewire\Order;
 
 use FluxErp\Livewire\DataTables\OrderPositionList;
+use FluxErp\Models\Order;
 use FluxErp\Models\OrderPosition;
 use FluxErp\Traits\CalculatesPositionAvailability;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Number;
 use Illuminate\View\ComponentAttributeBag;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Modelable;
+use Livewire\Attributes\On;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableRowAttributes;
 
 class ReplicateOrderPositionList extends OrderPositionList
@@ -50,6 +53,14 @@ class ReplicateOrderPositionList extends OrderPositionList
         return [];
     }
 
+    #[On('updateAlreadyTakenPositions')]
+    public function updateAlreadyTakenPositions(array $alreadyTakenPositions): void
+    {
+        $this->alreadyTakenPositions = $alreadyTakenPositions;
+        $this->selected = [];
+        $this->loadData();
+    }
+
     public function getFormatters(): array
     {
         return array_merge(
@@ -64,7 +75,7 @@ class ReplicateOrderPositionList extends OrderPositionList
     public function getSelectAttributes(): ComponentAttributeBag
     {
         return new ComponentAttributeBag([
-            'x-show' => '! record.is_bundle_position',
+            'x-show' => '! record.is_bundle_position && ! (record.is_free_text && record.has_children)',
         ]);
     }
 
@@ -114,45 +125,93 @@ class ReplicateOrderPositionList extends OrderPositionList
             )
             : [];
 
-        foreach ($tree as $key => &$item) {
-            if (data_get($item, 'is_free_text')) {
+        // First pass: remove taken positions
+        foreach ($tree as $key => $item) {
+            // Free text and bundle positions taken by ID
+            if (in_array(data_get($item, 'id'), $this->alreadyTakenPositions)) {
+                unset($tree[$key]);
+
                 continue;
             }
 
+            // Real positions also checked by signed_amount
+            if (! data_get($item, 'is_free_text') && ! data_get($item, 'is_bundle_position')) {
+                $totalAmount = data_get(
+                    array_find($maxAmounts, fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')),
+                    'signed_amount'
+                );
+
+                if (bccomp($totalAmount, 0) !== 1) {
+                    unset($tree[$key]);
+                }
+            }
+        }
+
+        // Second pass: remove bundle positions without parent and
+        // free text blocks without remaining real children
+        foreach ($tree as $key => $item) {
             if (data_get($item, 'is_bundle_position')) {
-                if (
-                    is_null(
-                        array_find_key(
-                            $tree,
-                            fn (array $value): bool => data_get($value, 'id') === data_get($item, 'parent_id')
-                        )
-                    )
-                ) {
+                $parentExists = collect($tree)
+                    ->contains(fn (array $v) => data_get($v, 'id') === data_get($item, 'parent_id'));
+
+                if (! $parentExists) {
                     unset($tree[$key]);
                 }
 
                 continue;
             }
 
-            $totalAmount = data_get(
-                array_find($maxAmounts, fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')),
-                'signed_amount'
-            );
+            if (data_get($item, 'is_free_text') && data_get($item, 'has_children')) {
+                $hasRemainingChildren = collect($tree)
+                    ->contains(fn (array $child) => data_get($child, 'parent_id') === data_get($item, 'id')
+                        && ! data_get($child, 'is_free_text'));
 
-            if (bccomp($totalAmount, 0) !== 1 || in_array(data_get($item, 'id'), $this->alreadyTakenPositions)) {
-                unset($tree[$key]);
+                if (! $hasRemainingChildren) {
+                    unset($tree[$key]);
+                }
+            }
+        }
 
-                continue;
+        // Third pass: format remaining items for display
+        $currencyIso = data_get(
+            resolve_static(Order::class, 'query')
+                ->whereKey($this->orderId)
+                ->with('currency:id,iso')
+                ->first(['id', 'currency_id']),
+            'currency.iso',
+            'EUR'
+        );
+
+        foreach ($tree as $key => &$item) {
+            $totalAmount = null;
+
+            if (! data_get($item, 'is_free_text') && ! data_get($item, 'is_bundle_position')) {
+                $totalAmount = data_get(
+                    array_find($maxAmounts, fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')),
+                    'signed_amount'
+                );
             }
 
             $item = Arr::only(Arr::dot($item), $returnKeys);
             $item['totalAmount'] = $totalAmount;
             $item['indentation'] = '';
-            $item['unit_price'] = $item['is_net'] ? ($item['unit_net_price'] ?? 0) : ($item['unit_gross_price'] ?? 0);
-            $item['alternative_tag'] = $item['is_alternative'] ? __('Alternative') : '';
+            $item['unit_price'] = data_get($item, 'is_net')
+                ? data_get($item, 'unit_net_price', 0)
+                : data_get($item, 'unit_gross_price', 0);
+            $item['alternative_tag'] = data_get($item, 'is_alternative') ? __('Alternative') : '';
 
-            if ($item['depth'] > 0) {
-                $indent = $item['depth'] * 20;
+            // Format money values
+            foreach (['unit_net_price', 'total_net_price'] as $moneyCol) {
+                $raw = data_get($item, $moneyCol);
+
+                if (! is_null($raw)) {
+                    $formatted = Number::currency((float) $raw, $currencyIso);
+                    $item[$moneyCol] = ['raw' => $raw, 'display' => e($formatted)];
+                }
+            }
+
+            if (data_get($item, 'depth', 0) > 0) {
+                $indent = data_get($item, 'depth') * 20;
                 $item['indentation'] = <<<HTML
                     <div class="text-right indent-icon" style="width:{$indent}px;">
                     </div>

--- a/src/Livewire/Order/ReplicateOrderPositionList.php
+++ b/src/Livewire/Order/ReplicateOrderPositionList.php
@@ -160,7 +160,7 @@ class ReplicateOrderPositionList extends OrderPositionList
             }
         }
 
-        return array_values($tree);
+        return ['data' => array_values($tree)];
     }
 
     protected function getReturnKeys(): array

--- a/tests/Livewire/Order/CreateChildOrderTest.php
+++ b/tests/Livewire/Order/CreateChildOrderTest.php
@@ -263,6 +263,420 @@ test('shows correct title for retoure', function (): void {
     expect($component->instance()->getTitle())->toEqual(__('Create Retoure'));
 });
 
+test('can take free text positions', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $freeText = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'Free Text Note',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', [$freeText->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $freeTextPosition = collect($positions)->firstWhere('id', $freeText->getKey());
+
+    expect($freeTextPosition)->not->toBeNull()
+        ->and($freeTextPosition['name'])->toBe('Free Text Note');
+});
+
+test('can take mix of real and free text positions', function (): void {
+    $vatRate = VatRate::factory()->create();
+    $realPosition = $this->parentOrder->orderPositions()->first();
+
+    $freeText = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'Section Header',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', [$freeText->getKey(), $realPosition->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+
+    expect($positions)->toHaveCount(2);
+
+    $names = collect($positions)->pluck('name')->toArray();
+    expect($names)->toContain('Section Header')
+        ->and($names)->toContain($realPosition->name);
+});
+
+test('takeOrderPositions dispatches updateAlreadyTakenPositions', function (): void {
+    $orderPosition = $this->parentOrder->orderPositions()->first();
+
+    Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ])
+        ->set('selectedPositions', [$orderPosition->getKey()])
+        ->call('takeOrderPositions')
+        ->assertDispatched('updateAlreadyTakenPositions', fn ($name, $params) => in_array($orderPosition->getKey(), $params['alreadyTakenPositions'])
+        );
+});
+
+test('removePosition dispatches updateAlreadyTakenPositions', function (): void {
+    $orderPosition = $this->parentOrder->orderPositions()->first();
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ])
+        ->set('selectedPositions', [$orderPosition->getKey()])
+        ->call('takeOrderPositions');
+
+    $component->call('removePosition', 0)
+        ->assertDispatched('updateAlreadyTakenPositions', fn ($name, $params) => empty($params['alreadyTakenPositions'])
+        );
+});
+
+test('taken positions follow tree order regardless of selection order', function (): void {
+    $vatRate = VatRate::factory()->create();
+    $existingPosition = $this->parentOrder->orderPositions()->where('is_free_text', false)->first();
+
+    // Create a second real position
+    $secondPosition = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'Second Position',
+        'amount' => 3,
+        'signed_amount' => 3,
+        'unit_net_price' => 50,
+        'unit_gross_price' => 59.50,
+        'total_net_price' => 150,
+        'total_gross_price' => 178.50,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    // Select in reverse order
+    $component->set('selectedPositions', [$secondPosition->getKey(), $existingPosition->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $ids = array_column($positions, 'id');
+
+    // Tree order: existing (lower ID) before second (higher ID)
+    expect(array_search($existingPosition->getKey(), $ids))
+        ->toBeLessThan(array_search($secondPosition->getKey(), $ids));
+});
+
+test('selecting child position auto-includes parent block', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'AutoBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'BlockChild',
+        'amount' => 2,
+        'signed_amount' => 2,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 200,
+        'total_gross_price' => 238,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    // Only select the child — block should be auto-included
+    $component->set('selectedPositions', [$child->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $ids = array_column($positions, 'id');
+
+    expect($ids)->toContain($block->getKey())
+        ->and($ids)->toContain($child->getKey());
+});
+
+test('block stays visible on left when only some children are taken', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'PartialBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $child1 = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'TakenChild',
+        'amount' => 2,
+        'signed_amount' => 2,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 200,
+        'total_gross_price' => 238,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'RemainingChild',
+        'amount' => 3,
+        'signed_amount' => 3,
+        'unit_net_price' => 50,
+        'unit_gross_price' => 59.50,
+        'total_net_price' => 150,
+        'total_gross_price' => 178.50,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    // Take only child1
+    $component->set('selectedPositions', [$child1->getKey()])
+        ->call('takeOrderPositions');
+
+    // alreadyTakenPositions must NOT contain the block ID
+    // so the block stays visible on the left with remaining children
+    $dispatched = $component->effects['dispatches'] ?? [];
+    $updateEvent = collect($dispatched)->firstWhere('name', 'updateAlreadyTakenPositions');
+    $takenIds = data_get($updateEvent, 'params.alreadyTakenPositions', []);
+
+    expect($takenIds)->toContain($child1->getKey())
+        ->and($takenIds)->not->toContain($block->getKey());
+});
+
+test('removing block removes all its children from right list', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'RemovableBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'BlockChildToRemove',
+        'amount' => 2,
+        'signed_amount' => 2,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 200,
+        'total_gross_price' => 238,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    // Take child (block auto-included)
+    $component->set('selectedPositions', [$child->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    expect($positions)->toHaveCount(2);
+
+    // Find block index and remove it
+    $blockIndex = array_search(
+        $block->getKey(),
+        array_column($positions, 'id')
+    );
+
+    $component->call('removePosition', $blockIndex);
+
+    // Both block and child should be gone
+    $remaining = $component->get('replicateOrder.order_positions');
+    $remainingIds = array_column($remaining, 'id');
+
+    expect($remainingIds)->not->toContain($block->getKey())
+        ->and($remainingIds)->not->toContain($child->getKey());
+});
+
+test('nested blocks: selecting deep child includes all ancestor blocks', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $outerBlock = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'OuterBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $innerBlock = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $outerBlock->getKey(),
+        'name' => 'InnerBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $deepChild = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $innerBlock->getKey(),
+        'name' => 'DeepChild',
+        'amount' => 1,
+        'signed_amount' => 1,
+        'unit_net_price' => 200,
+        'unit_gross_price' => 238,
+        'total_net_price' => 200,
+        'total_gross_price' => 238,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    // Select only the deep child
+    $component->set('selectedPositions', [$deepChild->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $ids = array_column($positions, 'id');
+
+    expect($ids)->toContain($outerBlock->getKey())
+        ->and($ids)->toContain($innerBlock->getKey())
+        ->and($ids)->toContain($deepChild->getKey());
+});
+
+test('nested blocks: removing outer block removes everything inside', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $outerBlock = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'OuterToRemove',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $innerBlock = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $outerBlock->getKey(),
+        'name' => 'InnerToRemove',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $deepChild = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $innerBlock->getKey(),
+        'name' => 'DeepChildToRemove',
+        'amount' => 1,
+        'signed_amount' => 1,
+        'unit_net_price' => 200,
+        'unit_gross_price' => 238,
+        'total_net_price' => 200,
+        'total_gross_price' => 238,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', [$deepChild->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $outerIndex = array_search($outerBlock->getKey(), array_column($positions, 'id'));
+
+    // Remove outer block — everything inside must go
+    $component->call('removePosition', $outerIndex);
+
+    $remaining = $component->get('replicateOrder.order_positions');
+    $remainingIds = array_column($remaining, 'id');
+
+    expect($remainingIds)->not->toContain($outerBlock->getKey())
+        ->and($remainingIds)->not->toContain($innerBlock->getKey())
+        ->and($remainingIds)->not->toContain($deepChild->getKey());
+});
+
+test('can take all positions with wildcard selection', function (): void {
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->getKey(),
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', ['*'])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+
+    expect($positions)->not->toBeEmpty();
+});
+
 test('shows correct title for split order', function (): void {
     $component = Livewire::test(CreateChildOrder::class, [
         'orderId' => $this->parentOrder->id,

--- a/tests/Livewire/Order/ReplicateOrderPositionListTest.php
+++ b/tests/Livewire/Order/ReplicateOrderPositionListTest.php
@@ -73,3 +73,310 @@ test('getResultFromQuery returns data key with positions', function (): void {
         ->and($result)->toHaveKey('data')
         ->and($result['data'])->not->toBeEmpty();
 });
+
+test('free text positions are included in result', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    // Free text (simple, no children)
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'FreeTextNote',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->toContain('FreeTextNote');
+});
+
+test('block headers are included when they have remaining children', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    // Block header (free text with children)
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'BlockHeader',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    // Child position inside the block
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'ChildPosition',
+        'amount' => 3,
+        'signed_amount' => 3,
+        'unit_net_price' => 50,
+        'unit_gross_price' => 59.50,
+        'total_net_price' => 150,
+        'total_gross_price' => 178.50,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    // Verify the tree structure loads correctly
+    $query = resolve_static(OrderPosition::class, 'familyTree')
+        ->where('order_id', $this->testOrder->getKey())
+        ->whereNull('parent_id');
+    $tree = to_flat_tree($query->get()->toArray());
+    $treeNames = collect($tree)->pluck('name')->toArray();
+
+    // Debug: ensure familyTree loads the block with its child
+    expect($treeNames)->toContain('BlockHeader')
+        ->and($treeNames)->toContain('ChildPosition');
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->toContain('BlockHeader')
+        ->and($names)->toContain('ChildPosition');
+});
+
+test('positions in alreadyTakenPositions are excluded', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $position = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'AlreadyTaken',
+        'amount' => 5,
+        'signed_amount' => 5,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 500,
+        'total_gross_price' => 595,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+            'alreadyTakenPositions' => [$position->getKey()],
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->not->toContain('AlreadyTaken');
+});
+
+test('block with only free text children remaining is removed', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'BlockOnlyFreeTextKids',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    // Real child — fully taken (signed_amount=0)
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'TakenChild',
+        'amount' => 3,
+        'signed_amount' => 0,
+        'unit_net_price' => 50,
+        'unit_gross_price' => 59.50,
+        'total_net_price' => 150,
+        'total_gross_price' => 178.50,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    // Free text child still in tree — but doesn't count as "real" child
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'FreeTextInBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->not->toContain('BlockOnlyFreeTextKids')
+        ->and($names)->not->toContain('TakenChild');
+});
+
+test('free text inside kept block is included', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'KeptBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    // Free text child
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'NoteInsideBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    // Real child — available
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'RealChild',
+        'amount' => 2,
+        'signed_amount' => 2,
+        'unit_net_price' => 80,
+        'unit_gross_price' => 95.20,
+        'total_net_price' => 160,
+        'total_gross_price' => 190.40,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->toContain('KeptBlock')
+        ->and($names)->toContain('NoteInsideBlock')
+        ->and($names)->toContain('RealChild');
+});
+
+test('taken free text positions are excluded from left list', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    $freeText = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'AlreadyTakenFreeText',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+            'alreadyTakenPositions' => [$freeText->getKey()],
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->not->toContain('AlreadyTakenFreeText');
+});
+
+test('updateAlreadyTakenPositions event updates state and clears selection', function (): void {
+    Livewire::test(ReplicateOrderPositionList::class, [
+        'orderId' => $this->testOrder->getKey(),
+    ])
+        ->assertSet('alreadyTakenPositions', [])
+        ->dispatch('updateAlreadyTakenPositions', alreadyTakenPositions: [999])
+        ->assertSet('alreadyTakenPositions', [999])
+        ->assertSet('selected', []);
+});
+
+test('empty order returns empty data', function (): void {
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+
+    expect($result)->toHaveKey('data')
+        ->and($result['data'])->toBeEmpty();
+});
+
+test('block headers are removed when no children remain', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    // Block header with a child that has signed_amount=0 (fully taken)
+    $block = OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'EmptyBlock',
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'parent_id' => $block->getKey(),
+        'name' => 'FullyTakenChild',
+        'amount' => 3,
+        'signed_amount' => 0,
+        'unit_net_price' => 50,
+        'unit_gross_price' => 59.50,
+        'total_net_price' => 150,
+        'total_gross_price' => 178.50,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $result = $instance->getResultFromQuery($instance->getBuilder(OrderPosition::query()));
+    $names = collect($result['data'])->pluck('name');
+
+    expect($names)->not->toContain('EmptyBlock')
+        ->and($names)->not->toContain('FullyTakenChild');
+});

--- a/tests/Livewire/Order/ReplicateOrderPositionListTest.php
+++ b/tests/Livewire/Order/ReplicateOrderPositionListTest.php
@@ -6,32 +6,70 @@ use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
+use FluxErp\Models\VatRate;
+use FluxErp\Models\Warehouse;
 use Livewire\Livewire;
+use function Livewire\invade;
 
-test('renders successfully', function (): void {
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
     $contact = Contact::factory()->create();
     $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
     $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order]);
     $paymentType = PaymentType::factory()
         ->hasAttached($this->dbTenant, relationship: 'tenants')
         ->create();
-    $priceList = PriceList::factory()->create();
-    $currency = Currency::factory()->create();
 
-    $order = Order::factory()->create([
+    $this->testOrder = Order::factory()->create([
         'order_type_id' => $orderType->getKey(),
         'address_invoice_id' => $address->getKey(),
         'contact_id' => $contact->getKey(),
         'payment_type_id' => $paymentType->getKey(),
-        'price_list_id' => $priceList->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
-        'currency_id' => $currency->getKey(),
+        'currency_id' => Currency::default()->getKey(),
         'language_id' => $this->defaultLanguage->getKey(),
     ]);
+});
 
-    Livewire::test(ReplicateOrderPositionList::class, ['orderId' => $order->getKey()])
+test('renders successfully', function (): void {
+    Livewire::test(ReplicateOrderPositionList::class, ['orderId' => $this->testOrder->getKey()])
         ->assertOk();
+});
+
+test('getResultFromQuery returns data key with positions', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    OrderPosition::factory()->create([
+        'order_id' => $this->testOrder->getKey(),
+        'vat_rate_id' => $vatRate->getKey(),
+        'name' => 'ReplicateTestPosition',
+        'amount' => 5,
+        'signed_amount' => 5,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 500,
+        'total_gross_price' => 595,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $instance = invade(
+        Livewire::test(ReplicateOrderPositionList::class, [
+            'orderId' => $this->testOrder->getKey(),
+        ])->instance()
+    );
+
+    $query = $instance->getBuilder(OrderPosition::query());
+    $result = $instance->getResultFromQuery($query);
+
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKey('data')
+        ->and($result['data'])->not->toBeEmpty();
 });


### PR DESCRIPTION
## Summary
- `ReplicateOrderPositionList::getResultFromQuery()` returned a flat array of positions
- The table view iterates over `$this->data['data']` (paginated format)
- Without the `data` key, the table showed no rows when creating a child order (Teilauftrag)
- Wrapped the result in `['data' => ...]` to match the expected format

## Summary by Sourcery

Ensure replicate order position lists return results in the expected paginated structure so child order tables render correctly.

Bug Fixes:
- Return replicate order positions under a data key to match the table component's expected paginated format and avoid empty child order tables.

Tests:
- Add a regression test verifying ReplicateOrderPositionList::getResultFromQuery returns a non-empty data array for an order with positions.
- Refactor Livewire replicate order position list tests to use shared setup with default warehouse, price list, and currency models.