### PR TITLE
Fix order position list view not updating after add/delete

### DIFF
--- a/resources/views/components/order/order-position-sort-item.blade.php
+++ b/resources/views/components/order/order-position-sort-item.blade.php
@@ -77,7 +77,7 @@
             data-parent-id="{{ data_get($position, "id") }}"
             @if(! $this->order->is_locked)
                 x-sort="$wire.movePosition($item, $position, {{ data_get($position, "id") }})"
-                x-sort:group="{{ data_get($position, "is_free_text") ? "nested-positions" : "bundle-positions-" . data_get($position, "id") }}"
+                x-sort:group="{{ data_get($position, "is_free_text") ? "nested_positions" : "bundle-positions-" . data_get($position, "id") }}"
             @endif
         >
             @if(count($children = data_get($position, "children", [])) > 0)

--- a/resources/views/components/order/sort-order-positions.blade.php
+++ b/resources/views/components/order/sort-order-positions.blade.php
@@ -21,7 +21,7 @@
         class="mt-2 space-y-2"
         @if(! $this->order->is_locked)
             x-sort="$wire.movePosition($item, $position)"
-            x-sort:group="nested - positions"
+            x-sort:group="nested_positions"
         @endif
     >
         @foreach($this->getSortableOrderPositions() as $position)

--- a/src/Livewire/Order/OrderPositions.php
+++ b/src/Livewire/Order/OrderPositions.php
@@ -167,13 +167,8 @@ class OrderPositions extends OrderPositionList
         ];
     }
 
-    #[Renderless]
     public function addOrderPosition(bool $reload = true): bool
     {
-        if ($this->orderPositionsView !== 'table') {
-            $this->forceRender();
-        }
-
         $this->orderPosition->order_id = $this->order->id;
         $this->orderPosition->vat_rate_id = $this->order->vat_rate_id ?? $this->orderPosition->vat_rate_id;
 
@@ -187,7 +182,10 @@ class OrderPositions extends OrderPositionList
 
         if ($reload) {
             $this->recalculateOrderTotals();
-            $this->loadData();
+
+            if ($this->orderPositionsView === 'table') {
+                $this->loadData();
+            }
         }
 
         $this->orderPosition->reset();
@@ -276,13 +274,8 @@ class OrderPositions extends OrderPositionList
         }
     }
 
-    #[Renderless]
     public function deleteOrderPosition(): bool
     {
-        if ($this->orderPositionsView !== 'table') {
-            $this->forceRender();
-        }
-
         try {
             $this->orderPosition->delete();
         } catch (ValidationException|UnauthorizedException $e) {
@@ -291,7 +284,10 @@ class OrderPositions extends OrderPositionList
             return false;
         }
 
-        $this->loadData();
+        if ($this->orderPositionsView === 'table') {
+            $this->loadData();
+        }
+
         $this->recalculateOrderTotals();
 
         return true;
@@ -455,7 +451,6 @@ class OrderPositions extends OrderPositionList
         }
     }
 
-    #[Renderless]
     public function quickAdd(): bool
     {
         $product = null;

--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -877,3 +877,52 @@ test('updating amount on bundle group parent propagates to children', function (
     expect((float) $child1->amount)->toEqual(6);
     expect((float) $child2->amount)->toEqual(15);
 });
+
+test('add order position in list view re-renders with new position', function (): void {
+    $existingPosition = $this->order->orderPositions->first();
+    $testName = 'New List View Position';
+
+    $component = Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->call('switchView', 'list');
+
+    // Verify existing position is shown in list view
+    $component->assertSeeHtml($existingPosition->name);
+
+    $component
+        ->set('orderPosition.name', $testName)
+        ->set('orderPosition.amount', 1)
+        ->set('orderPosition.unit_price', 50)
+        ->set('orderPosition.vat_rate_id', $this->vatRate->id)
+        ->call('addOrderPosition')
+        ->assertReturned(true)
+        ->assertSeeHtml($testName);
+});
+
+test('quick add in list view re-renders with new position', function (): void {
+    Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->call('switchView', 'list')
+        ->set('orderPosition.product_id', $this->product->id)
+        ->call('changedProductId', $this->product)
+        ->call('quickAdd')
+        ->assertReturned(true)
+        ->assertSeeHtml($this->product->name);
+});
+
+test('sort group names match between top level and free text children', function (): void {
+    OrderPosition::factory()->create([
+        'order_id' => $this->order->id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+    ]);
+
+    $html = Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->call('switchView', 'list')
+        ->html();
+
+    preg_match_all('/x-sort:group="([^"]*)"/', $html, $matches);
+    $groups = array_filter($matches[1], fn ($g) => ! str_starts_with($g, 'bundle'));
+
+    expect($groups)->not->toBeEmpty();
+    expect(array_unique($groups))->toHaveCount(1, 'Sort group names must match between top level and free text children');
+});


### PR DESCRIPTION
## Summary
- Fix positions not appearing in sortable list view after add/delete without browser refresh
- Fix drag-and-drop between top-level and free text blocks broken by prettier sort group rename
- Add tests for list view rendering and sort group consistency

## Summary by Sourcery

Ensure order positions list view updates correctly after add and delete operations and align sortable groups between top-level and free-text positions.

Bug Fixes:
- Fix list view not re-rendering after adding an order position.
- Fix list view not re-rendering after deleting an order position.
- Align Alpine x-sort group names between top-level and free-text order positions to restore drag-and-drop behavior.

Tests:
- Add Livewire tests verifying list view re-renders after adding and quick-adding order positions.
- Add test asserting sort group names match between top-level and free-text positions in list view.