### PR TITLE
Add Kanban view for project tasks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "spatie/laravel-tags": "^4.3",
         "spatie/pdf-to-image": "^3.0",
         "tallstackui/tallstackui": "^3.0.6",
-        "team-nifty-gmbh/tall-datatables": "^2.3.1",
+        "team-nifty-gmbh/tall-datatables": "^2.4.0",
         "webklex/laravel-imap": "^6.1"
     },
     "require-dev": {

--- a/src/Livewire/DataTables/BaseDataTable.php
+++ b/src/Livewire/DataTables/BaseDataTable.php
@@ -17,7 +17,7 @@ abstract class BaseDataTable extends DataTable
     use Actions, HasEloquentListeners;
 
     #[Renderless]
-    public function export(array $columns = [], string $format = 'xlsx'): Response|BinaryFileResponse|StreamedResponse
+    public function export(array $columns = [], string $format = 'xlsx', bool $formatted = true): Response|BinaryFileResponse|StreamedResponse
     {
         ExportDataTableJob::dispatch(
             serialize($this),

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Livewire\Project;
 
+use FluxErp\Actions\Task\UpdateTask;
 use FluxErp\Htmlables\TabButton;
 use FluxErp\Livewire\DataTables\TaskList as BaseTaskList;
 use FluxErp\Livewire\Forms\TaskForm;
@@ -12,7 +13,9 @@ use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 use FluxErp\Traits\Livewire\WithTabs;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class ProjectTaskList extends BaseTaskList
 {
@@ -79,10 +82,46 @@ class ProjectTaskList extends BaseTaskList
         ];
     }
 
+    public function kanbanMoveItem(int|string $id, string $targetLane): void
+    {
+        try {
+            UpdateTask::make([
+                'id' => $id,
+                'state' => $targetLane,
+            ])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+        }
+    }
+
     public function updatedTaskTab(): void {}
+
+    protected function availableLayouts(): array
+    {
+        return ['table', 'kanban'];
+    }
 
     protected function getBuilder(Builder $builder): Builder
     {
         return $builder->where('project_id', $this->projectId);
+    }
+
+    protected function kanbanColumn(): string
+    {
+        return 'state';
+    }
+
+    protected function kanbanLanes(): array
+    {
+        return collect($this->availableStates)
+            ->mapWithKeys(fn (array $state) => [
+                $state['name'] => [
+                    'label' => $state['label'],
+                ],
+            ])
+            ->toArray();
     }
 }

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -7,6 +7,7 @@ use FluxErp\Htmlables\TabButton;
 use FluxErp\Livewire\DataTables\TaskList as BaseTaskList;
 use FluxErp\Livewire\Forms\TaskForm;
 use FluxErp\Models\Task;
+use FluxErp\States\Task\TaskState;
 use FluxErp\Support\Livewire\Attributes\DataTableForm;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
@@ -42,13 +43,13 @@ class ProjectTaskList extends BaseTaskList
 
         $this->task->project_id = $this->projectId;
 
-        $this->availableStates = app(Task::class)->getStatesFor('state')
-            ->map(fn (string $state) => [
-                'label' => __(Str::headline($state)),
-                'name' => $state,
-                'is_end_state' => $state::$isEndState,
+        $this->availableStates = TaskState::all()
+            ->map(fn (string $stateClass, string $morphName) => [
+                'label' => __(Str::headline($morphName)),
+                'name' => $morphName,
+                'order' => $stateClass::$order,
             ])
-            ->sortBy('is_end_state')
+            ->sortBy('order')
             ->values()
             ->toArray();
     }
@@ -86,16 +87,22 @@ class ProjectTaskList extends BaseTaskList
     public function kanbanMoveItem(int|string $id, string $targetLane): void
     {
         try {
-            UpdateTask::make([
-                'id' => $id,
+            $task = resolve_static(Task::class, 'query')
+                ->whereKey($id)
+                ->first(['id', 'start_date', 'due_date']);
+
+            resolve_static(UpdateTask::class, 'make', [[
+                'id' => $task->getKey(),
                 'state' => $targetLane,
-            ])
+                'start_date' => $task->start_date,
+                'due_date' => $task->due_date,
+            ]])
                 ->checkPermission()
                 ->validate()
                 ->execute();
 
             $this->toast()
-                ->success(__('Task Updated'))
+                ->success(__(':model saved', ['model' => __('Task')]))
                 ->send();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);
@@ -121,12 +128,19 @@ class ProjectTaskList extends BaseTaskList
 
     protected function kanbanLanes(): array
     {
+        $task = app(Task::class);
+
         return collect($this->availableStates)
-            ->mapWithKeys(fn (array $state) => [
-                $state['name'] => [
-                    'label' => $state['label'],
-                ],
-            ])
+            ->mapWithKeys(function (array $state) use ($task) {
+                $task->state = $state['name'];
+
+                return [
+                    $state['name'] => [
+                        'label' => $state['label'],
+                        'color' => $task->state->color(),
+                    ],
+                ];
+            })
             ->toArray();
     }
 }

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -89,7 +89,11 @@ class ProjectTaskList extends BaseTaskList
         try {
             $task = resolve_static(Task::class, 'query')
                 ->whereKey($id)
-                ->first(['id', 'start_date', 'due_date']);
+                ->first(['id', 'state', 'start_date', 'due_date']);
+
+            if (is_null($task) || $targetLane === $task->state::$name) {
+                return;
+            }
 
             resolve_static(UpdateTask::class, 'make', [[
                 'id' => $task->getKey(),
@@ -109,6 +113,46 @@ class ProjectTaskList extends BaseTaskList
         }
     }
 
+    public function sortRows(int|string $id, int $position): void
+    {
+        $task = resolve_static(Task::class, 'query')
+            ->whereKey($id)
+            ->first(['id', 'state']);
+
+        if (is_null($task)) {
+            return;
+        }
+
+        $stateName = $task->state::$name;
+
+        $laneTasks = resolve_static(Task::class, 'query')
+            ->where('project_id', $this->projectId)
+            ->where('state', $stateName)
+            ->orderBy('priority')
+            ->pluck('id')
+            ->values()
+            ->toArray();
+
+        // Remove the moved task and insert at new position
+        $laneTasks = array_values(array_diff($laneTasks, [$task->getKey()]));
+        array_splice($laneTasks, $position, 0, [$task->getKey()]);
+
+        // Update priorities — highest number = top of lane (DESC order)
+        $total = count($laneTasks);
+        foreach ($laneTasks as $index => $taskId) {
+            resolve_static(Task::class, 'query')
+                ->whereKey($taskId)
+                ->update(['priority' => $total - $index]);
+        }
+
+        $this->islandsHaveMounted = false;
+        $this->loadData(forceRender: true);
+
+        $this->toast()
+            ->success(__(':model saved', ['model' => __('Task')]))
+            ->send();
+    }
+
     public function updatedTaskTab(): void {}
 
     protected function availableLayouts(): array
@@ -118,7 +162,18 @@ class ProjectTaskList extends BaseTaskList
 
     protected function getBuilder(Builder $builder): Builder
     {
-        return $builder->where('project_id', $this->projectId);
+        $builder->where('project_id', $this->projectId);
+
+        if ($this->activeLayout === 'kanban') {
+            $builder->reorder('priority', 'desc');
+        }
+
+        return $builder;
+    }
+
+    protected function isSortable(): bool
+    {
+        return $this->activeLayout === 'kanban';
     }
 
     protected function kanbanColumn(): string

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -43,12 +43,13 @@ class ProjectTaskList extends BaseTaskList
         $this->task->project_id = $this->projectId;
 
         $this->availableStates = app(Task::class)->getStatesFor('state')
-            ->map(function (string $state) {
-                return [
-                    'label' => __(Str::headline($state)),
-                    'name' => $state,
-                ];
-            })
+            ->map(fn (string $state) => [
+                'label' => __(Str::headline($state)),
+                'name' => $state,
+                'is_end_state' => $state::$isEndState,
+            ])
+            ->sortBy('is_end_state')
+            ->values()
             ->toArray();
     }
 
@@ -92,6 +93,10 @@ class ProjectTaskList extends BaseTaskList
                 ->checkPermission()
                 ->validate()
                 ->execute();
+
+            $this->toast()
+                ->success(__('Task Updated'))
+                ->send();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);
         }

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -86,15 +86,15 @@ class ProjectTaskList extends BaseTaskList
 
     public function kanbanMoveItem(int|string $id, string $targetLane): void
     {
+        $task = resolve_static(Task::class, 'query')
+            ->whereKey($id)
+            ->first(['id', 'state', 'start_date', 'due_date']);
+
+        if (is_null($task) || $targetLane === $task->state::$name) {
+            return;
+        }
+
         try {
-            $task = resolve_static(Task::class, 'query')
-                ->whereKey($id)
-                ->first(['id', 'state', 'start_date', 'due_date']);
-
-            if (is_null($task) || $targetLane === $task->state::$name) {
-                return;
-            }
-
             resolve_static(UpdateTask::class, 'make', [[
                 'id' => $task->getKey(),
                 'state' => $targetLane,

--- a/src/Rulesets/Task/UpdateTaskRuleset.php
+++ b/src/Rulesets/Task/UpdateTaskRuleset.php
@@ -53,7 +53,7 @@ class UpdateTaskRuleset extends FluxRuleset
             ],
             'name' => 'sometimes|required|string|max:255',
             'description' => 'string|nullable',
-            'start_date' => 'present|date|nullable',
+            'start_date' => 'sometimes|date|nullable',
             'start_time' => [
                 'nullable',
                 'exclude_if:start_date,null',
@@ -65,7 +65,7 @@ class UpdateTaskRuleset extends FluxRuleset
                 'integer',
                 'min:0',
             ],
-            'due_date' => 'present|date|nullable|after_or_equal:start_date',
+            'due_date' => 'sometimes|date|nullable|after_or_equal:start_date',
             'due_time' => [
                 'nullable',
                 'exclude_if:due_date,null',

--- a/src/Rulesets/Task/UpdateTaskRuleset.php
+++ b/src/Rulesets/Task/UpdateTaskRuleset.php
@@ -53,7 +53,7 @@ class UpdateTaskRuleset extends FluxRuleset
             ],
             'name' => 'sometimes|required|string|max:255',
             'description' => 'string|nullable',
-            'start_date' => 'sometimes|date|nullable',
+            'start_date' => 'present|date|nullable',
             'start_time' => [
                 'nullable',
                 'exclude_if:start_date,null',
@@ -65,7 +65,7 @@ class UpdateTaskRuleset extends FluxRuleset
                 'integer',
                 'min:0',
             ],
-            'due_date' => 'sometimes|date|nullable|after_or_equal:start_date',
+            'due_date' => 'present|date|nullable|after_or_equal:start_date',
             'due_time' => [
                 'nullable',
                 'exclude_if:due_date,null',

--- a/src/States/Task/Canceled.php
+++ b/src/States/Task/Canceled.php
@@ -8,6 +8,8 @@ class Canceled extends TaskState
 
     public static $name = 'canceled';
 
+    public static int $order = 4;
+
     public function color(): string
     {
         return static::$color ?? 'red';

--- a/src/States/Task/Done.php
+++ b/src/States/Task/Done.php
@@ -8,6 +8,8 @@ class Done extends TaskState
 
     public static $name = 'done';
 
+    public static int $order = 3;
+
     public function color(): string
     {
         return static::$color ?? 'emerald';

--- a/src/States/Task/InProgress.php
+++ b/src/States/Task/InProgress.php
@@ -6,6 +6,8 @@ class InProgress extends TaskState
 {
     public static $name = 'in_progress';
 
+    public static int $order = 2;
+
     public function color(): string
     {
         return static::$color ?? 'amber';

--- a/src/States/Task/Open.php
+++ b/src/States/Task/Open.php
@@ -6,6 +6,8 @@ class Open extends TaskState
 {
     public static $name = 'open';
 
+    public static int $order = 1;
+
     public function color(): string
     {
         return static::$color ?? 'neutral';

--- a/src/States/Task/TaskState.php
+++ b/src/States/Task/TaskState.php
@@ -8,6 +8,8 @@ use TeamNiftyGmbH\DataTable\Contracts\HasFrontendFormatter;
 
 abstract class TaskState extends EndableState implements HasFrontendFormatter
 {
+    public static int $order = 0;
+
     abstract public function color(): string;
 
     public static function config(): StateConfig

--- a/tests/Livewire/Project/ProjectTaskListTest.php
+++ b/tests/Livewire/Project/ProjectTaskListTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Livewire\Project\ProjectTaskList;
 use FluxErp\Models\Project;
+use FluxErp\Models\Task;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
@@ -28,4 +29,117 @@ test('can add new task', function (): void {
         'responsible_user_id' => $this->user->getKey(),
         'state' => 'open',
     ]);
+});
+
+test('kanbanMoveItem changes task state', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'state' => 'open',
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('kanbanMoveItem', $task->getKey(), 'in_progress');
+
+    expect($task->fresh()->state::$name)->toBe('in_progress');
+});
+
+test('kanbanMoveItem skips when target lane equals current state', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $task = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'state' => 'open',
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('kanbanMoveItem', $task->getKey(), 'open');
+
+    expect($task->fresh()->state::$name)->toBe('open');
+});
+
+test('sortRows updates priorities within a lane', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $tasks = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $tasks->push(Task::factory()->create([
+            'project_id' => $project->getKey(),
+            'state' => 'open',
+            'priority' => 0,
+        ]));
+    }
+
+    // Move last task to position 0 (top)
+    $movedTask = $tasks->last();
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('sortRows', $movedTask->getKey(), 0);
+
+    // Moved task should have the highest priority (top of DESC order)
+    $movedTask->refresh();
+    $otherPriorities = Task::query()
+        ->where('project_id', $project->getKey())
+        ->where('state', 'open')
+        ->whereKeyNot($movedTask->getKey())
+        ->pluck('priority')
+        ->toArray();
+
+    expect($movedTask->priority)->toBeGreaterThan(max($otherPriorities));
+});
+
+test('sortRows only affects tasks in the same lane', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $openTask = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'state' => 'open',
+        'priority' => 5,
+    ]);
+
+    $inProgressTask = Task::factory()->create([
+        'project_id' => $project->getKey(),
+        'state' => 'in_progress',
+        'priority' => 10,
+    ]);
+
+    Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()])
+        ->call('sortRows', $openTask->getKey(), 0);
+
+    // in_progress task priority should be unchanged
+    expect($inProgressTask->fresh()->priority)->toBe(10);
+});
+
+test('isSortable returns true only for kanban layout', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $component = Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()]);
+
+    // Table layout — not sortable
+    expect($component->instance()->activeLayout)->toBe('table');
+
+    $component->call('setLayout', 'kanban');
+    expect($component->instance()->activeLayout)->toBe('kanban');
+});
+
+test('availableLayouts includes table and kanban', function (): void {
+    $project = Project::factory()->create([
+        'tenant_id' => $this->dbTenant->id,
+    ]);
+
+    $component = Livewire::test(ProjectTaskList::class, ['projectId' => $project->getKey()]);
+    $viewData = $component->instance()->getIslandData();
+
+    expect($viewData['availableLayouts'])->toBe(['table', 'kanban']);
 });


### PR DESCRIPTION
## Summary
- Enable table/kanban layout switching for ProjectTaskList
- Kanban lanes based on task states (open, in_progress, done, canceled)
- Drag & drop between lanes updates task state via UpdateTask action
- Uses tall-datatables kanban layout infrastructure

## Summary by Sourcery

Add a kanban layout option to the project task list and wire it to update task state when tasks are moved between lanes.

New Features:
- Introduce kanban layout as an alternative to the existing table layout for project tasks.
- Support drag-and-drop movement of tasks between kanban lanes that represent task states.

Enhancements:
- Map available task states into kanban lanes based on the task state field and expose the supported layouts to the base task list component.