### PR TITLE
Fix export method signature to match parent class

### DIFF
--- a/src/Livewire/DataTables/BaseDataTable.php
+++ b/src/Livewire/DataTables/BaseDataTable.php
@@ -17,7 +17,7 @@ abstract class BaseDataTable extends DataTable
     use Actions, HasEloquentListeners;
 
     #[Renderless]
-    public function export(array $columns = [], string $format = 'xlsx'): Response|BinaryFileResponse|StreamedResponse
+    public function export(array $columns = [], string $format = 'xlsx', bool $formatted = true): Response|BinaryFileResponse|StreamedResponse
     {
         ExportDataTableJob::dispatch(
             serialize($this),


### PR DESCRIPTION
## Summary
- Add missing `bool $formatted = true` parameter to `BaseDataTable::export()` to match the updated parent signature in tall-datatables
- Fixes 500 error on all pages due to PHP fatal: incompatible method declaration

## Summary by Sourcery

Bug Fixes:
- Resolve a PHP fatal error caused by an incompatible export method signature in BaseDataTable compared to its parent class.