### PR TITLE
Restore model link in task dashboard widgets

### DIFF
--- a/resources/views/livewire/widgets/my-responsible-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-responsible-tasks.blade.php
@@ -24,6 +24,16 @@
                         class="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
                     >
                         {!! $task->state->badge() !!}
+                        @if($task->model && method_exists($task->model, 'getUrl') && method_exists($task->model, 'getLabel'))
+                            <a
+                                href="{{ $task->model->getUrl() }}"
+                                wire:navigate
+                                class="truncate hover:text-indigo-500"
+                            >
+                                {{ $task->model->getLabel() }}
+                            </a>
+                        @endif
+
                         @if($task->due_date)
                             <span
                                 class="{{ $task->due_date->isPast() ? 'text-red-500' : '' }}"

--- a/resources/views/livewire/widgets/my-tasks.blade.php
+++ b/resources/views/livewire/widgets/my-tasks.blade.php
@@ -39,6 +39,17 @@
                             </span>
                         @endif
 
+                        @if($task->model && method_exists($task->model, 'getUrl') && method_exists($task->model, 'getLabel'))
+                            <span>&middot;</span>
+                            <a
+                                href="{{ $task->model->getUrl() }}"
+                                wire:navigate
+                                class="truncate hover:text-indigo-500"
+                            >
+                                {{ $task->model->getLabel() }}
+                            </a>
+                        @endif
+
                         @if($task->due_date)
                             <span>&middot;</span>
                             <span


### PR DESCRIPTION
## Summary
- Re-add model link (contact/order info) to my-tasks and my-responsible-tasks dashboard widgets
- Was accidentally removed in widget styling overhaul (6daff4661)
- Model relation was still eager-loaded but not rendered in blade

## Summary by Sourcery

Restore linked model information in task dashboard widgets so users can navigate to related records from their tasks.

Bug Fixes:
- Re-display the related model link (contact/order info) in the my-tasks widget when the model provides URL and label accessors.
- Re-display the related model link in the my-responsible-tasks widget when the model provides URL and label accessors.