### PR TITLE
Extend Livewire test coverage with CRUD assertions

### DIFF
--- a/tests/Livewire/AbsenceRequest/AbsenceRequestTest.php
+++ b/tests/Livewire/AbsenceRequest/AbsenceRequestTest.php
@@ -2,10 +2,13 @@
 
 use FluxErp\Enums\AbsenceRequestDayPartEnum;
 use FluxErp\Enums\EmployeeCanCreateEnum;
+use FluxErp\Enums\OvertimeCompensationEnum;
 use FluxErp\Livewire\AbsenceRequest\AbsenceRequest;
 use FluxErp\Models\AbsenceRequest as AbsenceRequestModel;
 use FluxErp\Models\AbsenceType;
 use FluxErp\Models\Employee;
+use FluxErp\Models\Pivots\EmployeeWorkTimeModel;
+use FluxErp\Models\WorkTimeModel;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -39,4 +42,176 @@ test('renders successfully', function (): void {
 
     Livewire::test(AbsenceRequest::class, ['id' => $absenceRequest->getKey()])
         ->assertOk();
+});
+
+test('mount fills form with absence request data', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Urlaub',
+        'code' => 'URL',
+        'color' => '#22c55e',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => false,
+        'affects_vacation' => true,
+        'is_active' => true,
+    ]);
+
+    $startDate = now()->addWeek()->format('Y-m-d');
+
+    $absenceRequest = app(AbsenceRequestModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'state' => 'pending',
+        'day_part' => AbsenceRequestDayPartEnum::FullDay,
+        'start_date' => $startDate,
+        'end_date' => $startDate,
+        'reason' => 'Vacation test',
+    ]);
+
+    Livewire::test(AbsenceRequest::class, ['id' => $absenceRequest->getKey()])
+        ->assertOk()
+        ->assertSet('absenceRequestForm.id', $absenceRequest->getKey())
+        ->assertSet('absenceRequestForm.employee_id', $employee->getKey())
+        ->assertSet('absenceRequestForm.absence_type_id', $absenceType->getKey())
+        ->assertSet('absenceRequestForm.reason', 'Vacation test');
+});
+
+test('can update absence request via save', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Krank',
+        'code' => 'KRK',
+        'color' => '#ef4444',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => true,
+        'affects_vacation' => false,
+        'is_active' => true,
+    ]);
+
+    $absenceRequest = app(AbsenceRequestModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'state' => 'pending',
+        'day_part' => AbsenceRequestDayPartEnum::FullDay,
+        'start_date' => now()->addWeek(),
+        'end_date' => now()->addWeek(),
+    ]);
+
+    Livewire::test(AbsenceRequest::class, ['id' => $absenceRequest->getKey()])
+        ->set('absenceRequestForm.reason', 'Updated reason')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($absenceRequest->refresh()->reason)->toEqual('Updated reason');
+});
+
+test('can approve absence request', function (): void {
+    $workTimeModel = app(WorkTimeModel::class)->create([
+        'name' => 'Standard 40h',
+        'weekly_hours' => 40,
+        'work_days_per_week' => 5,
+        'annual_vacation_days' => 24,
+        'overtime_compensation' => OvertimeCompensationEnum::TimeOff,
+        'is_active' => true,
+    ]);
+
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    app(EmployeeWorkTimeModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'work_time_model_id' => $workTimeModel->getKey(),
+        'valid_from' => now()->subYear(),
+        'valid_until' => null,
+        'annual_vacation_days' => 24,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Krank',
+        'code' => 'KRK',
+        'color' => '#ef4444',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => true,
+        'affects_vacation' => false,
+        'is_active' => true,
+    ]);
+
+    $absenceRequest = app(AbsenceRequestModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'state' => 'pending',
+        'day_part' => AbsenceRequestDayPartEnum::FullDay,
+        'start_date' => now()->next('Monday'),
+        'end_date' => now()->next('Monday'),
+    ]);
+
+    Livewire::test(AbsenceRequest::class, ['id' => $absenceRequest->getKey()])
+        ->call('approve')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($absenceRequest->refresh()->state->value)->toEqual('approved');
+});
+
+test('can reject absence request', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Krank',
+        'code' => 'KRK',
+        'color' => '#ef4444',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => true,
+        'affects_vacation' => false,
+        'is_active' => true,
+    ]);
+
+    $absenceRequest = app(AbsenceRequestModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'state' => 'pending',
+        'day_part' => AbsenceRequestDayPartEnum::FullDay,
+        'start_date' => now()->addWeek(),
+        'end_date' => now()->addWeek(),
+    ]);
+
+    Livewire::test(AbsenceRequest::class, ['id' => $absenceRequest->getKey()])
+        ->call('reject')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($absenceRequest->refresh()->state->value)->toEqual('rejected');
 });

--- a/tests/Livewire/Contact/Accounting/CreditAccountsTest.php
+++ b/tests/Livewire/Contact/Accounting/CreditAccountsTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Livewire\Contact\Accounting\CreditAccounts;
 use FluxErp\Models\Contact;
+use FluxErp\Models\ContactBankConnection;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -9,4 +10,154 @@ test('renders successfully', function (): void {
 
     Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('contactBankConnection.id', null)
+        ->assertSet('contactBankConnection.iban', null)
+        ->assertSet('contactBankConnection.account_holder', null)
+        ->assertSet('contactBankConnection.bank_name', null)
+        ->assertOpensModal('edit-contact-bank-connection');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_credit_account' => true,
+    ]);
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $bankConnection->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('contactBankConnection.id', $bankConnection->getKey())
+        ->assertSet('contactBankConnection.iban', $bankConnection->iban)
+        ->assertSet('contactBankConnection.bank_name', $bankConnection->bank_name)
+        ->assertOpensModal('edit-contact-bank-connection');
+});
+
+test('can create credit account', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->set('contactBankConnection.bank_name', 'Test Credit Account')
+        ->set('contactBankConnection.account_holder', 'John Doe')
+        ->set('contactBankConnection.iban', 'DE89370400440532013000')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('contact_bank_connections', [
+        'contact_id' => $contact->getKey(),
+        'bank_name' => 'Test Credit Account',
+        'is_credit_account' => true,
+    ]);
+});
+
+test('can update credit account', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_credit_account' => true,
+        'bic' => null,
+    ]);
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $bankConnection->getKey())
+        ->assertSet('contactBankConnection.id', $bankConnection->getKey())
+        ->set('contactBankConnection.bank_name', 'Updated Credit Account')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($bankConnection->refresh()->bank_name)->toEqual('Updated Credit Account');
+});
+
+test('can delete credit account', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_credit_account' => true,
+    ]);
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('delete', $bankConnection->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('contact_bank_connections', [
+        'id' => $bankConnection->getKey(),
+    ]);
+});
+
+test('create transaction opens modal', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_credit_account' => true,
+    ]);
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('createTransaction', $bankConnection->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('transactionForm.contact_bank_connection_id', $bankConnection->getKey())
+        ->assertSet('transactionForm.booking_date', now()->format('Y-m-d'))
+        ->assertSet('transactionForm.value_date', now()->format('Y-m-d'))
+        ->assertExecutesJs("\$tsui.open.modal('transaction-details-modal')");
+});
+
+test('can save transaction', function (): void {
+    $contact = Contact::factory()->create();
+    $bankConnection = ContactBankConnection::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_credit_account' => true,
+    ]);
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->call('createTransaction', $bankConnection->getKey())
+        ->set('transactionForm.amount', 100.50)
+        ->set('transactionForm.purpose', 'Test Transaction')
+        ->call('saveTransaction')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('transactions', [
+        'contact_bank_connection_id' => $bankConnection->getKey(),
+        'amount' => 100.50,
+        'purpose' => 'Test Transaction',
+    ]);
+});
+
+test('save transaction validation fails with missing required fields', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->set('transactionForm.amount', null)
+        ->set('transactionForm.booking_date', null)
+        ->set('transactionForm.value_date', null)
+        ->call('saveTransaction')
+        ->assertOk()
+        ->assertReturned(false);
+});
+
+test('save credit account validation fails with missing contact', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(CreditAccounts::class, ['contactId' => $contact->getKey()])
+        ->set('contactBankConnection.iban', 'invalid-iban')
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Contact/Accounting/DiscountsTest.php
+++ b/tests/Livewire/Contact/Accounting/DiscountsTest.php
@@ -2,6 +2,8 @@
 
 use FluxErp\Livewire\Contact\Accounting\Discounts;
 use FluxErp\Models\Contact;
+use FluxErp\Models\Discount;
+use FluxErp\Models\Product;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -9,4 +11,139 @@ test('renders successfully', function (): void {
 
     Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
         ->assertOk();
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('discountForm.id', $discount->getKey())
+        ->assertOpensModal('edit-discount-modal');
+});
+
+test('reset discount clears form', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->assertSet('discountForm.id', $discount->getKey())
+        ->call('resetDiscount')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('discountForm.id', null)
+        ->assertSet('discountForm.discount', null)
+        ->assertSet('discountForm.name', null);
+});
+
+test('can create discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->set('discountForm.model_type', morph_alias(Product::class))
+        ->set('discountForm.model_id', $product->getKey())
+        ->set('discountForm.discount', 10)
+        ->set('discountForm.is_percentage', true)
+        ->set('discountForm.name', 'Test Discount')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('discounts', [
+        'name' => 'Test Discount',
+        'is_percentage' => true,
+    ]);
+
+    $discount = Discount::query()->where('name', 'Test Discount')->first();
+    expect($contact->discounts()->whereKey($discount->getKey())->exists())->toBeTrue();
+});
+
+test('can update discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => false,
+        'discount' => 5,
+        'name' => 'Old Name',
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->set('discountForm.name', 'Updated Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($discount->refresh()->name)->toEqual('Updated Name');
+});
+
+test('can delete discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('delete', $discount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('discounts', [
+        'id' => $discount->getKey(),
+    ]);
+});
+
+test('save validation fails with missing required fields', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->set('discountForm.model_type', morph_alias(Product::class))
+        ->set('discountForm.model_id', $product->getKey())
+        ->set('discountForm.discount', null)
+        ->set('discountForm.is_percentage', true)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Contact/Accounting/DiscountsTest.php
+++ b/tests/Livewire/Contact/Accounting/DiscountsTest.php
@@ -3,6 +3,7 @@
 use FluxErp\Livewire\Contact\Accounting\Discounts;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Discount;
+use FluxErp\Models\Product;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -29,4 +30,139 @@ test('sort rows updates order', function (): void {
         ->assertHasNoErrors();
 
     expect($last->fresh()->order_column)->toBe(1);
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('discountForm.id', $discount->getKey())
+        ->assertOpensModal('edit-discount-modal');
+});
+
+test('reset discount clears form', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->assertSet('discountForm.id', $discount->getKey())
+        ->call('resetDiscount')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('discountForm.id', null)
+        ->assertSet('discountForm.discount', null)
+        ->assertSet('discountForm.name', null);
+});
+
+test('can create discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->set('discountForm.model_type', morph_alias(Product::class))
+        ->set('discountForm.model_id', $product->getKey())
+        ->set('discountForm.discount', 10)
+        ->set('discountForm.is_percentage', true)
+        ->set('discountForm.name', 'Test Discount')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('discounts', [
+        'name' => 'Test Discount',
+        'is_percentage' => true,
+    ]);
+
+    $discount = Discount::query()->where('name', 'Test Discount')->first();
+    expect($contact->discounts()->whereKey($discount->getKey())->exists())->toBeTrue();
+});
+
+test('can update discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => false,
+        'discount' => 5,
+        'name' => 'Old Name',
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $discount->getKey())
+        ->set('discountForm.name', 'Updated Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($discount->refresh()->name)->toEqual('Updated Name');
+});
+
+test('can delete discount', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+    $discount = Discount::factory()->create([
+        'model_type' => morph_alias(Product::class),
+        'model_id' => $product->getKey(),
+        'is_percentage' => true,
+        'discount' => 0.1,
+    ]);
+    $contact->discounts()->attach($discount->getKey());
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('delete', $discount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('discounts', [
+        'id' => $discount->getKey(),
+    ]);
+});
+
+test('save validation fails with missing required fields', function (): void {
+    $contact = Contact::factory()->create();
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->set('discountForm.model_type', morph_alias(Product::class))
+        ->set('discountForm.model_id', $product->getKey())
+        ->set('discountForm.discount', null)
+        ->set('discountForm.is_percentage', true)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Contact/LeadsTest.php
+++ b/tests/Livewire/Contact/LeadsTest.php
@@ -1,9 +1,101 @@
 <?php
 
 use FluxErp\Livewire\Contact\Leads;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Lead;
+use FluxErp\Models\LeadState;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Leads::class)
         ->assertOk();
+});
+
+test('renders with contact id', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->assertOk()
+        ->assertSet('contactId', $contact->getKey());
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('leadForm.id', null)
+        ->assertSet('leadForm.name', null)
+        ->assertOpensModal();
+});
+
+test('edit with null sets address_id from contact main address', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+    $contact->update(['main_address_id' => $address->getKey()]);
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('leadForm.address_id', $address->getKey());
+});
+
+test('edit with id redirects to lead page', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+    ]);
+
+    $leadState = LeadState::factory()->create();
+    $lead = Lead::factory()->create([
+        'address_id' => $address->getKey(),
+        'lead_state_id' => $leadState->getKey(),
+    ]);
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->call('edit', $lead->getKey())
+        ->assertRedirect(route('sales.lead.id', $lead->getKey()));
+});
+
+test('can create lead via save', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+    ]);
+    $leadState = LeadState::factory()->create();
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->set('leadForm.name', 'Test Lead')
+        ->set('leadForm.address_id', $address->getKey())
+        ->set('leadForm.lead_state_id', $leadState->getKey())
+        ->set('leadForm.probability_percentage', 50)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('leads', [
+        'name' => 'Test Lead',
+        'address_id' => $address->getKey(),
+        'lead_state_id' => $leadState->getKey(),
+    ]);
+});
+
+test('save validation fails with missing required fields', function (): void {
+    $contact = Contact::factory()->create();
+
+    Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
+        ->call('edit', null)
+        ->set('leadForm.name', null)
+        ->set('leadForm.address_id', null)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Contact/LeadsTest.php
+++ b/tests/Livewire/Contact/LeadsTest.php
@@ -69,7 +69,10 @@ test('can create lead via save', function (): void {
     $address = Address::factory()->create([
         'contact_id' => $contact->getKey(),
     ]);
-    $leadState = LeadState::factory()->create();
+    $leadState = LeadState::factory()->create([
+        'is_won' => false,
+        'is_lost' => false,
+    ]);
 
     Livewire::test(Leads::class, ['contactId' => $contact->getKey()])
         ->call('edit', null)

--- a/tests/Livewire/Employee/EmployeeBalanceAdjustmentsTest.php
+++ b/tests/Livewire/Employee/EmployeeBalanceAdjustmentsTest.php
@@ -1,9 +1,133 @@
 <?php
 
+use FluxErp\Enums\EmployeeBalanceAdjustmentReasonEnum;
+use FluxErp\Enums\EmployeeBalanceAdjustmentTypeEnum;
 use FluxErp\Livewire\Employee\EmployeeBalanceAdjustments;
+use FluxErp\Models\Employee;
+use FluxErp\Models\EmployeeBalanceAdjustment;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(EmployeeBalanceAdjustments::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(EmployeeBalanceAdjustments::class, ['employeeId' => $employee->getKey()])
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('employeeBalanceAdjustmentForm.id', null)
+        ->assertSet('employeeBalanceAdjustmentForm.amount', null)
+        ->assertSet('employeeBalanceAdjustmentForm.type', null)
+        ->assertOpensModal('employee-balance-adjustment-form-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    $adjustment = app(EmployeeBalanceAdjustment::class)->create([
+        'employee_id' => $employee->getKey(),
+        'type' => EmployeeBalanceAdjustmentTypeEnum::Vacation->value,
+        'amount' => 5,
+        'effective_date' => now()->format('Y-m-d'),
+        'reason' => EmployeeBalanceAdjustmentReasonEnum::Correction,
+        'description' => 'Test adjustment',
+    ]);
+
+    Livewire::test(EmployeeBalanceAdjustments::class, ['employeeId' => $employee->getKey()])
+        ->call('edit', $adjustment->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('employeeBalanceAdjustmentForm.id', $adjustment->getKey())
+        ->assertSet('employeeBalanceAdjustmentForm.description', 'Test adjustment')
+        ->assertOpensModal('employee-balance-adjustment-form-modal');
+});
+
+test('can create balance adjustment via save', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(EmployeeBalanceAdjustments::class, ['employeeId' => $employee->getKey()])
+        ->call('edit')
+        ->set('employeeBalanceAdjustmentForm.type', EmployeeBalanceAdjustmentTypeEnum::Vacation->value)
+        ->set('employeeBalanceAdjustmentForm.amount', 3)
+        ->set('employeeBalanceAdjustmentForm.effective_date', now()->format('Y-m-d'))
+        ->set('employeeBalanceAdjustmentForm.reason', EmployeeBalanceAdjustmentReasonEnum::Correction)
+        ->set('employeeBalanceAdjustmentForm.description', 'Created via test')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('employee_balance_adjustments', [
+        'employee_id' => $employee->getKey(),
+        'type' => EmployeeBalanceAdjustmentTypeEnum::Vacation->value,
+        'description' => 'Created via test',
+    ]);
+});
+
+test('can update balance adjustment via save', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    $adjustment = app(EmployeeBalanceAdjustment::class)->create([
+        'employee_id' => $employee->getKey(),
+        'type' => EmployeeBalanceAdjustmentTypeEnum::Vacation->value,
+        'amount' => 5,
+        'effective_date' => now()->format('Y-m-d'),
+        'reason' => EmployeeBalanceAdjustmentReasonEnum::Correction,
+        'description' => 'Original description',
+    ]);
+
+    Livewire::test(EmployeeBalanceAdjustments::class, ['employeeId' => $employee->getKey()])
+        ->call('edit', $adjustment->getKey())
+        ->set('employeeBalanceAdjustmentForm.description', 'Updated description')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($adjustment->refresh()->description)->toEqual('Updated description');
+});
+
+test('save validates required fields', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(EmployeeBalanceAdjustments::class, ['employeeId' => $employee->getKey()])
+        ->call('edit')
+        ->set('employeeBalanceAdjustmentForm.type', null)
+        ->set('employeeBalanceAdjustmentForm.amount', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Employee/EmployeeTest.php
+++ b/tests/Livewire/Employee/EmployeeTest.php
@@ -16,3 +16,76 @@ test('renders successfully', function (): void {
     Livewire::test(Employee::class, ['id' => $employee->getKey()])
         ->assertOk();
 });
+
+test('mount fills form with employee data', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Max',
+        'lastname' => 'Mustermann',
+        'email' => 'max@example.com',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->assertOk()
+        ->assertSet('employee.id', $employee->getKey())
+        ->assertSet('employee.firstname', 'Max')
+        ->assertSet('employee.lastname', 'Mustermann')
+        ->assertSet('employee.email', 'max@example.com');
+});
+
+test('can update employee via save', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'employment_date' => now()->subYear()->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', 'Updated')
+        ->set('employee.lastname', 'Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $employee->refresh();
+    expect($employee->firstname)->toEqual('Updated');
+    expect($employee->lastname)->toEqual('Name');
+});
+
+test('save validates required fields', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', '')
+        ->set('employee.lastname', '')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('resetForm reloads employee data from database', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Original',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', 'Changed')
+        ->call('resetForm')
+        ->assertSet('employee.firstname', 'Original')
+        ->assertSet('employee.lastname', 'Employee');
+});

--- a/tests/Livewire/Employee/EmployeeTest.php
+++ b/tests/Livewire/Employee/EmployeeTest.php
@@ -18,3 +18,76 @@ test('renders successfully', function (): void {
         ->set('tab', 'employee.general')
         ->assertSee(__('Salary Type'));
 });
+
+test('mount fills form with employee data', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Max',
+        'lastname' => 'Mustermann',
+        'email' => 'max@example.com',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->assertOk()
+        ->assertSet('employee.id', $employee->getKey())
+        ->assertSet('employee.firstname', 'Max')
+        ->assertSet('employee.lastname', 'Mustermann')
+        ->assertSet('employee.email', 'max@example.com');
+});
+
+test('can update employee via save', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'employment_date' => now()->subYear()->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', 'Updated')
+        ->set('employee.lastname', 'Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $employee->refresh();
+    expect($employee->firstname)->toEqual('Updated');
+    expect($employee->lastname)->toEqual('Name');
+});
+
+test('save validates required fields', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', '')
+        ->set('employee.lastname', '')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('resetForm reloads employee data from database', function (): void {
+    $employee = app(EmployeeModel::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Original',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employee::class, ['id' => $employee->getKey()])
+        ->set('employee.firstname', 'Changed')
+        ->call('resetForm')
+        ->assertSet('employee.firstname', 'Original')
+        ->assertSet('employee.lastname', 'Employee');
+});

--- a/tests/Livewire/Features/CommissionRatesTest.php
+++ b/tests/Livewire/Features/CommissionRatesTest.php
@@ -1,9 +1,105 @@
 <?php
 
 use FluxErp\Livewire\Features\CommissionRates;
+use FluxErp\Models\CommissionRate;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(CommissionRates::class, ['userId' => $this->user->id])
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('edit')
+        ->assertSet('commissionRate.id', null)
+        ->assertSet('commissionRate.commission_rate', null)
+        ->assertExecutesJs("\$tsui.open.modal('edit-commission-rate-modal');");
+});
+
+test('edit with model fills form', function (): void {
+    $rate = CommissionRate::factory()->create([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => '0.25',
+    ]);
+
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('edit', $rate->getKey())
+        ->assertSet('commissionRate.id', $rate->getKey())
+        ->assertSet('commissionRate.user_id', $this->user->getKey())
+        ->assertExecutesJs("\$tsui.open.modal('edit-commission-rate-modal');");
+});
+
+test('can create commission rate', function (): void {
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('edit')
+        ->set('commissionRate.commission_rate', '15')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('commission_rates', [
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => '0.15',
+    ]);
+});
+
+test('can update commission rate', function (): void {
+    $rate = CommissionRate::factory()->create([
+        'user_id' => $this->user->getKey(),
+        'commission_rate' => '0.10',
+    ]);
+
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('edit', $rate->getKey())
+        ->set('commissionRate.commission_rate', '20')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('commission_rates', [
+        'id' => $rate->getKey(),
+        'commission_rate' => '0.20',
+    ]);
+});
+
+test('can delete commission rate', function (): void {
+    $rate = CommissionRate::factory()->create([
+        'user_id' => $this->user->getKey(),
+    ]);
+
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('delete', $rate->getKey())
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('commission_rates', [
+        'id' => $rate->getKey(),
+    ]);
+});
+
+test('save assigns user_id from component when not set on form', function (): void {
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->call('edit')
+        ->set('commissionRate.commission_rate', '10')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('commission_rates', [
+        'user_id' => $this->user->getKey(),
+    ]);
+});
+
+test('updating category_id clears product_id', function (): void {
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->set('commissionRate.product_id', 123)
+        ->set('commissionRate.category_id', 456)
+        ->assertSet('commissionRate.product_id', null);
+});
+
+test('updating product_id clears category_id', function (): void {
+    Livewire::test(CommissionRates::class, ['userId' => $this->user->getKey()])
+        ->set('commissionRate.category_id', 456)
+        ->set('commissionRate.product_id', 123)
+        ->assertSet('commissionRate.category_id', null);
 });

--- a/tests/Livewire/Features/CreateTaskModalTest.php
+++ b/tests/Livewire/Features/CreateTaskModalTest.php
@@ -1,9 +1,92 @@
 <?php
 
 use FluxErp\Livewire\Features\CreateTaskModal;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(CreateTaskModal::class)
         ->assertOk();
+});
+
+test('can create a task', function (): void {
+    $name = Str::uuid()->toString();
+
+    Livewire::test(CreateTaskModal::class)
+        ->call('resetTask')
+        ->set('task.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'name' => $name,
+        'responsible_user_id' => $this->user->getKey(),
+        'state' => 'open',
+    ]);
+});
+
+test('save validation fails without name', function (): void {
+    Livewire::test(CreateTaskModal::class)
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('resetTask resets the form', function (): void {
+    Livewire::test(CreateTaskModal::class)
+        ->set('task.name', 'Some Task')
+        ->set('task.description', 'Some description')
+        ->call('resetTask')
+        ->assertSet('task.name', null)
+        ->assertSet('task.description', null)
+        ->assertSet('task.responsible_user_id', $this->user->getKey())
+        ->assertSet('task.users', [$this->user->getKey()]);
+});
+
+test('save sets model type and model id when modelType is set', function (): void {
+    $project = FluxErp\Models\Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $name = Str::uuid()->toString();
+
+    Livewire::test(CreateTaskModal::class)
+        ->set('modelType', morph_alias(FluxErp\Models\Project::class))
+        ->set('modelId', $project->getKey())
+        ->call('resetTask')
+        ->set('task.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'name' => $name,
+        'model_type' => morph_alias(FluxErp\Models\Project::class),
+        'model_id' => $project->getKey(),
+    ]);
+});
+
+test('save clears model type and model id when modelType is null', function (): void {
+    $name = Str::uuid()->toString();
+
+    Livewire::test(CreateTaskModal::class)
+        ->set('modelType', null)
+        ->set('task.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'name' => $name,
+        'model_type' => null,
+        'model_id' => null,
+    ]);
+});
+
+test('form resets after successful save', function (): void {
+    Livewire::test(CreateTaskModal::class)
+        ->set('task.name', 'Test Task')
+        ->call('save')
+        ->assertReturned(true)
+        ->assertSet('task.name', null);
 });

--- a/tests/Livewire/HumanResources/AbsenceRequestsTest.php
+++ b/tests/Livewire/HumanResources/AbsenceRequestsTest.php
@@ -1,9 +1,144 @@
 <?php
 
+use FluxErp\Enums\AbsenceRequestDayPartEnum;
+use FluxErp\Enums\EmployeeCanCreateEnum;
+use FluxErp\Enums\OvertimeCompensationEnum;
 use FluxErp\Livewire\HumanResources\AbsenceRequests;
+use FluxErp\Models\AbsenceType;
+use FluxErp\Models\Employee;
+use FluxErp\Models\Pivots\EmployeeWorkTimeModel;
+use FluxErp\Models\WorkTimeModel;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(AbsenceRequests::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(AbsenceRequests::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('absenceRequestForm.id', null)
+        ->assertSet('absenceRequestForm.employee_id', null)
+        ->assertSet('absenceRequestForm.absence_type_id', null)
+        ->assertOpensModal('absence-request-form-modal');
+});
+
+test('edit with id redirects to detail route', function (): void {
+    $workTimeModel = app(WorkTimeModel::class)->create([
+        'name' => 'Standard 40h',
+        'weekly_hours' => 40,
+        'work_days_per_week' => 5,
+        'annual_vacation_days' => 24,
+        'overtime_compensation' => OvertimeCompensationEnum::TimeOff,
+        'is_active' => true,
+    ]);
+
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    app(EmployeeWorkTimeModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'work_time_model_id' => $workTimeModel->getKey(),
+        'valid_from' => now()->subYear(),
+        'valid_until' => null,
+        'annual_vacation_days' => 24,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Krank',
+        'code' => 'KRK',
+        'color' => '#ef4444',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => true,
+        'affects_vacation' => false,
+        'is_active' => true,
+    ]);
+
+    $absenceRequest = app(FluxErp\Models\AbsenceRequest::class)->create([
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'state' => 'pending',
+        'day_part' => AbsenceRequestDayPartEnum::FullDay,
+        'start_date' => now()->addWeek(),
+        'end_date' => now()->addWeek(),
+    ]);
+
+    Livewire::test(AbsenceRequests::class)
+        ->call('edit', $absenceRequest->getKey())
+        ->assertRedirect();
+});
+
+test('can create absence request via save', function (): void {
+    $workTimeModel = app(WorkTimeModel::class)->create([
+        'name' => 'Standard 40h',
+        'weekly_hours' => 40,
+        'work_days_per_week' => 5,
+        'annual_vacation_days' => 24,
+        'overtime_compensation' => OvertimeCompensationEnum::TimeOff,
+        'is_active' => true,
+    ]);
+
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    app(EmployeeWorkTimeModel::class)->create([
+        'employee_id' => $employee->getKey(),
+        'work_time_model_id' => $workTimeModel->getKey(),
+        'valid_from' => now()->subYear(),
+        'valid_until' => null,
+        'annual_vacation_days' => 24,
+    ]);
+
+    $absenceType = app(AbsenceType::class)->create([
+        'name' => 'Krank',
+        'code' => 'KRK',
+        'color' => '#ef4444',
+        'employee_can_create' => EmployeeCanCreateEnum::Yes,
+        'affects_overtime' => false,
+        'affects_sick_leave' => true,
+        'affects_vacation' => false,
+        'is_active' => true,
+    ]);
+
+    $startDate = now()->next('Monday')->format('Y-m-d');
+
+    Livewire::test(AbsenceRequests::class)
+        ->call('edit')
+        ->set('absenceRequestForm.employee_id', $employee->getKey())
+        ->set('absenceRequestForm.absence_type_id', $absenceType->getKey())
+        ->set('absenceRequestForm.day_part', 'full_day')
+        ->set('absenceRequestForm.start_date', $startDate)
+        ->set('absenceRequestForm.end_date', $startDate)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('absence_requests', [
+        'employee_id' => $employee->getKey(),
+        'absence_type_id' => $absenceType->getKey(),
+        'start_date' => $startDate,
+    ]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(AbsenceRequests::class)
+        ->call('edit')
+        ->set('absenceRequestForm.employee_id', null)
+        ->set('absenceRequestForm.absence_type_id', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/HumanResources/EmployeesTest.php
+++ b/tests/Livewire/HumanResources/EmployeesTest.php
@@ -1,9 +1,80 @@
 <?php
 
+use FluxErp\Enums\OvertimeCompensationEnum;
 use FluxErp\Livewire\HumanResources\Employees;
+use FluxErp\Models\Employee;
+use FluxErp\Models\WorkTimeModel;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Employees::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Employees::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('employeeForm.id', null)
+        ->assertSet('employeeForm.firstname', null)
+        ->assertSet('employeeForm.lastname', null)
+        ->assertOpensModal('employee-form-modal');
+});
+
+test('edit with id redirects to detail route', function (): void {
+    $employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Employees::class)
+        ->call('edit', $employee->getKey())
+        ->assertRedirect();
+});
+
+test('can create employee via save', function (): void {
+    $workTimeModel = app(WorkTimeModel::class)->create([
+        'name' => 'Standard 40h',
+        'weekly_hours' => 40,
+        'work_days_per_week' => 5,
+        'annual_vacation_days' => 24,
+        'overtime_compensation' => OvertimeCompensationEnum::TimeOff,
+        'is_active' => true,
+    ]);
+
+    $newUser = FluxErp\Models\User::factory()->create([
+        'is_active' => true,
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    Livewire::test(Employees::class)
+        ->call('edit')
+        ->set('employeeForm.firstname', 'New')
+        ->set('employeeForm.lastname', 'Employee')
+        ->set('employeeForm.tenant_id', $this->dbTenant->getKey())
+        ->set('employeeForm.user_id', $newUser->getKey())
+        ->set('employeeForm.employment_date', now()->format('Y-m-d'))
+        ->set('employeeForm.work_time_model_id', $workTimeModel->getKey())
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('employees', [
+        'firstname' => 'New',
+        'lastname' => 'Employee',
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Employees::class)
+        ->call('edit')
+        ->set('employeeForm.firstname', null)
+        ->set('employeeForm.lastname', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/HumanResources/WorkTimesTest.php
+++ b/tests/Livewire/HumanResources/WorkTimesTest.php
@@ -1,9 +1,114 @@
 <?php
 
 use FluxErp\Livewire\HumanResources\WorkTimes;
+use FluxErp\Models\WorkTime;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(WorkTimes::class)
         ->assertOk();
+});
+
+test('edit with new work time resets form', function (): void {
+    Livewire::test(WorkTimes::class)
+        ->call('edit', app(WorkTime::class))
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('workTime.id', null)
+        ->assertSet('workTime.user_id', null)
+        ->assertSet('workTime.started_at', null)
+        ->assertSet('workTime.ended_at', null);
+});
+
+test('edit with existing work time fills form', function (): void {
+    $workTime = app(WorkTime::class)->create([
+        'user_id' => $this->user->getKey(),
+        'started_at' => now()->subHours(2)->format('Y-m-d H:i:s'),
+        'ended_at' => now()->subHour()->format('Y-m-d H:i:s'),
+        'name' => 'Test Work',
+        'is_locked' => true,
+        'is_daily_work_time' => false,
+    ]);
+
+    Livewire::test(WorkTimes::class)
+        ->call('edit', $workTime)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('workTime.id', $workTime->getKey())
+        ->assertSet('workTime.name', 'Test Work');
+});
+
+test('can create locked work time via save', function (): void {
+    $startedAt = now()->subHours(3)->format('Y-m-d H:i:s');
+    $endedAt = now()->subHour()->format('Y-m-d H:i:s');
+
+    Livewire::test(WorkTimes::class)
+        ->call('edit', app(WorkTime::class))
+        ->set('workTime.user_id', $this->user->getKey())
+        ->set('workTime.started_at', $startedAt)
+        ->set('workTime.ended_at', $endedAt)
+        ->set('workTime.name', 'Created Work Time')
+        ->set('workTime.is_daily_work_time', false)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('work_times', [
+        'user_id' => $this->user->getKey(),
+        'name' => 'Created Work Time',
+        'is_locked' => true,
+    ]);
+});
+
+test('can update locked work time via save', function (): void {
+    $workTime = app(WorkTime::class)->create([
+        'user_id' => $this->user->getKey(),
+        'started_at' => now()->subHours(2)->format('Y-m-d H:i:s'),
+        'ended_at' => now()->subHour()->format('Y-m-d H:i:s'),
+        'name' => 'Original Work Time',
+        'is_locked' => true,
+        'is_daily_work_time' => false,
+        'paused_time_ms' => 0,
+        'is_billable' => false,
+    ]);
+
+    Livewire::test(WorkTimes::class)
+        ->call('edit', $workTime)
+        ->set('workTime.name', 'Updated Work Time')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect($workTime->refresh()->name)->toEqual('Updated Work Time');
+});
+
+test('can delete work time', function (): void {
+    $workTime = app(WorkTime::class)->create([
+        'user_id' => $this->user->getKey(),
+        'started_at' => now()->subHours(2)->format('Y-m-d H:i:s'),
+        'ended_at' => now()->subHour()->format('Y-m-d H:i:s'),
+        'name' => 'To Delete',
+        'is_locked' => true,
+        'is_daily_work_time' => false,
+    ]);
+
+    Livewire::test(WorkTimes::class)
+        ->call('delete', $workTime)
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('work_times', [
+        'id' => $workTime->getKey(),
+    ]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(WorkTimes::class)
+        ->call('edit', app(WorkTime::class))
+        ->set('workTime.user_id', null)
+        ->set('workTime.started_at', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Lead/LeadTest.php
+++ b/tests/Livewire/Lead/LeadTest.php
@@ -1,9 +1,88 @@
 <?php
 
 use FluxErp\Livewire\Lead\Lead;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Lead as LeadModel;
+use FluxErp\Models\LeadState;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+    ]);
+    $this->leadState = LeadState::factory()->create();
+});
 
 test('renders successfully', function (): void {
     Livewire::test(Lead::class)
         ->assertOk();
+});
+
+test('renders with existing lead', function (): void {
+    $lead = LeadModel::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    Livewire::test(Lead::class, ['id' => $lead])
+        ->assertOk()
+        ->assertSet('leadForm.id', $lead->getKey())
+        ->assertSet('leadForm.name', $lead->name);
+});
+
+test('can save a lead', function (): void {
+    $lead = LeadModel::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    $newName = Str::uuid()->toString();
+
+    Livewire::test(Lead::class, ['id' => $lead])
+        ->set('leadForm.name', $newName)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('leads', [
+        'id' => $lead->getKey(),
+        'name' => $newName,
+    ]);
+});
+
+test('save validation fails without name', function (): void {
+    $lead = LeadModel::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    Livewire::test(Lead::class, ['id' => $lead])
+        ->set('leadForm.name', '')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('resetForm reloads lead data from database', function (): void {
+    $lead = LeadModel::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    Livewire::test(Lead::class, ['id' => $lead])
+        ->set('leadForm.name', 'Changed Name')
+        ->call('resetForm')
+        ->assertSet('leadForm.name', $lead->name);
+});
+
+test('lead form fills user_id with authenticated user', function (): void {
+    $lead = LeadModel::factory()->create([
+        'address_id' => $this->address->getKey(),
+        'lead_state_id' => $this->leadState->getKey(),
+    ]);
+
+    Livewire::test(Lead::class, ['id' => $lead])
+        ->assertSet('leadForm.user_id', $this->user->getKey());
 });

--- a/tests/Livewire/Lead/TasksTest.php
+++ b/tests/Livewire/Lead/TasksTest.php
@@ -2,6 +2,8 @@
 
 use FluxErp\Livewire\Lead\Tasks;
 use FluxErp\Models\Lead;
+use FluxErp\Models\Task;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -9,4 +11,61 @@ test('renders successfully', function (): void {
 
     Livewire::test(Tasks::class, ['modelId' => $lead->getKey()])
         ->assertOk();
+});
+
+test('edit resets form and opens modal', function (): void {
+    $lead = Lead::factory()->create();
+
+    Livewire::test(Tasks::class, ['modelId' => $lead->getKey()])
+        ->call('edit')
+        ->assertSet('task.id', null)
+        ->assertSet('task.name', null)
+        ->assertSet('task.responsible_user_id', $this->user->getKey())
+        ->assertSet('task.users', [$this->user->getKey()])
+        ->assertExecutesJs("\$tsui.open.modal('new-task-modal');");
+});
+
+test('can create a task for a lead', function (): void {
+    $lead = Lead::factory()->create();
+    $name = Str::uuid()->toString();
+
+    Livewire::test(Tasks::class, ['modelId' => $lead->getKey()])
+        ->call('edit')
+        ->set('task.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'name' => $name,
+        'model_type' => morph_alias(Lead::class),
+        'model_id' => $lead->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+});
+
+test('save validation fails without name', function (): void {
+    $lead = Lead::factory()->create();
+
+    Livewire::test(Tasks::class, ['modelId' => $lead->getKey()])
+        ->call('edit')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('task is associated with lead model', function (): void {
+    $lead = Lead::factory()->create();
+    $name = Str::uuid()->toString();
+
+    Livewire::test(Tasks::class, ['modelId' => $lead->getKey()])
+        ->call('edit')
+        ->set('task.name', $name)
+        ->call('save')
+        ->assertReturned(true);
+
+    $task = Task::query()->where('name', $name)->first();
+
+    expect($task)->not->toBeNull()
+        ->and($task->model_type)->toBe(morph_alias(Lead::class))
+        ->and($task->model_id)->toBe($lead->getKey());
 });

--- a/tests/Livewire/Product/BundleListTest.php
+++ b/tests/Livewire/Product/BundleListTest.php
@@ -1,9 +1,125 @@
 <?php
 
+use FluxErp\Livewire\Forms\ProductForm;
 use FluxErp\Livewire\Product\BundleList;
+use FluxErp\Models\Pivots\BundleProductProduct;
+use FluxErp\Models\Product;
 use Livewire\Livewire;
 
+beforeEach(function (): void {
+    $this->product = Product::factory()->create(['is_bundle' => false]);
+    $this->product->tenants()->attach($this->dbTenant->getKey());
+
+    $this->productForm = new ProductForm(Livewire::new(BundleList::class), 'product');
+    $this->productForm->fill($this->product);
+});
+
 test('renders successfully', function (): void {
-    Livewire::test(BundleList::class)
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
         ->assertOk();
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $bundleProduct = Product::factory()->create();
+    $bundleProduct->tenants()->attach($this->dbTenant->getKey());
+
+    $pivot = BundleProductProduct::create([
+        'product_id' => $this->product->getKey(),
+        'bundle_product_id' => $bundleProduct->getKey(),
+        'count' => 3,
+    ]);
+
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->call('edit', $pivot->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('productBundleProductForm.pivot_id', $pivot->getKey())
+        ->assertSet('productBundleProductForm.bundle_product_id', $bundleProduct->getKey())
+        ->assertSet('productBundleProductForm.count', 3)
+        ->assertOpensModal('edit-bundle-product-modal');
+});
+
+test('can create bundle product', function (): void {
+    $bundleProduct = Product::factory()->create();
+    $bundleProduct->tenants()->attach($this->dbTenant->getKey());
+
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->set('productBundleProductForm.bundle_product_id', $bundleProduct->getKey())
+        ->set('productBundleProductForm.count', 5)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('bundle_product_product', [
+        'product_id' => $this->product->getKey(),
+        'bundle_product_id' => $bundleProduct->getKey(),
+        'count' => 5,
+    ]);
+});
+
+test('can update bundle product', function (): void {
+    $bundleProduct = Product::factory()->create();
+    $bundleProduct->tenants()->attach($this->dbTenant->getKey());
+
+    $pivot = BundleProductProduct::create([
+        'product_id' => $this->product->getKey(),
+        'bundle_product_id' => $bundleProduct->getKey(),
+        'count' => 2,
+    ]);
+
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->call('edit', $pivot->getKey())
+        ->set('productBundleProductForm.count', 10)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    expect(BundleProductProduct::query()->whereKey($pivot->getKey())->value('count'))->toEqual(10);
+});
+
+test('can delete bundle product', function (): void {
+    $bundleProduct = Product::factory()->create();
+    $bundleProduct->tenants()->attach($this->dbTenant->getKey());
+
+    $pivot = BundleProductProduct::create([
+        'product_id' => $this->product->getKey(),
+        'bundle_product_id' => $bundleProduct->getKey(),
+        'count' => 2,
+    ]);
+
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->call('delete', $pivot->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('bundle_product_product', [
+        'pivot_id' => $pivot->getKey(),
+    ]);
+});
+
+test('save validation fails with missing required fields', function (): void {
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->set('productBundleProductForm.bundle_product_id', null)
+        ->set('productBundleProductForm.count', null)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
+});
+
+test('save sets is_bundle to true on first bundle product', function (): void {
+    $bundleProduct = Product::factory()->create();
+    $bundleProduct->tenants()->attach($this->dbTenant->getKey());
+
+    expect($this->product->is_bundle)->toBeFalse();
+
+    Livewire::test(BundleList::class, ['product' => $this->productForm])
+        ->set('productBundleProductForm.bundle_product_id', $bundleProduct->getKey())
+        ->set('productBundleProductForm.count', 1)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true)
+        ->assertSet('product.is_bundle', true);
 });

--- a/tests/Livewire/Product/SerialNumber/SerialNumberListTest.php
+++ b/tests/Livewire/Product/SerialNumber/SerialNumberListTest.php
@@ -1,9 +1,61 @@
 <?php
 
 use FluxErp\Livewire\Product\SerialNumber\SerialNumberList;
+use FluxErp\Models\Product;
+use FluxErp\Models\Warehouse;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(SerialNumberList::class)
         ->assertOk();
+});
+
+test('edit resets form and opens modal', function (): void {
+    Livewire::test(SerialNumberList::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('stockPosting.id', null)
+        ->assertSet('stockPosting.product_id', null)
+        ->assertSet('stockPosting.address', ['id' => null, 'quantity' => 1])
+        ->assertOpensModal('create-serial-number-modal');
+});
+
+test('can save serial number', function (): void {
+    $warehouse = Warehouse::factory()->create(['is_default' => true]);
+    $product = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(SerialNumberList::class)
+        ->call('edit')
+        ->set('stockPosting.product_id', $product->getKey())
+        ->set('stockPosting.serial_number.serial_number', 'SN-12345')
+        ->set('stockPosting.purchase_price', 99.99)
+        ->set('stockPosting.address', [])
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('serial_numbers', [
+        'serial_number' => 'SN-12345',
+    ]);
+
+    $this->assertDatabaseHas('stock_postings', [
+        'product_id' => $product->getKey(),
+        'warehouse_id' => $warehouse->getKey(),
+        'posting' => 0,
+    ]);
+});
+
+test('save validation fails with missing product', function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    Livewire::test(SerialNumberList::class)
+        ->call('edit')
+        ->set('stockPosting.product_id', null)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Product/StockPostingListTest.php
+++ b/tests/Livewire/Product/StockPostingListTest.php
@@ -2,13 +2,101 @@
 
 use FluxErp\Livewire\Product\StockPostingList;
 use FluxErp\Models\Product;
+use FluxErp\Models\Warehouse;
 use Livewire\Livewire;
 
-test('renders successfully', function (): void {
-    $product = Product::factory()
+beforeEach(function (): void {
+    $this->warehouse = Warehouse::factory()->create(['is_default' => true]);
+
+    $this->product = Product::factory()
         ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
         ->create();
+});
 
-    Livewire::test(StockPostingList::class, ['productId' => $product->id])
+test('renders successfully', function (): void {
+    Livewire::test(StockPostingList::class, ['productId' => $this->product->getKey()])
         ->assertOk();
+});
+
+test('create resets form and opens modal', function (): void {
+    Livewire::test(StockPostingList::class, ['productId' => $this->product->getKey()])
+        ->call('create')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('stockPosting.id', null)
+        ->assertSet('stockPosting.warehouse_id', $this->warehouse->getKey())
+        ->assertOpensModal('create-stock-posting-modal');
+});
+
+test('create uses warehouse id if set', function (): void {
+    $otherWarehouse = Warehouse::factory()->create();
+
+    Livewire::test(StockPostingList::class, [
+        'productId' => $this->product->getKey(),
+        'warehouseId' => $otherWarehouse->getKey(),
+    ])
+        ->call('create')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('stockPosting.warehouse_id', $otherWarehouse->getKey());
+});
+
+test('can save stock posting', function (): void {
+    Livewire::test(StockPostingList::class, ['productId' => $this->product->getKey()])
+        ->call('create')
+        ->set('stockPosting.posting', 10)
+        ->set('stockPosting.purchase_price', 25.50)
+        ->set('stockPosting.description', 'Test posting')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('stock_postings', [
+        'product_id' => $this->product->getKey(),
+        'warehouse_id' => $this->warehouse->getKey(),
+        'posting' => 10,
+        'description' => 'Test posting',
+    ]);
+});
+
+test('save validation fails with missing posting', function (): void {
+    Livewire::test(StockPostingList::class, ['productId' => $this->product->getKey()])
+        ->call('create')
+        ->set('stockPosting.posting', null)
+        ->call('save')
+        ->assertOk()
+        ->assertReturned(false);
+});
+
+test('mount detects has serial numbers', function (): void {
+    $productWithSerials = Product::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create(['has_serial_numbers' => true]);
+
+    $component = Livewire::test(StockPostingList::class, [
+        'productId' => $productWithSerials->getKey(),
+    ]);
+
+    expect($component->get('hasSerialNumbers'))->toBeTrue();
+});
+
+test('mount detects no serial numbers', function (): void {
+    $component = Livewire::test(StockPostingList::class, [
+        'productId' => $this->product->getKey(),
+    ]);
+
+    expect($component->get('hasSerialNumbers'))->toBeFalse();
+});
+
+test('updated warehouse id sets user filters', function (): void {
+    $otherWarehouse = Warehouse::factory()->create();
+
+    $component = Livewire::test(StockPostingList::class, ['productId' => $this->product->getKey()])
+        ->set('warehouseId', $otherWarehouse->getKey());
+
+    $filters = $component->get('userFilters');
+    expect($filters)->not->toBeEmpty();
+    expect($filters[0][0]['column'])->toEqual('warehouse_id');
+    expect($filters[0][0]['value'])->toEqual($otherWarehouse->getKey());
 });

--- a/tests/Livewire/Product/VariantListTest.php
+++ b/tests/Livewire/Product/VariantListTest.php
@@ -3,13 +3,124 @@
 use FluxErp\Livewire\Forms\ProductForm;
 use FluxErp\Livewire\Product\VariantList;
 use FluxErp\Models\Product;
+use FluxErp\Models\ProductOption;
+use FluxErp\Models\ProductOptionGroup;
+use FluxErp\Models\VatRate;
 use Livewire\Livewire;
 
-test('renders successfully', function (): void {
-    $product = Product::factory()->create();
-    $form = new ProductForm(Livewire::new(VariantList::class), 'product');
-    $form->fill($product);
+beforeEach(function (): void {
+    $this->vatRate = VatRate::factory()->create();
+    $this->product = Product::factory()->create([
+        'parent_id' => null,
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'is_bundle' => false,
+    ]);
+    $this->product->tenants()->attach($this->dbTenant->getKey());
 
-    Livewire::test(VariantList::class, ['product' => $form])
+    $this->productForm = new ProductForm(Livewire::new(VariantList::class), 'product');
+    $this->productForm->fill($this->product);
+});
+
+test('renders successfully', function (): void {
+    Livewire::test(VariantList::class, ['product' => $this->productForm])
         ->assertOk();
+});
+
+test('load options returns options for group', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+    $option = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Option A',
+    ]);
+
+    $component = Livewire::test(VariantList::class, ['product' => $this->productForm])
+        ->call('loadOptions', $group->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($component->get('productOptions'))->not->toBeEmpty();
+    expect($component->get('productOptions.0.name'))->toEqual('Option A');
+});
+
+test('next generates variant plan', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+    $optionA = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Option A',
+    ]);
+    $optionB = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Option B',
+    ]);
+
+    $component = Livewire::test(VariantList::class, ['product' => $this->productForm])
+        ->set('selectedOptions.' . $group->getKey(), [$optionA->getKey(), $optionB->getKey()])
+        ->call('next')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $variants = $component->get('variants');
+    expect($variants)->toHaveKey('new');
+    expect($variants['new'])->toHaveCount(2);
+});
+
+test('save creates new variants', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+    $optionA = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Red',
+    ]);
+
+    Livewire::test(VariantList::class, ['product' => $this->productForm])
+        ->set('selectedOptions.' . $group->getKey(), [$optionA->getKey()])
+        ->call('next')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $children = Product::query()->where('parent_id', $this->product->getKey())->get();
+    expect($children)->toHaveCount(1);
+});
+
+test('save deletes variants not in selection', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+    $optionA = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Red',
+    ]);
+
+    $child = Product::factory()->create([
+        'parent_id' => $this->product->getKey(),
+    ]);
+    $child->tenants()->attach($this->dbTenant->getKey());
+    $child->productOptions()->attach($optionA->getKey());
+
+    Livewire::test(VariantList::class, ['product' => $this->productForm])
+        ->set('selectedOptions.' . $group->getKey(), [])
+        ->call('next')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('products', [
+        'id' => $child->getKey(),
+    ]);
+});
+
+test('mount initializes selected options from existing children', function (): void {
+    $group = ProductOptionGroup::factory()->create();
+    $option = ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Blue',
+    ]);
+
+    $child = Product::factory()->create([
+        'parent_id' => $this->product->getKey(),
+    ]);
+    $child->productOptions()->attach($option->getKey());
+
+    $component = Livewire::test(VariantList::class, ['product' => $this->productForm]);
+
+    $selectedOptions = $component->get('selectedOptions');
+    expect($selectedOptions[$group->getKey()])->toContain($option->getKey());
 });

--- a/tests/Livewire/Project/ProjectListTest.php
+++ b/tests/Livewire/Project/ProjectListTest.php
@@ -1,9 +1,58 @@
 <?php
 
 use FluxErp\Livewire\Project\ProjectList;
+use FluxErp\Models\Project;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(ProjectList::class)
         ->assertOk();
+});
+
+test('createProject resets form and opens modal', function (): void {
+    Livewire::test(ProjectList::class)
+        ->call('createProject')
+        ->assertSet('project.id', null)
+        ->assertSet('project.name', null)
+        ->assertExecutesJs("\$tsui.open.modal('edit-project');");
+});
+
+test('can create a project', function (): void {
+    $name = Str::uuid()->toString();
+
+    Livewire::test(ProjectList::class)
+        ->call('createProject')
+        ->set('project.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('projects', [
+        'name' => $name,
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+});
+
+test('save validation fails without name', function (): void {
+    Livewire::test(ProjectList::class)
+        ->call('createProject')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('project form fills after save', function (): void {
+    $name = Str::uuid()->toString();
+
+    $component = Livewire::test(ProjectList::class)
+        ->call('createProject')
+        ->set('project.name', $name)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $project = Project::query()->where('name', $name)->first();
+
+    expect($project)->not->toBeNull()
+        ->and($project->tenant_id)->toBe($this->dbTenant->getKey());
 });

--- a/tests/Livewire/Project/ProjectTaskListTest.php
+++ b/tests/Livewire/Project/ProjectTaskListTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Livewire\Project\ProjectTaskList;
 use FluxErp\Models\Project;
+use FluxErp\Models\Task;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
@@ -27,5 +28,94 @@ test('can add new task', function (): void {
         'project_id' => $project->id,
         'responsible_user_id' => $this->user->getKey(),
         'state' => 'open',
+    ]);
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit')
+        ->assertExecutesJs("\$tsui.open.modal('task-form-modal');")
+        ->assertSet('task.id', null)
+        ->assertSet('task.name', null)
+        ->assertSet('task.project_id', $project->getKey())
+        ->assertSet('task.responsible_user_id', $this->user->getKey())
+        ->assertSet('task.users', [$this->user->getKey()]);
+});
+
+test('edit with existing task fills form', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit', $task->getKey())
+        ->assertExecutesJs("\$tsui.open.modal('task-form-modal');")
+        ->assertSet('task.id', $task->getKey())
+        ->assertSet('task.name', $task->name)
+        ->assertSet('task.project_id', $project->getKey());
+});
+
+test('save validation fails without name', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('can update existing task', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    $newName = Str::uuid()->toString();
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit', $task->getKey())
+        ->set('task.name', $newName)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'id' => $task->getKey(),
+        'name' => $newName,
+        'project_id' => $project->getKey(),
+    ]);
+});
+
+test('can delete task', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('delete', $task->getKey())
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('tasks', [
+        'id' => $task->getKey(),
     ]);
 });

--- a/tests/Livewire/Project/ProjectTaskListTest.php
+++ b/tests/Livewire/Project/ProjectTaskListTest.php
@@ -143,3 +143,92 @@ test('availableLayouts includes table and kanban', function (): void {
 
     expect($viewData['availableLayouts'])->toBe(['table', 'kanban']);
 });
+
+test('edit with null resets form and opens modal', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit')
+        ->assertExecutesJs("\$tsui.open.modal('task-form-modal');")
+        ->assertSet('task.id', null)
+        ->assertSet('task.name', null)
+        ->assertSet('task.project_id', $project->getKey())
+        ->assertSet('task.responsible_user_id', $this->user->getKey())
+        ->assertSet('task.users', [$this->user->getKey()]);
+});
+
+test('edit with existing task fills form', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit', $task->getKey())
+        ->assertExecutesJs("\$tsui.open.modal('task-form-modal');")
+        ->assertSet('task.id', $task->getKey())
+        ->assertSet('task.name', $task->name)
+        ->assertSet('task.project_id', $project->getKey());
+});
+
+test('save validation fails without name', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit')
+        ->call('save')
+        ->assertReturned(false);
+});
+
+test('can update existing task', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    $newName = Str::uuid()->toString();
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('edit', $task->getKey())
+        ->set('task.name', $newName)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('tasks', [
+        'id' => $task->getKey(),
+        'name' => $newName,
+        'project_id' => $project->getKey(),
+    ]);
+});
+
+test('can delete task', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('delete', $task->getKey())
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('tasks', [
+        'id' => $task->getKey(),
+    ]);
+});

--- a/tests/Livewire/Settings/AddressTypesTest.php
+++ b/tests/Livewire/Settings/AddressTypesTest.php
@@ -1,9 +1,81 @@
 <?php
 
 use FluxErp\Livewire\Settings\AddressTypes;
+use FluxErp\Models\AddressType;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(AddressTypes::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(AddressTypes::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('addressType.id', null)
+        ->assertSet('addressType.name', null)
+        ->assertOpensModal('edit-address-type-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $addressType = AddressType::factory()->create();
+
+    Livewire::test(AddressTypes::class)
+        ->call('edit', $addressType->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('addressType.id', $addressType->getKey())
+        ->assertSet('addressType.name', $addressType->name)
+        ->assertOpensModal('edit-address-type-modal');
+});
+
+test('can create via save', function (): void {
+    Livewire::test(AddressTypes::class)
+        ->call('edit')
+        ->set('addressType.name', 'Test Address Type')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('address_types', ['name' => 'Test Address Type']);
+});
+
+test('can update via save', function (): void {
+    $addressType = AddressType::factory()->create();
+
+    Livewire::test(AddressTypes::class)
+        ->call('edit', $addressType->getKey())
+        ->set('addressType.name', 'Updated Address Type')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('address_types', [
+        'id' => $addressType->getKey(),
+        'name' => 'Updated Address Type',
+    ]);
+});
+
+test('can delete', function (): void {
+    $addressType = AddressType::factory()->create();
+
+    Livewire::test(AddressTypes::class)
+        ->call('delete', $addressType->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('address_types', ['id' => $addressType->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(AddressTypes::class)
+        ->call('edit')
+        ->set('addressType.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/CategoriesTest.php
+++ b/tests/Livewire/Settings/CategoriesTest.php
@@ -1,9 +1,111 @@
 <?php
 
 use FluxErp\Livewire\Settings\Categories;
+use FluxErp\Models\Category;
+use FluxErp\Models\Product;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Categories::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Categories::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('category.id', null)
+        ->assertSet('category.name', null)
+        ->assertSet('category.model_type', null)
+        ->assertSet('category.parent_id', null)
+        ->assertSet('category.is_active', true);
+});
+
+test('edit with model fills form', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(Product::class),
+    ]);
+
+    Livewire::test(Categories::class)
+        ->call('edit', $category->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('category.id', $category->getKey())
+        ->assertSet('category.name', $category->name)
+        ->assertSet('category.model_type', $category->model_type);
+});
+
+test('can create category', function (): void {
+    $name = Str::uuid()->toString();
+
+    Livewire::test(Categories::class)
+        ->call('edit')
+        ->set('category.name', $name)
+        ->set('category.model_type', morph_alias(Product::class))
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('categories', [
+        'name' => $name,
+        'model_type' => morph_alias(Product::class),
+    ]);
+});
+
+test('can update category', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(Product::class),
+    ]);
+
+    Livewire::test(Categories::class)
+        ->call('edit', $category->getKey())
+        ->assertSet('category.id', $category->getKey())
+        ->set('category.name', 'Updated Category Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($category->refresh()->name)->toEqual('Updated Category Name');
+});
+
+test('can delete category', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(Product::class),
+    ]);
+
+    $categoryId = $category->getKey();
+
+    Livewire::test(Categories::class)
+        ->call('delete', $categoryId)
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('categories', [
+        'id' => $categoryId,
+    ]);
+});
+
+test('create category validation fails without required fields', function (): void {
+    Livewire::test(Categories::class)
+        ->call('edit')
+        ->set('category.name', null)
+        ->set('category.model_type', null)
+        ->call('save')
+        ->assertHasErrors();
+});
+
+test('edit resets form when switching from existing to new', function (): void {
+    $category = Category::factory()->create([
+        'model_type' => morph_alias(Product::class),
+    ]);
+
+    Livewire::test(Categories::class)
+        ->call('edit', $category->getKey())
+        ->assertSet('category.id', $category->getKey())
+        ->assertSet('category.name', $category->name)
+        ->call('edit')
+        ->assertSet('category.id', null)
+        ->assertSet('category.name', null);
 });

--- a/tests/Livewire/Settings/CountriesTest.php
+++ b/tests/Livewire/Settings/CountriesTest.php
@@ -1,9 +1,103 @@
 <?php
 
 use FluxErp\Livewire\Settings\Countries;
+use FluxErp\Models\Country;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Language;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Countries::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Countries::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('country.id', null)
+        ->assertSet('country.name', null)
+        ->assertSet('country.iso_alpha2', null)
+        ->assertOpensModal('edit-country-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $country = Country::factory()->create([
+        'language_id' => Language::factory(),
+        'currency_id' => Currency::factory(),
+    ]);
+
+    Livewire::test(Countries::class)
+        ->call('edit', $country->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('country.id', $country->getKey())
+        ->assertSet('country.name', $country->name)
+        ->assertSet('country.iso_alpha2', $country->iso_alpha2)
+        ->assertOpensModal('edit-country-modal');
+});
+
+test('can create via save', function (): void {
+    $language = Language::factory()->create();
+    $currency = Currency::factory()->create();
+
+    Livewire::test(Countries::class)
+        ->call('edit')
+        ->set('country.name', 'Test Country')
+        ->set('country.iso_alpha2', 'ZZ')
+        ->set('country.language_id', $language->getKey())
+        ->set('country.currency_id', $currency->getKey())
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('countries', [
+        'name' => 'Test Country',
+        'iso_alpha2' => 'ZZ',
+    ]);
+});
+
+test('can update via save', function (): void {
+    $country = Country::factory()->create([
+        'language_id' => Language::factory(),
+        'currency_id' => Currency::factory(),
+    ]);
+
+    Livewire::test(Countries::class)
+        ->call('edit', $country->getKey())
+        ->set('country.name', 'Updated Country')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('countries', [
+        'id' => $country->getKey(),
+        'name' => 'Updated Country',
+    ]);
+});
+
+test('can delete', function (): void {
+    $country = Country::factory()->create([
+        'language_id' => Language::factory(),
+        'currency_id' => Currency::factory(),
+    ]);
+
+    Livewire::test(Countries::class)
+        ->call('delete', $country->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('countries', ['id' => $country->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Countries::class)
+        ->call('edit')
+        ->set('country.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/CurrenciesTest.php
+++ b/tests/Livewire/Settings/CurrenciesTest.php
@@ -1,9 +1,91 @@
 <?php
 
 use FluxErp\Livewire\Settings\Currencies;
+use FluxErp\Models\Currency;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Currencies::class)
         ->assertOk();
+});
+
+test('showEditModal with null resets form and opens modal', function (): void {
+    Livewire::test(Currencies::class)
+        ->call('showEditModal')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('selectedCurrency.id', null)
+        ->assertSet('selectedCurrency.name', null)
+        ->assertSet('selectedCurrency.iso', null)
+        ->assertSet('selectedCurrency.symbol', null)
+        ->assertSet('editModal', true);
+});
+
+test('showEditModal with model fills form and opens modal', function (): void {
+    $currency = Currency::factory()->create();
+
+    Livewire::test(Currencies::class)
+        ->call('showEditModal', $currency->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('selectedCurrency.id', $currency->getKey())
+        ->assertSet('selectedCurrency.name', $currency->name)
+        ->assertSet('selectedCurrency.iso', $currency->iso)
+        ->assertSet('selectedCurrency.symbol', $currency->symbol)
+        ->assertSet('editModal', true);
+});
+
+test('can create via save', function (): void {
+    Livewire::test(Currencies::class)
+        ->call('showEditModal')
+        ->set('selectedCurrency.name', 'Test Currency')
+        ->set('selectedCurrency.iso', 'ZZZ')
+        ->set('selectedCurrency.symbol', 'T')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('currencies', [
+        'name' => 'Test Currency',
+        'iso' => 'ZZZ',
+        'symbol' => 'T',
+    ]);
+});
+
+test('can update via save', function (): void {
+    $currency = Currency::factory()->create();
+
+    Livewire::test(Currencies::class)
+        ->call('showEditModal', $currency->getKey())
+        ->set('selectedCurrency.name', 'Updated Currency')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('currencies', [
+        'id' => $currency->getKey(),
+        'name' => 'Updated Currency',
+    ]);
+});
+
+test('can delete', function (): void {
+    $currency = Currency::factory()->create();
+
+    Livewire::test(Currencies::class)
+        ->call('delete', $currency->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('currencies', ['id' => $currency->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Currencies::class)
+        ->call('showEditModal')
+        ->set('selectedCurrency.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/IndustriesTest.php
+++ b/tests/Livewire/Settings/IndustriesTest.php
@@ -1,9 +1,81 @@
 <?php
 
 use FluxErp\Livewire\Settings\Industries;
+use FluxErp\Models\Industry;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Industries::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('industryForm.id', null)
+        ->assertSet('industryForm.name', null)
+        ->assertOpensModal('edit-industry-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('edit', $industry->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('industryForm.id', $industry->getKey())
+        ->assertSet('industryForm.name', $industry->name)
+        ->assertOpensModal('edit-industry-modal');
+});
+
+test('can create via save', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->set('industryForm.name', 'Test Industry')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('industries', ['name' => 'Test Industry']);
+});
+
+test('can update via save', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('edit', $industry->getKey())
+        ->set('industryForm.name', 'Updated Industry')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('industries', [
+        'id' => $industry->getKey(),
+        'name' => 'Updated Industry',
+    ]);
+});
+
+test('can delete', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('delete', $industry->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('industries', ['id' => $industry->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->set('industryForm.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/IndustriesTest.php
+++ b/tests/Livewire/Settings/IndustriesTest.php
@@ -20,3 +20,74 @@ test('sort rows updates order', function (): void {
 
     expect($last->fresh()->order_column)->toBe(1);
 });
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('industryForm.id', null)
+        ->assertSet('industryForm.name', null)
+        ->assertOpensModal('edit-industry-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('edit', $industry->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('industryForm.id', $industry->getKey())
+        ->assertSet('industryForm.name', $industry->name)
+        ->assertOpensModal('edit-industry-modal');
+});
+
+test('can create via save', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->set('industryForm.name', 'Test Industry')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('industries', ['name' => 'Test Industry']);
+});
+
+test('can update via save', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('edit', $industry->getKey())
+        ->set('industryForm.name', 'Updated Industry')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('industries', [
+        'id' => $industry->getKey(),
+        'name' => 'Updated Industry',
+    ]);
+});
+
+test('can delete', function (): void {
+    $industry = Industry::factory()->create();
+
+    Livewire::test(Industries::class)
+        ->call('delete', $industry->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('industries', ['id' => $industry->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Industries::class)
+        ->call('edit')
+        ->set('industryForm.name', null)
+        ->call('save')
+        ->assertReturned(false);
+});

--- a/tests/Livewire/Settings/LanguagesTest.php
+++ b/tests/Livewire/Settings/LanguagesTest.php
@@ -1,9 +1,90 @@
 <?php
 
 use FluxErp\Livewire\Settings\Languages;
+use FluxErp\Models\Language;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Languages::class)
         ->assertOk();
+});
+
+test('showEditModal with null resets form and opens modal', function (): void {
+    Livewire::test(Languages::class)
+        ->call('showEditModal')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('selectedLanguage.id', null)
+        ->assertSet('selectedLanguage.name', null)
+        ->assertSet('selectedLanguage.language_code', null)
+        ->assertSet('selectedLanguage.iso_name', null)
+        ->assertSet('editModal', true);
+});
+
+test('showEditModal with id fills form and opens modal', function (): void {
+    $language = Language::factory()->create();
+
+    Livewire::test(Languages::class)
+        ->call('showEditModal', $language->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('selectedLanguage.id', $language->getKey())
+        ->assertSet('selectedLanguage.name', $language->name)
+        ->assertSet('selectedLanguage.language_code', $language->language_code)
+        ->assertSet('selectedLanguage.iso_name', $language->iso_name)
+        ->assertSet('editModal', true);
+});
+
+test('can create via save', function (): void {
+    Livewire::test(Languages::class)
+        ->call('showEditModal')
+        ->set('selectedLanguage.name', 'Test Language')
+        ->set('selectedLanguage.iso_name', 'Test ISO Name')
+        ->set('selectedLanguage.language_code', 'zz')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('languages', [
+        'name' => 'Test Language',
+        'language_code' => 'zz',
+    ]);
+});
+
+test('can update via save', function (): void {
+    $language = Language::factory()->create();
+
+    Livewire::test(Languages::class)
+        ->call('showEditModal', $language->getKey())
+        ->set('selectedLanguage.name', 'Updated Language')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('languages', [
+        'id' => $language->getKey(),
+        'name' => 'Updated Language',
+    ]);
+});
+
+test('can delete', function (): void {
+    $language = Language::factory()->create();
+
+    Livewire::test(Languages::class)
+        ->call('delete', $language->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('languages', ['id' => $language->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Languages::class)
+        ->call('showEditModal')
+        ->set('selectedLanguage.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/LedgerAccountsTest.php
+++ b/tests/Livewire/Settings/LedgerAccountsTest.php
@@ -1,9 +1,90 @@
 <?php
 
+use FluxErp\Enums\LedgerAccountTypeEnum;
 use FluxErp\Livewire\Settings\LedgerAccounts;
+use FluxErp\Models\LedgerAccount;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(LedgerAccounts::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(LedgerAccounts::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('ledgerAccount.id', null)
+        ->assertSet('ledgerAccount.name', null)
+        ->assertSet('ledgerAccount.number', null)
+        ->assertSet('ledgerAccount.ledger_account_type_enum', null)
+        ->assertOpensModal('edit-ledger-account-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $ledgerAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(LedgerAccounts::class)
+        ->call('edit', $ledgerAccount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('ledgerAccount.id', $ledgerAccount->getKey())
+        ->assertSet('ledgerAccount.name', $ledgerAccount->name)
+        ->assertSet('ledgerAccount.number', $ledgerAccount->number)
+        ->assertOpensModal('edit-ledger-account-modal');
+});
+
+test('can create ledger account', function (): void {
+    Livewire::test(LedgerAccounts::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('ledgerAccount.name', $name = Str::uuid()->toString())
+        ->set('ledgerAccount.number', '4711')
+        ->set('ledgerAccount.ledger_account_type_enum', LedgerAccountTypeEnum::Revenue->value)
+        ->set('ledgerAccount.tenant_id', $this->dbTenant->getKey())
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('ledger_accounts', [
+        'name' => $name,
+        'number' => '4711',
+    ]);
+});
+
+test('can update ledger account', function (): void {
+    $ledgerAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(LedgerAccounts::class)
+        ->assertOk()
+        ->call('edit', $ledgerAccount->getKey())
+        ->assertSet('ledgerAccount.id', $ledgerAccount->getKey())
+        ->set('ledgerAccount.name', 'Updated LedgerAccount Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($ledgerAccount->refresh()->name)->toEqual('Updated LedgerAccount Name');
+});
+
+test('can delete ledger account', function (): void {
+    $ledgerAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    Livewire::test(LedgerAccounts::class)
+        ->assertOk()
+        ->call('delete', $ledgerAccount->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('ledger_accounts', [
+        'id' => $ledgerAccount->getKey(),
+    ]);
 });

--- a/tests/Livewire/Settings/PaymentReminderTextsTest.php
+++ b/tests/Livewire/Settings/PaymentReminderTextsTest.php
@@ -1,9 +1,92 @@
 <?php
 
 use FluxErp\Livewire\Settings\PaymentReminderTexts;
+use FluxErp\Models\PaymentReminderText;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(PaymentReminderTexts::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('paymentReminderTextForm.id', null)
+        ->assertSet('paymentReminderTextForm.reminder_subject', null)
+        ->assertSet('paymentReminderTextForm.reminder_body', null)
+        ->assertSet('paymentReminderTextForm.reminder_level', null);
+});
+
+test('edit with model fills form', function (): void {
+    $text = PaymentReminderText::factory()->create();
+
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('edit', $text->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('paymentReminderTextForm.id', $text->getKey())
+        ->assertSet('paymentReminderTextForm.reminder_subject', $text->reminder_subject)
+        ->assertSet('paymentReminderTextForm.reminder_level', $text->reminder_level);
+});
+
+test('can create payment reminder text', function (): void {
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('edit')
+        ->set('paymentReminderTextForm.reminder_subject', 'Test Reminder Subject')
+        ->set('paymentReminderTextForm.reminder_body', 'Test reminder body content')
+        ->set('paymentReminderTextForm.reminder_level', 99)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('payment_reminder_texts', [
+        'reminder_subject' => 'Test Reminder Subject',
+        'reminder_level' => 99,
+    ]);
+});
+
+test('can update payment reminder text', function (): void {
+    $text = PaymentReminderText::factory()->create();
+
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('edit', $text->getKey())
+        ->assertSet('paymentReminderTextForm.id', $text->getKey())
+        ->set('paymentReminderTextForm.reminder_subject', 'Updated Subject')
+        ->set('paymentReminderTextForm.reminder_body', 'Updated body content')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $refreshed = $text->refresh();
+    expect($refreshed->reminder_subject)->toEqual('Updated Subject');
+    expect($refreshed->reminder_body)->toEqual('Updated body content');
+});
+
+test('can delete payment reminder text', function (): void {
+    $text = PaymentReminderText::factory()->create();
+    $textId = $text->getKey();
+
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('delete', $textId)
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('payment_reminder_texts', [
+        'id' => $textId,
+    ]);
+});
+
+test('edit resets form when switching from existing to new', function (): void {
+    $text = PaymentReminderText::factory()->create();
+
+    Livewire::test(PaymentReminderTexts::class)
+        ->call('edit', $text->getKey())
+        ->assertSet('paymentReminderTextForm.id', $text->getKey())
+        ->assertSet('paymentReminderTextForm.reminder_subject', $text->reminder_subject)
+        ->call('edit')
+        ->assertSet('paymentReminderTextForm.id', null)
+        ->assertSet('paymentReminderTextForm.reminder_subject', null);
 });

--- a/tests/Livewire/Settings/PaymentTypesTest.php
+++ b/tests/Livewire/Settings/PaymentTypesTest.php
@@ -1,9 +1,85 @@
 <?php
 
 use FluxErp\Livewire\Settings\PaymentTypes;
+use FluxErp\Models\PaymentType;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(PaymentTypes::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(PaymentTypes::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('paymentType.id', null)
+        ->assertSet('paymentType.name', null)
+        ->assertSet('paymentType.is_active', true)
+        ->assertSet('paymentType.is_sales', true)
+        ->assertOpensModal('edit-payment-type-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(PaymentTypes::class)
+        ->call('edit', $paymentType->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('paymentType.id', $paymentType->getKey())
+        ->assertSet('paymentType.name', $paymentType->name)
+        ->assertOpensModal('edit-payment-type-modal');
+});
+
+test('can create payment type', function (): void {
+    Livewire::test(PaymentTypes::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('paymentType.name', $name = Str::uuid()->toString())
+        ->set('paymentType.tenants', [$this->dbTenant->getKey()])
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('payment_types', [
+        'name' => $name,
+    ]);
+});
+
+test('can update payment type', function (): void {
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    Livewire::test(PaymentTypes::class)
+        ->assertOk()
+        ->call('edit', $paymentType->getKey())
+        ->assertSet('paymentType.id', $paymentType->getKey())
+        ->set('paymentType.name', 'Updated PaymentType Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($paymentType->refresh()->name)->toEqual('Updated PaymentType Name');
+});
+
+test('can delete payment type', function (): void {
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create(['is_default' => false]);
+
+    Livewire::test(PaymentTypes::class)
+        ->assertOk()
+        ->call('delete', $paymentType->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('payment_types', [
+        'id' => $paymentType->getKey(),
+    ]);
 });

--- a/tests/Livewire/Settings/PrintersTest.php
+++ b/tests/Livewire/Settings/PrintersTest.php
@@ -1,9 +1,127 @@
 <?php
 
 use FluxErp\Livewire\Settings\Printers;
+use FluxErp\Models\Printer;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Printers::class)
         ->assertOk();
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $printer = Printer::query()->create([
+        'name' => 'Office Printer',
+        'spooler_name' => 'hp-laserjet',
+        'media_sizes' => ['A4', 'A3'],
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Printers::class)
+        ->call('edit', $printer->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('printerForm.id', $printer->getKey())
+        ->assertSet('printerForm.alias', $printer->alias)
+        ->assertSet('printerForm.is_visible', $printer->is_visible)
+        ->assertOpensModal('edit-printer-modal');
+});
+
+test('can update printer alias', function (): void {
+    $printer = Printer::query()->create([
+        'name' => 'Office Printer',
+        'spooler_name' => 'hp-laserjet',
+        'media_sizes' => ['A4'],
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Printers::class)
+        ->call('edit', $printer->getKey())
+        ->assertSet('printerForm.id', $printer->getKey())
+        ->set('printerForm.alias', 'My Printer Alias')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($printer->refresh()->alias)->toEqual('My Printer Alias');
+});
+
+test('can update printer visibility', function (): void {
+    $printer = Printer::query()->create([
+        'name' => 'Office Printer',
+        'spooler_name' => 'hp-laserjet',
+        'media_sizes' => ['A4'],
+        'is_active' => true,
+        'is_visible' => false,
+    ]);
+
+    Livewire::test(Printers::class)
+        ->call('edit', $printer->getKey())
+        ->assertSet('printerForm.is_visible', false)
+        ->set('printerForm.is_visible', true)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($printer->refresh()->is_visible)->toBeTrue();
+});
+
+test('can delete spooler and associated printers', function (): void {
+    $spoolerName = 'test-spooler-delete';
+
+    $printer1 = Printer::query()->create([
+        'name' => 'Printer 1',
+        'spooler_name' => $spoolerName,
+        'media_sizes' => ['A4'],
+        'is_active' => true,
+    ]);
+
+    $printer2 = Printer::query()->create([
+        'name' => 'Printer 2',
+        'spooler_name' => $spoolerName,
+        'media_sizes' => ['A4'],
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Printers::class)
+        ->set('deleteSpoolerName', $spoolerName)
+        ->call('deleteSpooler')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('printers', ['id' => $printer1->getKey()]);
+    $this->assertDatabaseMissing('printers', ['id' => $printer2->getKey()]);
+});
+
+test('delete spooler fails without spooler name', function (): void {
+    $result = Livewire::test(Printers::class)
+        ->call('deleteSpooler');
+
+    $result->assertOk();
+});
+
+test('edit resets form between different printers', function (): void {
+    $printer1 = Printer::query()->create([
+        'name' => 'Printer One',
+        'spooler_name' => 'spooler-1',
+        'media_sizes' => ['A4'],
+        'alias' => 'First Alias',
+        'is_active' => true,
+    ]);
+
+    $printer2 = Printer::query()->create([
+        'name' => 'Printer Two',
+        'spooler_name' => 'spooler-2',
+        'media_sizes' => ['A3'],
+        'alias' => 'Second Alias',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Printers::class)
+        ->call('edit', $printer1->getKey())
+        ->assertSet('printerForm.id', $printer1->getKey())
+        ->assertSet('printerForm.alias', 'First Alias')
+        ->call('edit', $printer2->getKey())
+        ->assertSet('printerForm.id', $printer2->getKey())
+        ->assertSet('printerForm.alias', 'Second Alias');
 });

--- a/tests/Livewire/Settings/SchedulingTest.php
+++ b/tests/Livewire/Settings/SchedulingTest.php
@@ -7,3 +7,13 @@ test('renders successfully', function (): void {
     Livewire::test(Scheduling::class)
         ->assertOk();
 });
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Scheduling::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('schedule.id', null)
+        ->assertSet('schedule.name', null)
+        ->assertSet('schedule.is_active', true);
+});

--- a/tests/Livewire/Settings/SerialNumberRangesTest.php
+++ b/tests/Livewire/Settings/SerialNumberRangesTest.php
@@ -1,9 +1,102 @@
 <?php
 
+use FluxErp\Actions\SerialNumberRange\CreateSerialNumberRange;
 use FluxErp\Livewire\Settings\SerialNumberRanges;
+use FluxErp\Models\Order;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(SerialNumberRanges::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(SerialNumberRanges::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('serialNumberRange.id', null)
+        ->assertSet('serialNumberRange.model_type', null)
+        ->assertSet('serialNumberRange.type', null)
+        ->assertSet('serialNumberRange.prefix', null)
+        ->assertOpensModal('edit-serial-number-range-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $serialNumberRange = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(Order::class),
+        'type' => 'test_number',
+        'prefix' => 'TST-',
+        'start_number' => 1,
+    ])->validate()->execute();
+
+    Livewire::test(SerialNumberRanges::class)
+        ->call('edit', $serialNumberRange->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('serialNumberRange.id', $serialNumberRange->getKey())
+        ->assertSet('serialNumberRange.prefix', 'TST-')
+        ->assertOpensModal('edit-serial-number-range-modal');
+});
+
+test('can create serial number range', function (): void {
+    Livewire::test(SerialNumberRanges::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('serialNumberRange.tenant_id', $this->dbTenant->getKey())
+        ->set('serialNumberRange.model_type', morph_alias(Order::class))
+        ->set('serialNumberRange.type', 'livewire_test')
+        ->set('serialNumberRange.prefix', 'LW-')
+        ->set('serialNumberRange.current_number', 0)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('serial_number_ranges', [
+        'type' => 'livewire_test',
+        'prefix' => 'LW-',
+    ]);
+});
+
+test('can update serial number range', function (): void {
+    $serialNumberRange = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(Order::class),
+        'type' => 'update_test',
+        'prefix' => 'OLD-',
+        'start_number' => 100,
+    ])->validate()->execute();
+
+    Livewire::test(SerialNumberRanges::class)
+        ->assertOk()
+        ->call('edit', $serialNumberRange->getKey())
+        ->assertSet('serialNumberRange.id', $serialNumberRange->getKey())
+        ->set('serialNumberRange.prefix', 'NEW-')
+        ->set('serialNumberRange.length', 4)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($serialNumberRange->refresh()->prefix)->toEqual('NEW-');
+});
+
+test('can delete serial number range', function (): void {
+    $serialNumberRange = CreateSerialNumberRange::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'model_type' => morph_alias(Order::class),
+        'type' => 'delete_test',
+        'start_number' => 1,
+    ])->validate()->execute();
+
+    Livewire::test(SerialNumberRanges::class)
+        ->assertOk()
+        ->call('delete', $serialNumberRange->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('serial_number_ranges', [
+        'id' => $serialNumberRange->getKey(),
+        'deleted_at' => null,
+    ]);
 });

--- a/tests/Livewire/Settings/TagsTest.php
+++ b/tests/Livewire/Settings/TagsTest.php
@@ -1,9 +1,80 @@
 <?php
 
 use FluxErp\Livewire\Settings\Tags;
+use FluxErp\Models\Tag;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Tags::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Tags::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('tagForm.id', null)
+        ->assertSet('tagForm.name', null)
+        ->assertSet('tagForm.color', null)
+        ->assertSet('tagForm.type', null)
+        ->assertOpensModal('edit-tag-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $tag = Tag::factory()->create();
+
+    Livewire::test(Tags::class)
+        ->call('edit', $tag->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('tagForm.id', $tag->getKey())
+        ->assertSet('tagForm.name', $tag->name)
+        ->assertOpensModal('edit-tag-modal');
+});
+
+test('can create tag', function (): void {
+    Livewire::test(Tags::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('tagForm.name', $name = Str::uuid()->toString())
+        ->set('tagForm.type', 'test_type')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('tags', [
+        'name' => $name,
+        'type' => 'test_type',
+    ]);
+});
+
+test('can update tag', function (): void {
+    $tag = Tag::factory()->create();
+
+    Livewire::test(Tags::class)
+        ->assertOk()
+        ->call('edit', $tag->getKey())
+        ->assertSet('tagForm.id', $tag->getKey())
+        ->set('tagForm.name', 'Updated Tag Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($tag->refresh()->name)->toEqual('Updated Tag Name');
+});
+
+test('can delete tag', function (): void {
+    $tag = Tag::factory()->create();
+
+    Livewire::test(Tags::class)
+        ->assertOk()
+        ->call('delete', $tag->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseMissing('tags', [
+        'id' => $tag->getKey(),
+    ]);
 });

--- a/tests/Livewire/Settings/UnitsTest.php
+++ b/tests/Livewire/Settings/UnitsTest.php
@@ -1,9 +1,87 @@
 <?php
 
 use FluxErp\Livewire\Settings\Units;
+use FluxErp\Models\Unit;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Units::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Units::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('unit.id', null)
+        ->assertSet('unit.name', null)
+        ->assertSet('unit.abbreviation', null)
+        ->assertOpensModal('edit-unit-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $unit = Unit::factory()->create();
+
+    Livewire::test(Units::class)
+        ->call('edit', $unit->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('unit.id', $unit->getKey())
+        ->assertSet('unit.name', $unit->name)
+        ->assertSet('unit.abbreviation', $unit->abbreviation)
+        ->assertOpensModal('edit-unit-modal');
+});
+
+test('can create via save', function (): void {
+    Livewire::test(Units::class)
+        ->call('edit')
+        ->set('unit.name', 'Test Unit')
+        ->set('unit.abbreviation', 'tu')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('units', [
+        'name' => 'Test Unit',
+        'abbreviation' => 'tu',
+    ]);
+});
+
+test('can update via save', function (): void {
+    $unit = Unit::factory()->create();
+
+    Livewire::test(Units::class)
+        ->call('edit', $unit->getKey())
+        ->set('unit.name', 'Updated Unit')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertDatabaseHas('units', [
+        'id' => $unit->getKey(),
+        'name' => 'Updated Unit',
+    ]);
+});
+
+test('can delete', function (): void {
+    $unit = Unit::factory()->create();
+
+    Livewire::test(Units::class)
+        ->call('delete', $unit->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('units', ['id' => $unit->getKey()]);
+});
+
+test('save validates required fields', function (): void {
+    Livewire::test(Units::class)
+        ->call('edit')
+        ->set('unit.name', null)
+        ->call('save')
+        ->assertReturned(false);
 });

--- a/tests/Livewire/Settings/VatRatesTest.php
+++ b/tests/Livewire/Settings/VatRatesTest.php
@@ -1,9 +1,80 @@
 <?php
 
 use FluxErp\Livewire\Settings\VatRates;
+use FluxErp\Models\VatRate;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(VatRates::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(VatRates::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('vatRate.id', null)
+        ->assertSet('vatRate.name', null)
+        ->assertSet('vatRate.rate_percentage', null)
+        ->assertOpensModal('edit-vat-rate-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    Livewire::test(VatRates::class)
+        ->call('edit', $vatRate->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('vatRate.id', $vatRate->getKey())
+        ->assertSet('vatRate.name', $vatRate->name)
+        ->assertSet('vatRate.rate_percentage', $vatRate->rate_percentage)
+        ->assertOpensModal('edit-vat-rate-modal');
+});
+
+test('can create vat rate', function (): void {
+    Livewire::test(VatRates::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('vatRate.name', $name = Str::uuid()->toString())
+        ->set('vatRate.rate_percentage_frontend', 19)
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('vat_rates', [
+        'name' => $name,
+        'rate_percentage' => 0.19,
+    ]);
+});
+
+test('can update vat rate', function (): void {
+    $vatRate = VatRate::factory()->create();
+
+    Livewire::test(VatRates::class)
+        ->assertOk()
+        ->call('edit', $vatRate->getKey())
+        ->assertSet('vatRate.id', $vatRate->getKey())
+        ->set('vatRate.name', 'Updated VatRate Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($vatRate->refresh()->name)->toEqual('Updated VatRate Name');
+});
+
+test('can delete vat rate', function (): void {
+    $vatRate = VatRate::factory()->create(['is_default' => false]);
+
+    Livewire::test(VatRates::class)
+        ->assertOk()
+        ->call('delete', $vatRate->getKey())
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('vat_rates', [
+        'id' => $vatRate->getKey(),
+    ]);
 });

--- a/tests/Livewire/Settings/WarehousesTest.php
+++ b/tests/Livewire/Settings/WarehousesTest.php
@@ -1,9 +1,79 @@
 <?php
 
 use FluxErp\Livewire\Settings\Warehouses;
+use FluxErp\Models\Warehouse;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Warehouses::class)
         ->assertOk();
+});
+
+test('edit with null resets form and opens modal', function (): void {
+    Livewire::test(Warehouses::class)
+        ->call('edit')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('warehouse.id', null)
+        ->assertSet('warehouse.name', null)
+        ->assertSet('warehouse.is_default', false)
+        ->assertOpensModal('edit-warehouse-modal');
+});
+
+test('edit with model fills form and opens modal', function (): void {
+    $warehouse = Warehouse::factory()->create();
+
+    Livewire::test(Warehouses::class)
+        ->call('edit', $warehouse->getKey())
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('warehouse.id', $warehouse->getKey())
+        ->assertSet('warehouse.name', $warehouse->name)
+        ->assertOpensModal('edit-warehouse-modal');
+});
+
+test('can create warehouse', function (): void {
+    Livewire::test(Warehouses::class)
+        ->assertOk()
+        ->call('edit')
+        ->set('warehouse.name', $name = Str::uuid()->toString())
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('warehouses', [
+        'name' => $name,
+    ]);
+});
+
+test('can update warehouse', function (): void {
+    $warehouse = Warehouse::factory()->create();
+
+    Livewire::test(Warehouses::class)
+        ->assertOk()
+        ->call('edit', $warehouse->getKey())
+        ->assertSet('warehouse.id', $warehouse->getKey())
+        ->set('warehouse.name', 'Updated Warehouse Name')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($warehouse->refresh()->name)->toEqual('Updated Warehouse Name');
+});
+
+test('can delete warehouse', function (): void {
+    $warehouse = Warehouse::factory()->create();
+
+    Livewire::test(Warehouses::class)
+        ->assertOk()
+        ->call('edit', $warehouse->getKey())
+        ->assertSet('warehouse.id', $warehouse->getKey())
+        ->call('delete')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertSoftDeleted('warehouses', [
+        'id' => $warehouse->getKey(),
+    ]);
 });

--- a/tests/Livewire/Ticket/CommentsTest.php
+++ b/tests/Livewire/Ticket/CommentsTest.php
@@ -1,10 +1,131 @@
 <?php
 
 use FluxErp\Livewire\Ticket\Comments;
+use FluxErp\Models\Comment;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
 use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $this->ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $this->user->getKey(),
+    ]);
+});
 
 test('renders successfully', function (): void {
     Livewire::actingAs($this->user)
         ->test(Comments::class)
         ->assertOk();
+});
+
+test('renders with ticket model id', function (): void {
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->assertOk();
+});
+
+test('can save a comment on a ticket', function (): void {
+    $commentText = 'This is a test comment';
+
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('saveComment', ['comment' => $commentText])
+        ->assertReturned(function (?array $result) use ($commentText): true {
+            expect($result)->not->toBeNull()
+                ->and($result['comment'])->toBe($commentText);
+
+            return true;
+        });
+
+    $this->assertDatabaseHas('comments', [
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+        'comment' => $commentText,
+    ]);
+});
+
+test('save comment returns null on validation failure', function (): void {
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('saveComment', ['comment' => null])
+        ->assertReturned(null);
+});
+
+test('can load comments for a ticket', function (): void {
+    Comment::factory()->count(3)->create([
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+    ]);
+
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('loadComments')
+        ->assertReturned(function (array $comments): true {
+            expect(data_get($comments, 'data'))->toHaveCount(3);
+
+            return true;
+        });
+});
+
+test('can load sticky comments for a ticket', function (): void {
+    Comment::factory()->count(2)->create([
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+    ]);
+
+    Comment::factory()->create([
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+        'is_sticky' => true,
+    ]);
+
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('loadStickyComments')
+        ->assertReturned(function (array $stickyComments): true {
+            expect($stickyComments)->toHaveCount(1);
+
+            return true;
+        });
+});
+
+test('can toggle sticky on a comment', function (): void {
+    $comment = Comment::factory()->create([
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+        'is_sticky' => false,
+    ]);
+
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('toggleSticky', $comment->getKey());
+
+    $this->assertDatabaseHas('comments', [
+        'id' => $comment->getKey(),
+        'is_sticky' => true,
+    ]);
+});
+
+test('can delete a comment', function (): void {
+    $comment = Comment::factory()->create([
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $this->ticket->getKey(),
+    ]);
+
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class, ['modelId' => $this->ticket->getKey()])
+        ->call('delete', $comment->getKey())
+        ->assertReturned(true);
+
+    $this->assertSoftDeleted('comments', [
+        'id' => $comment->getKey(),
+    ]);
+});
+
+test('load comments returns empty for no model id', function (): void {
+    Livewire::withoutLazyLoading()
+        ->test(Comments::class)
+        ->call('loadComments')
+        ->assertReturned([]);
 });


### PR DESCRIPTION
## Summary
- Add CRUD tests for 36 Livewire components (Settings, Contact, Product, HR, Employee, Feature, Project, Lead, Ticket)
- Components go from smoke-only to edit/create/update/delete/validation assertions
- Uses `assertOpensModal()` macro for modal verification
- +3270 lines of tests

## Summary by Sourcery

Expand Livewire component coverage with CRUD, modal, validation, and workflow tests across HR, contact/accounting, product, ticket, project, lead, and settings modules.

Tests:
- Add create/update/delete and validation tests for HR components including absence requests, employees, employee balance adjustments, and work times.
- Add full CRUD and workflow tests for contact-related components such as leads, discounts, credit accounts, comments, and lead tasks.
- Add product lifecycle tests for variants, bundles, stock postings, serial numbers, and related configuration entities like VAT rates, units, warehouses, and categories.
- Add tests for project management features including project list creation and project task CRUD flows.
- Add tests for various settings and configuration components including printers, countries, currencies, languages, ledger accounts, payment types, payment reminder texts, serial number ranges, tags, address types, industries, scheduling, and commission rates.