### PR TITLE
use getRelativePathname for more robust command loading

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -178,8 +178,14 @@ class FluxServiceProvider extends ServiceProvider
 
     protected function findCommands(): array
     {
+        $path = flux_path('src/Console/Commands');
+
+        if (! is_dir($path)) {
+            return [];
+        }
+
         $iterator = Finder::create()
-            ->in(flux_path('src/Console/Commands'))
+            ->in($path)
             ->files()
             ->name('*.php')
             ->sortByName();
@@ -187,10 +193,17 @@ class FluxServiceProvider extends ServiceProvider
         $commandClasses = [];
 
         foreach ($iterator as $file) {
-            $classPath = str_replace([__DIR__ . '/', '/'], ['', '\\'], $file->getPathname());
-            $classNamespace = '\\FluxErp\\';
-            $class = $classNamespace . str_replace('.php', '', $classPath);
-            $commandClasses[] = $class;
+            $relativePath = $file->getRelativePathname();
+
+            $class = 'FluxErp\\Console\\Commands\\' . str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                $relativePath
+            );
+
+            if (class_exists($class)) {
+                $commandClasses[] = $class;
+            }
         }
 
         return $commandClasses;


### PR DESCRIPTION
## Summary by Sourcery

Improve discovery of console command classes in the Flux service provider to be more robust and namespace-aware.

Enhancements:
- Guard command discovery when the console commands directory does not exist.
- Derive console command class names from their relative path within the commands directory and only register those that actually exist.