### PR TITLE
Automatically expand tree nodes during a search to improve immediate …

### DIFF
--- a/resources/views/components/checkbox-tree.blade.php
+++ b/resources/views/components/checkbox-tree.blade.php
@@ -86,7 +86,7 @@
                         class="ph ph-caret-right text-base transition-transform duration-200"
                         x-bind:class="
                             node[childrenAttribute]
-                                ? (search?.length > 0 || isOpen(node))
+                                ? search?.length > 0 || isOpen(node)
                                     ? 'rotate-90'
                                     : 'rotate-0'
                                 : 'invisible'
@@ -153,7 +153,7 @@
                             x-sort="(item, position) => {{{ $attributes->get("moved", "null") }}}"
                             x-sort:group="folder - tree"
                         @endif
-                        x-show="(search?.length > 0 || isOpen(node))"
+                        x-show="search?.length > 0 || isOpen(node)"
                         x-transition
                         class="tree__children border-l border-gray-200 pl-4 dark:border-slate-500"
                     >

--- a/resources/views/components/checkbox-tree.blade.php
+++ b/resources/views/components/checkbox-tree.blade.php
@@ -86,7 +86,7 @@
                         class="ph ph-caret-right text-base transition-transform duration-200"
                         x-bind:class="
                             node[childrenAttribute]
-                                ? isOpen(node)
+                                ? (search?.length > 0 || isOpen(node))
                                     ? 'rotate-90'
                                     : 'rotate-0'
                                 : 'invisible'
@@ -153,7 +153,7 @@
                             x-sort="(item, position) => {{{ $attributes->get("moved", "null") }}}"
                             x-sort:group="folder - tree"
                         @endif
-                        x-show="isOpen(node)"
+                        x-show="(search?.length > 0 || isOpen(node))"
                         x-transition
                         class="tree__children border-l border-gray-200 pl-4 dark:border-slate-500"
                     >


### PR DESCRIPTION
…visibility

## Summary by Sourcery

Expand checkbox tree nodes automatically while a search term is present to keep matching results and their children visible.

Enhancements:
- Ensure tree caret icon shows an expanded state whenever a search term is active, regardless of prior open state.
- Show child nodes in the checkbox tree whenever a search is active, even if their parent nodes were previously collapsed.