### PR TITLE
Add SalutationEnum cast to Address model

### DIFF
--- a/src/Enums/SalutationEnum.php
+++ b/src/Enums/SalutationEnum.php
@@ -4,6 +4,7 @@ namespace FluxErp\Enums;
 
 use FluxErp\Enums\Traits\EnumTrait;
 use FluxErp\Support\Enums\FluxEnum;
+use Illuminate\Database\Eloquent\Model;
 
 class SalutationEnum extends FluxEnum
 {
@@ -53,5 +54,14 @@ class SalutationEnum extends FluxEnum
                 default => __('salutation.informal.no_salutation', $parameter),
             };
         }
+    }
+
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?object
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return static::tryFrom($value) ?? (object) ['name' => $value, 'value' => $value];
     }
 }

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -342,6 +342,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
     {
         return [
             'date_of_birth' => 'date',
+            'salutation' => SalutationEnum::class,
             'advertising_state' => AdvertisingState::class,
             'password' => 'hashed',
             'search_aliases' => 'array',

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -341,11 +341,11 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
     protected function casts(): array
     {
         return [
-            'date_of_birth' => 'date',
             'salutation' => SalutationEnum::class,
-            'advertising_state' => AdvertisingState::class,
+            'date_of_birth' => 'date',
             'password' => 'hashed',
             'search_aliases' => 'array',
+            'advertising_state' => AdvertisingState::class,
             'has_formal_salutation' => 'boolean',
             'is_main_address' => 'boolean',
             'is_invoice_address' => 'boolean',

--- a/tests/Feature/Api/AddressTest.php
+++ b/tests/Feature/Api/AddressTest.php
@@ -230,7 +230,7 @@ test('get address', function (): void {
     expect($jsonAddress->contact_id)->toEqual($this->addresses[0]->contact_id);
     expect($jsonAddress->company)->toEqual($this->addresses[0]->company);
     expect($jsonAddress->title)->toEqual($this->addresses[0]->title);
-    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation);
+    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation->value);
     expect($jsonAddress->firstname)->toEqual($this->addresses[0]->firstname);
     expect($jsonAddress->lastname)->toEqual($this->addresses[0]->lastname);
     expect($jsonAddress->addition)->toEqual($this->addresses[0]->addition);
@@ -279,7 +279,7 @@ test('get addresses', function (): void {
                 $jsonAddress->contact_id === $address->contact_id &&
                 $jsonAddress->company === $address->company &&
                 $jsonAddress->title === $address->title &&
-                $jsonAddress->salutation === $address->salutation &&
+                $jsonAddress->salutation === $address->salutation?->value &&
                 $jsonAddress->firstname === $address->firstname &&
                 $jsonAddress->lastname === $address->lastname &&
                 $jsonAddress->addition === $address->addition &&

--- a/tests/Feature/Api/AddressTest.php
+++ b/tests/Feature/Api/AddressTest.php
@@ -155,7 +155,7 @@ test('create address maximum', function (): void {
     expect($dbAddress->country_id)->toEqual($address['country_id']);
     expect($dbAddress->company)->toEqual($address['company']);
     expect($dbAddress->title)->toEqual($address['title']);
-    expect($dbAddress->salutation)->toEqual($address['salutation']);
+    expect($dbAddress->salutation->value)->toEqual($address['salutation']);
     expect($dbAddress->firstname)->toEqual($address['firstname']);
     expect($dbAddress->lastname)->toEqual($address['lastname']);
     expect($dbAddress->addition)->toEqual($address['addition']);
@@ -394,7 +394,7 @@ test('update address maximum', function (): void {
     expect($dbAddress->contact_id)->toEqual($address['contact_id']);
     expect($dbAddress->company)->toEqual($address['company']);
     expect($dbAddress->title)->toEqual($address['title']);
-    expect($dbAddress->salutation)->toEqual($address['salutation']);
+    expect($dbAddress->salutation->value)->toEqual($address['salutation']);
     expect($dbAddress->firstname)->toEqual($address['firstname']);
     expect($dbAddress->lastname)->toEqual($address['lastname']);
     expect($dbAddress->addition)->toEqual($address['addition']);

--- a/tests/Unit/Enums/FluxEnumCastTest.php
+++ b/tests/Unit/Enums/FluxEnumCastTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use FluxErp\Models\Address;
+
+test('cast returns enum object for known value', function (): void {
+    $address = Address::factory()->make(['salutation' => 'mr']);
+
+    expect($address->salutation)->not->toBeNull()
+        ->and($address->salutation->value)->toBe('mr')
+        ->and($address->salutation->name)->toBe('Mr');
+});
+
+test('cast returns null for null value', function (): void {
+    $address = Address::factory()->make(['salutation' => null]);
+
+    expect($address->salutation)->toBeNull();
+});
+
+test('cast returns fallback object for unknown value', function (): void {
+    $address = Address::factory()->make();
+    $address->setRawAttributes(array_merge($address->getAttributes(), ['salutation' => 'custom_value']));
+
+    expect($address->salutation)->not->toBeNull()
+        ->and($address->salutation->value)->toBe('custom_value');
+});


### PR DESCRIPTION
## Summary
- Add missing SalutationEnum cast to Address model salutation column
- Enables automatic translation of salutation values in DataTables
- Enables select dropdown filter instead of free text for salutation column
- Depends on Team-Nifty-GmbH/tall-datatables#210

## Summary by Sourcery

Enhancements:
- Cast the Address model salutation attribute to SalutationEnum for consistent typed access and downstream integrations.