### PR TITLE
Fix HasDefault caching relation data that shadows actual relations

### DIFF
--- a/src/Traits/Model/HasDefault.php
+++ b/src/Traits/Model/HasDefault.php
@@ -21,7 +21,7 @@ trait HasDefault
                 fn () => resolve_static(static::class, 'query')
                     ->where(static::$defaultColumn, true)
                     ->first()
-                    ?->toArray()
+                    ?->getAttributes()
             );
 
         if (! is_null($attributes) && ! is_array($attributes)) {
@@ -29,7 +29,7 @@ trait HasDefault
             $attributes = resolve_static(static::class, 'query')
                 ->where(static::$defaultColumn, true)
                 ->first()
-                ?->toArray();
+                ?->getAttributes();
         }
 
         if (! $attributes) {

--- a/tests/Unit/Traits/HasDefaultTest.php
+++ b/tests/Unit/Traits/HasDefaultTest.php
@@ -47,6 +47,20 @@ test('default works with serializable_classes disabled', function (): void {
         ->and($languageFromCache->getKey())->toBe($language->getKey());
 });
 
+test('default model does not shadow media relation with cached array', function (): void {
+    $tenant = FluxErp\Models\Tenant::factory()->create(['is_default' => true]);
+
+    $tenant->addMedia(Illuminate\Http\UploadedFile::fake()->image('logo.png'))
+        ->toMediaCollection('logo');
+
+    Cache::memo()->forget('default_' . morph_alias(FluxErp\Models\Tenant::class));
+
+    $default = resolve_static(FluxErp\Models\Tenant::class, 'default');
+
+    expect($default)->not->toBeNull();
+    expect($default->getFirstMedia('logo'))->toBeInstanceOf(Spatie\MediaLibrary\MediaCollections\Models\Media::class);
+});
+
 test('deleting default model invalidates cache', function (): void {
     $vatRate = VatRate::factory()->create(['is_default' => true]);
 


### PR DESCRIPTION
## Summary
- `HasDefault::default()` used `toArray()` to cache model data, which included eager-loaded relations (like `media` on Tenant) and appended accessors that re-load relations
- When `forceFill()` receives this data, relation keys are set as regular attributes, shadowing the actual Eloquent relation
- This caused `$tenant->getFirstMedia()` to fail with "Argument must be of type Media, array given" when sending emails
- Fixed by using `getAttributes()` which returns only raw DB column values

## Summary by Sourcery

Prevent default models from caching relation data that shadows actual Eloquent relations.

Bug Fixes:
- Avoid storing eager-loaded relations and appended accessors in the cached default model attributes to prevent relation shadowing errors.

Tests:
- Add a regression test ensuring the cached default Tenant model does not shadow the media relation and that media retrieval still returns Media instances.