### PR TITLE
Add missing TallStackUI v3 CSS animations and plugins

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -99,7 +99,8 @@
     --color-dark-950: #020617;
 
     --animate-progress: progress 2s linear forwards;
-    --animate-indeterminate: indeterminate 1.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    --animate-indeterminate: indeterminate 1.5s cubic-bezier(0.4, 0, 0.2, 1)
+        infinite;
 
     @keyframes progress {
         0% {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,6 +19,10 @@
     layer(base);
 
 @import 'tailwindcss';
+@import '../../vendor/tallstackui/tallstackui/css/plugins/custom-scrollbar.css';
+@import '../../vendor/tallstackui/tallstackui/css/plugins/soft-scrollbar.css';
+@import '../../vendor/tallstackui/tallstackui/css/plugins/command-palette-scrollbar.css';
+@import '../../vendor/tallstackui/tallstackui/css/plugins/number-appearance-none.css';
 
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
@@ -93,6 +97,27 @@
     --color-dark-800: #1e293b;
     --color-dark-900: #0f172a;
     --color-dark-950: #020617;
+
+    --animate-progress: progress 2s linear forwards;
+    --animate-indeterminate: indeterminate 1.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+
+    @keyframes progress {
+        0% {
+            width: 0;
+        }
+        100% {
+            width: 100%;
+        }
+    }
+
+    @keyframes indeterminate {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(400%);
+        }
+    }
 }
 
 @variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary
- Add `animate-progress` and `animate-indeterminate` keyframes to `@theme` block (fixes toast progress bar not animating)
- Import TallStackUI plugin CSS files (custom-scrollbar, soft-scrollbar, command-palette-scrollbar, number-appearance-none)
- These were defined in TallStackUI's own `v4.css` entry file but never included because flux-core uses its own Tailwind entry point

## Summary by Sourcery

Integrate missing TallStackUI v3 visual behaviors by importing its plugin CSS and defining required animation keyframes in the main Tailwind entry stylesheet.

New Features:
- Enable TallStackUI custom, soft, and command-palette scrollbars via imported plugin CSS.
- Disable native number input appearance through the TallStackUI number-appearance-none plugin CSS.
- Provide configurable progress and indeterminate animation variables for use across UI components.

Bug Fixes:
- Restore toast progress bar and other TallStackUI components that rely on progress and indeterminate animations by defining their keyframes in the theme block.

Enhancements:
- Align the app's Tailwind entry CSS with TallStackUI's v4.css defaults to ensure bundled styles and animations are consistently applied.