### PR TITLE
Fix missing leading backslash on SchemaInfo in FluxOptimize

### DIFF
--- a/src/Console/Commands/FluxOptimize.php
+++ b/src/Console/Commands/FluxOptimize.php
@@ -484,7 +484,7 @@ class FluxOptimize extends Command
     protected function optimizeModelInfo(): void
     {
         if ($this->forget) {
-            TeamNiftyGmbH\DataTable\Helpers\SchemaInfo::flush();
+            \TeamNiftyGmbH\DataTable\Helpers\SchemaInfo::flush();
         }
     }
 }

--- a/src/Console/Commands/FluxOptimize.php
+++ b/src/Console/Commands/FluxOptimize.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 use Livewire\Component;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
+use TeamNiftyGmbH\DataTable\Helpers\SchemaInfo;
 
 class FluxOptimize extends Command
 {
@@ -484,7 +485,7 @@ class FluxOptimize extends Command
     protected function optimizeModelInfo(): void
     {
         if ($this->forget) {
-            \TeamNiftyGmbH\DataTable\Helpers\SchemaInfo::flush();
+            SchemaInfo::flush();
         }
     }
 }

--- a/tests/Browser/Orders/OrdersTest.php
+++ b/tests/Browser/Orders/OrdersTest.php
@@ -32,7 +32,7 @@ test('can create new order', function (): void {
         ->assertRoute('orders.orders')
         ->assertNoSmoke();
 
-    waitForElement($page, '[tall-datatable] [wire\\:id]');
+    waitForElement($page, '[tall-datatable] [wire\\\\:id]');
 
     $page->click('New order');
 

--- a/tests/Browser/Orders/OrdersTest.php
+++ b/tests/Browser/Orders/OrdersTest.php
@@ -32,7 +32,18 @@ test('can create new order', function (): void {
         ->assertRoute('orders.orders')
         ->assertNoSmoke();
 
-    waitForElement($page, '[tall-datatable] [wire\\\\:id]');
+    $page->script("() => new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Livewire not ready')), 10000);
+        const check = () => {
+            if (window.Livewire) {
+                clearTimeout(timeout);
+                resolve();
+            } else {
+                setTimeout(check, 200);
+            }
+        };
+        check();
+    })");
 
     $page->click('New order');
 

--- a/tests/Browser/Orders/OrdersTest.php
+++ b/tests/Browser/Orders/OrdersTest.php
@@ -32,8 +32,7 @@ test('can create new order', function (): void {
         ->assertRoute('orders.orders')
         ->assertNoSmoke();
 
-    // Wait for Livewire to fully hydrate before clicking
-    $page->assertPresent('[tall-datatable]');
+    waitForElement($page, '[tall-datatable] [wire\\:id]');
 
     $page->click('New order');
 


### PR DESCRIPTION
## Summary
- `TeamNiftyGmbH\DataTable\Helpers\SchemaInfo::flush()` was missing the leading `\`, causing PHP to resolve it relative to `FluxErp\Console\Commands\` namespace

## Summary by Sourcery

Bug Fixes:
- Fix SchemaInfo::flush() being resolved in the wrong namespace by adding the missing leading backslash in FluxOptimize.