### PR TITLE
Add ext-xsl to CI Docker image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git curl zip unzip libpng-dev libjpeg-dev libfreetype6-dev \
-      libzip-dev libicu-dev libonig-dev libexif-dev libmagickwand-dev \
+      libzip-dev libicu-dev libonig-dev libexif-dev libmagickwand-dev libxslt1-dev \
       gnupg ca-certificates \
     && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
          curl -sL "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-client-core_8.0.42-1debian12_amd64.deb" -o /tmp/mysql-client.deb \
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          apt-get install -y --no-install-recommends default-mysql-client; \
        fi \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) pdo_mysql gd zip bcmath intl exif pcntl sockets \
+    && docker-php-ext-install -j$(nproc) pdo_mysql gd zip bcmath intl exif pcntl sockets xsl \
     && pecl install imagick redis xdebug && docker-php-ext-enable imagick redis xdebug \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/docker/8.5/Dockerfile
+++ b/docker/8.5/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
        php8.5-pgsql php8.5-sqlite3 php8.5-gd \
        php8.5-curl php8.5-mongodb \
        php8.5-imap php8.5-mysql php8.5-mbstring \
-       php8.5-xml php8.5-zip php8.5-bcmath php8.5-soap \
+       php8.5-xml php8.5-xsl php8.5-zip php8.5-bcmath php8.5-soap \
        php8.5-intl php8.5-readline \
        php8.5-ldap \
        php8.5-msgpack php8.5-igbinary php8.5-redis \


### PR DESCRIPTION
## Summary
- Add `php8.5-xsl` package to the CI Docker image