### PR TITLE
add null-safety to Number::currency() passed data

### DIFF
--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -167,7 +167,7 @@
                                                 <div
                                                     class="text-sm text-gray-600 dark:text-gray-400"
                                                 >
-                                                    {{ Number::currency(data_get($position, "is_net") ? data_get($position, "unit_net_price") : data_get($position, "unit_gross_price"), data_get($parentOrder, "currency.iso")) }}
+                                                    {{ Number::currency((data_get($position, "is_net") ? data_get($position, "unit_net_price") : data_get($position, "unit_gross_price")) ?? 0, data_get($parentOrder, "currency.iso")) }}
                                                     @if(data_get($position, "unit_abbreviation"))
                                                         / {{ data_get($position, "unit_abbreviation") }}
                                                     @endif

--- a/src/Actions/OrderPosition/CreateOrderPosition.php
+++ b/src/Actions/OrderPosition/CreateOrderPosition.php
@@ -219,7 +219,6 @@ class CreateOrderPosition extends FluxAction
                     ];
                 }
 
-                $multiplier = $order->orderType?->order_type_enum?->multiplier() ?? 1;
                 $maxAmount = data_get(
                     array_find(
                         $this->calculateMaxAmounts(


### PR DESCRIPTION
remove unused variable in CreateOrderPosition action

## Summary by Sourcery

Ensure safe handling of potentially null pricing data in the order creation view and remove unused code from the order position creation action.

Bug Fixes:
- Prevent Number::currency() from receiving a null unit price by defaulting to zero when the calculated price is null.

Chores:
- Remove an unused multiplier variable from the CreateOrderPosition action to tidy up the codebase.