### PR TITLE
fix folder-tree uploaded files are being incorrectly replaced

### DIFF
--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -113,7 +113,7 @@
 
                             if (multipleFileUpload) {
                                 lastUploads.forEach((file) => {
-                                    this.selectionProxy.children.push(file)
+                                    this.selectionProxy.children.push(JSON.parse(JSON.stringify(file)))
                                     this.selection = JSON.parse(JSON.stringify(this.selectionProxy))
                                 }, this)
                             } else {

--- a/src/Actions/Media/UploadMedia.php
+++ b/src/Actions/Media/UploadMedia.php
@@ -81,6 +81,7 @@ class UploadMedia extends FluxAction
                         ]
                     )
                 )
+                ->preservingOriginal()
                 ->storingConversionsOnDisk(config('flux.media.conversion'))
                 ->toMediaCollection(collectionName: $this->getData('collection_name'), diskName: $diskName);
         } catch (FileUnacceptableForCollection $e) {

--- a/src/Traits/Livewire/WithFileUploads.php
+++ b/src/Traits/Livewire/WithFileUploads.php
@@ -107,7 +107,7 @@ trait WithFileUploads
 
         $collection = $this->collection ?: 'default';
 
-        $keys = data_get($this->filesArray, '*.key') ?? [];
+        $keys = array_column($this->filesArray, 'key');
         foreach ($files as $file) {
             if (! in_array($file->getFilename(), $keys)) {
                 /** @var TemporaryUploadedFile $file */

--- a/src/Traits/Livewire/WithFileUploads.php
+++ b/src/Traits/Livewire/WithFileUploads.php
@@ -154,7 +154,7 @@ trait WithFileUploads
 
         $response = [];
         DB::transaction(
-            function () use (&$response) {
+            function () use (&$response): void {
                 foreach ($this->filesArray as $file) {
                     $response[] = UploadMedia::make($file)
                         ->checkPermission()

--- a/src/Traits/Livewire/WithFileUploads.php
+++ b/src/Traits/Livewire/WithFileUploads.php
@@ -8,6 +8,8 @@ use FluxErp\Actions\Media\UploadMedia;
 use FluxErp\Models\Media;
 use FluxErp\Models\MediaFolder;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads as WithFileUploadsBase;
@@ -98,25 +100,27 @@ trait WithFileUploads
     public function prepareForMediaLibrary(string $name, ?int $modelId = null, ?string $modelType = null): void
     {
         $this->filesArrayDirty = true;
-        $property = $this->getPropertyValue($name);
-        $property = ! is_array($property) ? [$property] : $property;
+        $files = Arr::wrap($this->getPropertyValue($name));
 
         $modelId = $modelId ?: $this->modelId ?? null;
         $modelType = $modelType ?: $this->modelType;
 
         $collection = $this->collection ?: 'default';
 
-        foreach ($property as $file) {
-            /** @var TemporaryUploadedFile $file */
-            $this->filesArray[] = [
-                'key' => $file->getFilename(),
-                'name' => $file->getClientOriginalName(),
-                'file_name' => $file->getClientOriginalName(),
-                'model_id' => $modelId,
-                'model_type' => $modelType,
-                'collection_name' => $collection,
-                'media' => $file->getRealPath(),
-            ];
+        $keys = data_get($this->filesArray, '*.key') ?? [];
+        foreach ($files as $file) {
+            if (! in_array($file->getFilename(), $keys)) {
+                /** @var TemporaryUploadedFile $file */
+                $this->filesArray[] = [
+                    'key' => $file->getFilename(),
+                    'name' => $file->getClientOriginalName(),
+                    'file_name' => $file->getClientOriginalName(),
+                    'model_id' => $modelId,
+                    'model_type' => $modelType,
+                    'collection_name' => $collection,
+                    'media' => $file->getRealPath(),
+                ];
+            }
         }
     }
 
@@ -129,23 +133,38 @@ trait WithFileUploads
 
     public function saveFileUploadsToMediaLibrary(string $name, ?int $modelId = null, ?string $modelType = null): array
     {
-        if (! $this->filesArray && ! $this->filesArrayDirty) {
-            $this->prepareForMediaLibrary($name, $modelId, $modelType);
-        } else {
+        $files = Arr::wrap($this->getPropertyValue($name));
+        $filenames = array_map(fn (TemporaryUploadedFile $file) => $file->getFilename(), $files);
+
+        $this->filesArray = array_filter(
+            $this->filesArray,
+            fn (array $media) => in_array(data_get($media, 'key'), $filenames)
+        );
+
+        if ($this->filesArray && $this->filesArrayDirty) {
             $this->filesArray = array_map(
                 fn ($file) => array_merge($file, ['model_type' => $modelType, 'model_id' => $modelId]),
                 $this->filesArray
             );
         }
 
-        $response = [];
-        foreach ($this->filesArray as $file) {
-            $response[] = UploadMedia::make($file)
-                ->checkPermission()
-                ->validate()
-                ->execute()
-                ->toArray();
+        if (count($this->filesArray) !== count($files)) {
+            $this->prepareForMediaLibrary($name, $modelId, $modelType);
         }
+
+        $response = [];
+        DB::transaction(
+            function () use (&$response) {
+                foreach ($this->filesArray as $file) {
+                    $response[] = UploadMedia::make($file)
+                        ->checkPermission()
+                        ->validate()
+                        ->execute()
+                        ->toArray();
+                }
+            },
+            5
+        );
 
         $this->filesArray = [];
         $this->filesArrayDirty = false;

--- a/tests/Feature/Api/AddressTest.php
+++ b/tests/Feature/Api/AddressTest.php
@@ -230,7 +230,7 @@ test('get address', function (): void {
     expect($jsonAddress->contact_id)->toEqual($this->addresses[0]->contact_id);
     expect($jsonAddress->company)->toEqual($this->addresses[0]->company);
     expect($jsonAddress->title)->toEqual($this->addresses[0]->title);
-    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation->value);
+    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation?->value);
     expect($jsonAddress->firstname)->toEqual($this->addresses[0]->firstname);
     expect($jsonAddress->lastname)->toEqual($this->addresses[0]->lastname);
     expect($jsonAddress->addition)->toEqual($this->addresses[0]->addition);


### PR DESCRIPTION
fix media upload issues after validation exceptions

## Summary by Sourcery

Resolve issues with media uploads being incorrectly replaced or lost, especially after validation exceptions, and improve handling of uploaded files in the folder tree UI and media storage.

Bug Fixes:
- Prevent duplicate or missing media entries by only adding new uploaded files to the internal files array when their keys are not already present.
- Ensure the internal files array stays in sync with currently uploaded files before saving to the media library, avoiding stale or removed uploads being processed.
- Fix folder tree multiple-upload behavior so each uploaded file is pushed as an independent copy, preventing later mutations from unintentionally affecting previous entries.
- Preserve original uploaded files in the media library when storing media, avoiding unwanted overwrites during upload and conversion.

Enhancements:
- Wrap media upload persistence in a database transaction with retries to ensure atomic and more robust media upload operations.