### PR TITLE
remove isTimeFrameAwareWidget trait from TicketsByTopCustomersByState…

### DIFF
--- a/resources/views/components/dashboard/edit-dashboard.blade.php
+++ b/resources/views/components/dashboard/edit-dashboard.blade.php
@@ -81,16 +81,18 @@
 
     @if ($canEdit)
         <div class="flex flex-col items-center gap-2 md:flex-row">
-            <x-button
-                color="secondary"
-                loading
-                light
-                x-cloak
-                x-show="!editGrid"
-                x-on:click="editGridMode(true)"
-                icon="pencil"
-                class="shrink-0"
-            />
+            <div class="mt-4">
+                <x-button
+                    color="secondary"
+                    loading
+                    light
+                    x-cloak
+                    x-show="!editGrid"
+                    x-on:click="editGridMode(true)"
+                    icon="pencil"
+                    class="shrink-0"
+                />
+            </div>
             <div x-cloak x-show="editGrid" class="flex gap-2">
                 <x-button
                     color="secondary"

--- a/src/Livewire/Widgets/TicketsByTopCustomersByState.php
+++ b/src/Livewire/Widgets/TicketsByTopCustomersByState.php
@@ -23,7 +23,7 @@ use TeamNiftyGmbH\DataTable\Helpers\SessionFilter;
 
 class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
 {
-    use IsTimeFrameAwareWidget, Widgetable;
+    use Widgetable;
 
     public ?array $chart = [
         'type' => 'bar',
@@ -47,26 +47,13 @@ class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
         return view('flux::livewire.support.widgets.charts.chart');
     }
 
-    #[Renderless]
-    public function calculateByTimeFrame(): void
-    {
-        $this->calculateChart();
-        $this->updateData();
-    }
-
     public function calculateChart(): void
     {
-        $dateRange = [
-            $this->getStart()->toDateTimeString(),
-            $this->getEnd()->toDateTimeString(),
-        ];
-
         $allStates = TicketState::all();
         $endStates = $this->getEndStates($allStates);
 
         $topCustomers = resolve_static(Ticket::class, 'query')
             ->where('authenticatable_type', morph_alias(Address::class))
-            ->whereBetween('created_at', $dateRange)
             ->whereNotIn('state', $endStates)
             ->groupBy('authenticatable_type', 'authenticatable_id')
             ->selectRaw('authenticatable_type, authenticatable_id, COUNT(*) as total')
@@ -118,7 +105,6 @@ class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
 
         $ticketsByCustomer = resolve_static(Ticket::class, 'query')
             ->where('authenticatable_type', morph_alias(Address::class))
-            ->whereBetween('created_at', $dateRange)
             ->whereNotIn('state', $endStates)
             ->where(function (Builder $query) use ($topCustomers): void {
                 foreach ($topCustomers as $customer) {
@@ -211,16 +197,12 @@ class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
         $authenticatableId = data_get($params, 'authenticatable_id');
         $name = data_get($params, 'name');
 
-        $start = $this->getStart()->toDateTimeString();
-        $end = $this->getEnd()->toDateTimeString();
-
         SessionFilter::make(
             Livewire::new(resolve_static(TicketList::class, 'class'))->getCacheKey(),
             fn (Builder $query) => $query
                 ->where('authenticatable_type', $authenticatableType)
                 ->where('authenticatable_id', $authenticatableId)
-                ->whereNotIn('state', $this->getEndStates())
-                ->whereBetween('created_at', [$start, $end]),
+                ->whereNotIn('state', $this->getEndStates()),
             __('Tickets by :customer', ['customer' => $name]),
         )
             ->store();

--- a/src/Livewire/Widgets/TicketsByTopCustomersByState.php
+++ b/src/Livewire/Widgets/TicketsByTopCustomersByState.php
@@ -10,7 +10,6 @@ use FluxErp\Livewire\Support\Widgets\Charts\Chart;
 use FluxErp\Models\Address;
 use FluxErp\Models\Ticket;
 use FluxErp\States\Ticket\TicketState;
-use FluxErp\Traits\Livewire\Widget\IsTimeFrameAwareWidget;
 use FluxErp\Traits\Livewire\Widget\Widgetable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;


### PR DESCRIPTION
… widget

move "edit" button down to better match alignment with the other input fields.

## Summary by Sourcery

Simplify the TicketsByTopCustomersByState widget by removing time-frame awareness and adjust the dashboard edit button layout for better visual alignment.

Bug Fixes:
- Ensure the dashboard edit button aligns more consistently with other input fields.

Enhancements:
- Remove time-frame awareness from the TicketsByTopCustomersByState widget and stop filtering its data by created_at ranges.