### PR TITLE
fix null exceptions on form fill

### DIFF
--- a/src/Livewire/Contact/Accounting/BankConnections.php
+++ b/src/Livewire/Contact/Accounting/BankConnections.php
@@ -77,7 +77,9 @@ class BankConnections extends BaseContactBankConnectionList
     public function edit(?ContactBankConnection $contactBankConnection = null): void
     {
         $this->contactBankConnection->reset();
-        $this->contactBankConnection->fill($contactBankConnection);
+        if (! is_null($contactBankConnection)) {
+            $this->contactBankConnection->fill($contactBankConnection);
+        }
 
         $this->js(<<<'JS'
             $tsui.open.modal('edit-contact-bank-connection');

--- a/src/Livewire/Contact/Accounting/SepaMandates.php
+++ b/src/Livewire/Contact/Accounting/SepaMandates.php
@@ -122,7 +122,9 @@ class SepaMandates extends SepaMandateList
     public function edit(?SepaMandate $sepaMandate = null): void
     {
         $this->sepaMandate->reset();
-        $this->sepaMandate->fill($sepaMandate);
+        if (! is_null($sepaMandate)) {
+            $this->sepaMandate->fill($sepaMandate);
+        }
 
         $this->js(<<<'JS'
             $tsui.open.modal('edit-sepa-mandate-modal');

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -128,7 +128,7 @@ class PurchaseInvoiceList extends BaseDataTable
         $this->purchaseInvoiceForm->reset();
         $this->mediaForm->reset();
 
-        if ($purchaseInvoice->exists) {
+        if ($purchaseInvoice?->exists) {
             $purchaseInvoice->loadMissing(['purchaseInvoicePositions', 'invoice']);
             $this->purchaseInvoiceForm->fill($purchaseInvoice);
             $this->purchaseInvoiceForm->mediaUrl = $purchaseInvoice->getFirstMediaUrl('purchase_invoice')

--- a/src/Livewire/Features/Communications/Communication.php
+++ b/src/Livewire/Features/Communications/Communication.php
@@ -201,7 +201,10 @@ abstract class Communication extends CommunicationList
     public function edit(?CommunicationModel $communication = null): void
     {
         $this->communication->reset();
-        $this->communication->fill($communication);
+        if (! is_null($communication)) {
+            $this->communication->fill($communication);
+        }
+
         $this->communication->mail_account_id ??= auth()
             ->user()
             ->defaultMailAccount()

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -79,10 +79,7 @@ class ProjectTaskList extends BaseTaskList
         ];
     }
 
-    public function updatedTaskTab(): void
-    {
-        $this->forceRender();
-    }
+    public function updatedTaskTab(): void {}
 
     protected function getBuilder(Builder $builder): Builder
     {

--- a/src/Livewire/Settings/Permissions.php
+++ b/src/Livewire/Settings/Permissions.php
@@ -94,7 +94,10 @@ class Permissions extends RoleList
     public function edit(?Role $role, string $modal = 'edit-role-permissions-modal'): void
     {
         $this->roleForm->reset();
-        $this->roleForm->fill($role);
+        if (! is_null($role)) {
+            $this->roleForm->fill($role);
+        }
+
         $this->permissions = $this->getPermissionTree();
 
         $this->js(<<<JS

--- a/src/Livewire/Settings/ProductOptionGroups.php
+++ b/src/Livewire/Settings/ProductOptionGroups.php
@@ -79,9 +79,11 @@ class ProductOptionGroups extends ProductOptionGroupList
 
     public function edit(?ProductOptionGroup $productOptionGroup = null): void
     {
-        $productOptionGroup->loadMissing('productOptions:id,product_option_group_id,name');
         $this->productOptionGroupForm->reset();
-        $this->productOptionGroupForm->fill($productOptionGroup);
+        if (! is_null($productOptionGroup)) {
+            $productOptionGroup->loadMissing('productOptions:id,product_option_group_id,name');
+            $this->productOptionGroupForm->fill($productOptionGroup);
+        }
 
         $this->js(<<<'JS'
             $tsui.open.modal('edit-product-option-group-modal');

--- a/src/Livewire/Settings/ProductPropertyGroups.php
+++ b/src/Livewire/Settings/ProductPropertyGroups.php
@@ -82,9 +82,11 @@ class ProductPropertyGroups extends ProductPropertyGroupList
     #[Renderless]
     public function edit(?ProductPropertyGroup $productPropertyGroup = null): void
     {
-        $productPropertyGroup->loadMissing('productProperties:id,product_property_group_id,name,property_type_enum');
         $this->productPropertyGroup->reset();
-        $this->productPropertyGroup->fill($productPropertyGroup);
+        if (! is_null($productPropertyGroup)) {
+            $productPropertyGroup->loadMissing('productProperties:id,product_property_group_id,name,property_type_enum');
+            $this->productPropertyGroup->fill($productPropertyGroup);
+        }
 
         $this->js(<<<'JS'
             $tsui.open.modal('edit-product-property-group-modal');

--- a/src/Livewire/Settings/Targets.php
+++ b/src/Livewire/Settings/Targets.php
@@ -74,8 +74,6 @@ class Targets extends TargetList
         } else {
             $this->aggregateColumns = [];
         }
-
-        $this->forceRender();
     }
 
     public function updateSelectableColumns(?string $modelType = null): void
@@ -98,8 +96,6 @@ class Targets extends TargetList
             $this->target->aggregate_type = data_get($this->aggregateTypes, '0.value');
             $this->target->owner_column = data_get($this->ownerColumns, '0.value');
         }
-
-        $this->forceRender();
     }
 
     protected function getViewData(): array

--- a/src/Livewire/Settings/Tenants.php
+++ b/src/Livewire/Settings/Tenants.php
@@ -156,7 +156,6 @@ class Tenants extends TenantList
             $this->logoSmall->fill($record->getMedia('logo_small')->first() ?? []);
         }
 
-
         $this->js(<<<'JS'
             $tsui.open.modal('edit-tenant');
         JS);

--- a/src/Livewire/Settings/Tenants.php
+++ b/src/Livewire/Settings/Tenants.php
@@ -142,25 +142,27 @@ class Tenants extends TenantList
     public function edit(?Tenant $record = null): void
     {
         $this->tenant->reset();
-        $record->load('bankConnections:id');
-        $tenant = $record->toArray();
-        $tenant['bank_connections'] = array_column($tenant['bank_connections'], 'id');
-        $tenant['opening_hours'] = $tenant['opening_hours'] ?? [];
+        $this->logo->reset();
+        $this->logoSmall->reset();
 
-        $this->tenant->fill($tenant);
+        if (! is_null($record)) {
+            $record->load('bankConnections:id');
+            $tenant = $record->toArray();
+            $tenant['bank_connections'] = array_column($tenant['bank_connections'], 'id');
+            $tenant['opening_hours'] = $tenant['opening_hours'] ?? [];
 
-        $this->logo->fill($record->getMedia('logo')->first() ?? []);
-        $this->logoSmall->fill($record->getMedia('logo_small')->first() ?? []);
+            $this->tenant->fill($tenant);
+            $this->logo->fill($record->getMedia('logo')->first() ?? []);
+            $this->logoSmall->fill($record->getMedia('logo_small')->first() ?? []);
+        }
+
 
         $this->js(<<<'JS'
             $tsui.open.modal('edit-tenant');
         JS);
     }
 
-    public function updatingTab(): void
-    {
-        $this->forceRender();
-    }
+    public function updatingTab(): void {}
 
     protected function getBuilder(Builder $builder): Builder
     {

--- a/src/Providers/TestServiceProvider.php
+++ b/src/Providers/TestServiceProvider.php
@@ -37,6 +37,41 @@ class TestServiceProvider extends ServiceProvider
             );
         }
 
+        if (! Testable::hasMacro('assertOpensModal')) {
+            Testable::macro(
+                'assertOpensModal',
+                function (?string $modalName = null) {
+                    if (is_null($modalName)) {
+                        $instance = $this->instance();
+
+                        if (method_exists($instance, 'modalName')) {
+                            $modalName = invade($instance)->modalName();
+                        } else {
+                            foreach (get_object_vars($instance) as $value) {
+                                if (
+                                    is_object($value)
+                                    && in_array(
+                                        \FluxErp\Traits\Livewire\Form\SupportsAutoRender::class,
+                                        class_uses_recursive($value)
+                                    )
+                                ) {
+                                    $modalName = $value->modalName();
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    Assert::assertNotNull($modalName, 'Could not determine modal name.');
+
+                    $this->assertExecutesJs("\$tsui.open.modal('{$modalName}')");
+                    $this->assertSeeHtml('id="' . $modalName . '"');
+
+                    return $this;
+                }
+            );
+        }
+
         if (! Testable::hasMacro('assertToastNotification')) {
             Testable::macro(
                 'assertToastNotification',

--- a/tests/Livewire/Contact/Accounting/BankConnectionsTest.php
+++ b/tests/Livewire/Contact/Accounting/BankConnectionsTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Livewire\Contact\Accounting\BankConnections;
 use FluxErp\Models\Contact;
+use FluxErp\Models\ContactBankConnection;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -11,11 +12,30 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     $contact = Contact::factory()->create();
 
     Livewire::test(BankConnections::class, ['contactId' => $contact->getKey()])
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('contactBankConnection.id', null)
+        ->assertSet('contactBankConnection.iban', null)
+        ->assertSet('contactBankConnection.account_holder', null)
+        ->assertOpensModal('edit-contact-bank-connection');
+});
+
+test('edit with model fills form', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+    ]);
+
+    Livewire::test(BankConnections::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $bankConnection->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('contactBankConnection.id', $bankConnection->getKey())
+        ->assertSet('contactBankConnection.iban', $bankConnection->iban)
+        ->assertOpensModal('edit-contact-bank-connection');
 });

--- a/tests/Livewire/Contact/Accounting/BankConnectionsTest.php
+++ b/tests/Livewire/Contact/Accounting/BankConnectionsTest.php
@@ -10,3 +10,12 @@ test('renders successfully', function (): void {
     Livewire::test(BankConnections::class, ['contactId' => $contact->getKey()])
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(BankConnections::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Contact/Accounting/SepaMandatesTest.php
+++ b/tests/Livewire/Contact/Accounting/SepaMandatesTest.php
@@ -7,3 +7,10 @@ test('renders successfully', function (): void {
     Livewire::test(SepaMandates::class)
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    Livewire::test(SepaMandates::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Contact/Accounting/SepaMandatesTest.php
+++ b/tests/Livewire/Contact/Accounting/SepaMandatesTest.php
@@ -8,9 +8,12 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(SepaMandates::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('sepaMandate.id', null)
+        ->assertSet('sepaMandate.contact_bank_connection_id', null)
+        ->assertOpensModal('edit-sepa-mandate-modal');
 });

--- a/tests/Livewire/Contact/CommunicationTest.php
+++ b/tests/Livewire/Contact/CommunicationTest.php
@@ -13,3 +13,9 @@ test('can call edit without arguments to create new communication', function ():
         ->call('edit')
         ->assertOk();
 });
+
+test('can call edit with null to create a new communication', function (): void {
+    Livewire::test(Communication::class)
+        ->call('edit', null)
+        ->assertOk();
+});

--- a/tests/Livewire/Contact/CommunicationTest.php
+++ b/tests/Livewire/Contact/CommunicationTest.php
@@ -8,14 +8,25 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('can call edit without arguments to create new communication', function (): void {
+test('edit without arguments resets form and opens modal', function (): void {
     Livewire::test(Communication::class)
         ->call('edit')
-        ->assertOk();
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('communication.id', null)
+        ->assertSet('communication.subject', null)
+        ->assertSet('communication.to', [])
+        ->assertSet('communication.cc', [])
+        ->assertSet('communication.bcc', [])
+        ->assertOpensModal('edit-communication');
 });
 
-test('can call edit with null to create a new communication', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(Communication::class)
         ->call('edit', null)
-        ->assertOk();
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('communication.id', null)
+        ->assertSet('communication.subject', null)
+        ->assertOpensModal('edit-communication');
 });

--- a/tests/Livewire/DataTables/PaymentRunListTest.php
+++ b/tests/Livewire/DataTables/PaymentRunListTest.php
@@ -40,7 +40,8 @@ test('edit loads orders into payment run form', function (): void {
     $paymentRun->orders()->attach($order->getKey(), ['amount' => '100.00']);
 
     $component = Livewire::test(PaymentRunList::class)
-        ->call('edit', $paymentRun);
+        ->call('edit', $paymentRun)
+        ->assertOpensModal('execute-payment-run');
 
     $orders = $component->get('paymentRunForm.orders');
 

--- a/tests/Livewire/DataTables/PurchaseInvoiceListTest.php
+++ b/tests/Livewire/DataTables/PurchaseInvoiceListTest.php
@@ -49,3 +49,10 @@ test('augmentItemArray sets url from media', function (): void {
         ->and($itemArray)->toHaveKey('media.file_name')
         ->and($itemArray['media.file_name'])->toBe('invoice.jpg');
 });
+
+test('open new modal', function (): void {
+    Livewire::test(PurchaseInvoiceList::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/DataTables/PurchaseInvoiceListTest.php
+++ b/tests/Livewire/DataTables/PurchaseInvoiceListTest.php
@@ -50,9 +50,13 @@ test('augmentItemArray sets url from media', function (): void {
         ->and($itemArray['media.file_name'])->toBe('invoice.jpg');
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(PurchaseInvoiceList::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('purchaseInvoiceForm.id', null)
+        ->assertSet('purchaseInvoiceForm.invoice_number', null)
+        ->assertSet('purchaseInvoiceForm.contact_id', null)
+        ->assertOpensModal('edit-purchase-invoice-modal');
 });

--- a/tests/Livewire/Settings/EmailTemplatesTest.php
+++ b/tests/Livewire/Settings/EmailTemplatesTest.php
@@ -35,6 +35,7 @@ test('can update email template', function (): void {
     Livewire::test(EmailTemplates::class)
         ->assertOk()
         ->call('edit', $this->emailTemplate->id)
+        ->assertOpensModal()
         ->assertSet('emailTemplateForm.id', $this->emailTemplate->id)
         ->set('emailTemplateForm.name', 'Updated Name')
         ->set('emailTemplateForm.subject', 'Updated Subject')
@@ -53,6 +54,7 @@ test('can delete email template', function (): void {
     Livewire::test(EmailTemplates::class)
         ->assertOk()
         ->call('edit', $emailTemplateId)
+        ->assertOpensModal()
         ->call('delete', $emailTemplateId)
         ->assertOk()
         ->assertHasNoErrors();
@@ -94,6 +96,7 @@ test('can edit existing template and load form data', function (): void {
     Livewire::test(EmailTemplates::class)
         ->assertOk()
         ->call('edit', $this->emailTemplate->id)
+        ->assertOpensModal()
         ->assertSet('emailTemplateForm.id', $this->emailTemplate->id)
         ->assertSet('emailTemplateForm.name', $this->emailTemplate->name)
         ->assertSet('emailTemplateForm.subject', $this->emailTemplate->subject);

--- a/tests/Livewire/Settings/PermissionsTest.php
+++ b/tests/Livewire/Settings/PermissionsTest.php
@@ -8,9 +8,13 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(Permissions::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('roleForm.id', null)
+        ->assertSet('roleForm.name', null)
+        ->assertSet('roleForm.guard_name', null)
+        ->assertOpensModal('edit-role-permissions-modal');
 });

--- a/tests/Livewire/Settings/PermissionsTest.php
+++ b/tests/Livewire/Settings/PermissionsTest.php
@@ -7,3 +7,10 @@ test('renders successfully', function (): void {
     Livewire::test(Permissions::class)
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    Livewire::test(Permissions::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Settings/ProductOptionGroupsTest.php
+++ b/tests/Livewire/Settings/ProductOptionGroupsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use FluxErp\Livewire\Settings\ProductOptionGroups;
+use FluxErp\Models\ProductOptionGroup;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -8,9 +9,25 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(ProductOptionGroups::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('productOptionGroupForm.id', null)
+        ->assertSet('productOptionGroupForm.name', null)
+        ->assertSet('productOptionGroupForm.product_options', [])
+        ->assertOpensModal('edit-product-option-group-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+
+    Livewire::test(ProductOptionGroups::class)
+        ->call('edit', $group->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('productOptionGroupForm.id', $group->getKey())
+        ->assertSet('productOptionGroupForm.name', $group->name)
+        ->assertOpensModal('edit-product-option-group-modal');
 });

--- a/tests/Livewire/Settings/ProductOptionGroupsTest.php
+++ b/tests/Livewire/Settings/ProductOptionGroupsTest.php
@@ -7,3 +7,10 @@ test('renders successfully', function (): void {
     Livewire::test(ProductOptionGroups::class)
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    Livewire::test(ProductOptionGroups::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Settings/ProductPropertyGroupsTest.php
+++ b/tests/Livewire/Settings/ProductPropertyGroupsTest.php
@@ -8,9 +8,13 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(ProductPropertyGroups::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('productPropertyGroup.id', null)
+        ->assertSet('productPropertyGroup.name', null)
+        ->assertSet('productPropertyGroup.product_properties', [])
+        ->assertOpensModal('edit-product-property-group-modal');
 });

--- a/tests/Livewire/Settings/ProductPropertyGroupsTest.php
+++ b/tests/Livewire/Settings/ProductPropertyGroupsTest.php
@@ -7,3 +7,10 @@ test('renders successfully', function (): void {
     Livewire::test(ProductPropertyGroups::class)
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    Livewire::test(ProductPropertyGroups::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Settings/TargetsTest.php
+++ b/tests/Livewire/Settings/TargetsTest.php
@@ -25,6 +25,8 @@ test('edit preserves saved dropdown values', function (): void {
 
     Livewire::test(Targets::class)
         ->call('edit', $target->getKey())
+        ->assertOk()
+        ->assertOpensModal()
         ->assertSet('target.timeframe_column', 'invoice_date')
         ->assertSet('target.aggregate_type', 'sum')
         ->assertSet('target.aggregate_column', 'total_net_price')

--- a/tests/Livewire/Settings/TenantsTest.php
+++ b/tests/Livewire/Settings/TenantsTest.php
@@ -7,3 +7,10 @@ test('renders successfully', function (): void {
     Livewire::test(Tenants::class)
         ->assertOk();
 });
+
+test('open new modal', function (): void {
+    Livewire::test(Tenants::class)
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Settings/TenantsTest.php
+++ b/tests/Livewire/Settings/TenantsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use FluxErp\Livewire\Settings\Tenants;
+use FluxErp\Models\Tenant;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -8,9 +9,26 @@ test('renders successfully', function (): void {
         ->assertOk();
 });
 
-test('open new modal', function (): void {
+test('edit with null resets form and opens modal', function (): void {
     Livewire::test(Tenants::class)
         ->call('edit', null)
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertSet('tenant.id', null)
+        ->assertSet('tenant.name', null)
+        ->assertSet('tenant.ceo', null)
+        ->assertSet('tenant.city', null)
+        ->assertOpensModal('edit-tenant');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $tenant = Tenant::factory()->create();
+
+    Livewire::test(Tenants::class)
+        ->call('edit', $tenant->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('tenant.id', $tenant->getKey())
+        ->assertSet('tenant.name', $tenant->name)
+        ->assertOpensModal('edit-tenant');
 });

--- a/tests/Livewire/Task/TaskListTest.php
+++ b/tests/Livewire/Task/TaskListTest.php
@@ -9,6 +9,7 @@ test('create new task', function (): void {
     Livewire::actingAs($this->user)
         ->test(TaskList::class)
         ->call('edit')
+        ->assertOpensModal('new-task-modal')
         ->assertSet('task.responsible_user_id', $this->user->id)
         ->set('task.name', $taskName = Str::uuid())
         ->set('task.description', $taskDescription = Str::uuid())


### PR DESCRIPTION
remove deprecated forceRender calls

## Summary by Sourcery

Handle nullable records when opening edit modals across multiple Livewire components and remove deprecated forceRender usage.

Bug Fixes:
- Prevent null reference errors when calling edit methods with a null model by guarding fill and relationship loading across settings, contact accounting, communication, and datatable components.

Enhancements:
- Reset related form and media state before opening edit modals and make tab update hooks no-ops instead of forcing Livewire re-renders.
- Simplify target settings reactive methods by removing unnecessary forceRender calls.

Tests:
- Add tests to ensure calling edit with null opens modals or performs correctly without errors for various Livewire components, including bank connections, SEPA mandates, purchase invoices, permissions, product option/property groups, tenants, and communications.