### PR TITLE
Fix email attachments using cached documents when force is active

### DIFF
--- a/src/Traits/Livewire/CreatesDocuments.php
+++ b/src/Traits/Livewire/CreatesDocuments.php
@@ -278,8 +278,16 @@ trait CreatesDocuments
             ->unique()
             ->all();
 
+        $forceLayouts = data_get($this->selectedPrintLayouts, 'force') ?? [];
+
         $mailAttachments = [];
         foreach ($emailDocuments as $createDocument) {
+            if (in_array($createDocument, $forceLayouts)) {
+                $mailAttachments[] = $this->getCreateAttachmentArray($item, $createDocument);
+
+                continue;
+            }
+
             $media = $item instanceof HasMedia ? $item->getMedia($createDocument)->last() : null;
 
             if ($media && ! $media->isTemporary) {

--- a/tests/Feature/Api/AddressTest.php
+++ b/tests/Feature/Api/AddressTest.php
@@ -155,7 +155,7 @@ test('create address maximum', function (): void {
     expect($dbAddress->country_id)->toEqual($address['country_id']);
     expect($dbAddress->company)->toEqual($address['company']);
     expect($dbAddress->title)->toEqual($address['title']);
-    expect($dbAddress->salutation->value)->toEqual($address['salutation']);
+    expect($dbAddress->salutation?->value)->toEqual($address['salutation']);
     expect($dbAddress->firstname)->toEqual($address['firstname']);
     expect($dbAddress->lastname)->toEqual($address['lastname']);
     expect($dbAddress->addition)->toEqual($address['addition']);
@@ -230,7 +230,7 @@ test('get address', function (): void {
     expect($jsonAddress->contact_id)->toEqual($this->addresses[0]->contact_id);
     expect($jsonAddress->company)->toEqual($this->addresses[0]->company);
     expect($jsonAddress->title)->toEqual($this->addresses[0]->title);
-    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation->value);
+    expect($jsonAddress->salutation)->toEqual($this->addresses[0]->salutation?->value);
     expect($jsonAddress->firstname)->toEqual($this->addresses[0]->firstname);
     expect($jsonAddress->lastname)->toEqual($this->addresses[0]->lastname);
     expect($jsonAddress->addition)->toEqual($this->addresses[0]->addition);
@@ -394,7 +394,7 @@ test('update address maximum', function (): void {
     expect($dbAddress->contact_id)->toEqual($address['contact_id']);
     expect($dbAddress->company)->toEqual($address['company']);
     expect($dbAddress->title)->toEqual($address['title']);
-    expect($dbAddress->salutation->value)->toEqual($address['salutation']);
+    expect($dbAddress->salutation?->value)->toEqual($address['salutation']);
     expect($dbAddress->firstname)->toEqual($address['firstname']);
     expect($dbAddress->lastname)->toEqual($address['lastname']);
     expect($dbAddress->addition)->toEqual($address['addition']);

--- a/tests/Feature/Traits/CreatesDocumentsForceEmailTest.php
+++ b/tests/Feature/Traits/CreatesDocumentsForceEmailTest.php
@@ -5,7 +5,7 @@ use FluxErp\Models\Media;
 use FluxErp\Traits\Livewire\CreatesDocuments;
 use Livewire\Component;
 
-it('regenerates email attachment when force is active instead of using cached media', function (): void {
+test('regenerates email attachment when force is active instead of using cached media', function (): void {
     $contact = Contact::factory()->create();
 
     // Attach an old "cached" balance-statement media to the contact

--- a/tests/Feature/Traits/CreatesDocumentsForceEmailTest.php
+++ b/tests/Feature/Traits/CreatesDocumentsForceEmailTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use FluxErp\Models\Contact;
+use FluxErp\Models\Media;
+use FluxErp\Traits\Livewire\CreatesDocuments;
+use Livewire\Component;
+
+it('regenerates email attachment when force is active instead of using cached media', function (): void {
+    $contact = Contact::factory()->create();
+
+    // Attach an old "cached" balance-statement media to the contact
+    $oldMedia = $contact
+        ->addMediaFromString('old PDF content')
+        ->usingFileName('old_balance_statement.pdf')
+        ->toMediaCollection('balance-statement');
+
+    // Create a test component using the CreatesDocuments trait
+    $component = new class() extends Component
+    {
+        use CreatesDocuments;
+
+        public function render()
+        {
+            return view('flux::livewire.support.dashboard');
+        }
+
+        public function getPrintLayouts(): array
+        {
+            return [
+                'balance-statement' => FluxErp\View\Printing\Contact\BalanceStatement::class,
+            ];
+        }
+
+        public function createDocuments(): void {}
+
+        public function getTo($item, array $emailDocuments): array
+        {
+            return ['test@example.com'];
+        }
+
+        public function callCollectMailMessages($item): array
+        {
+            $mailMessages = [];
+            $defaultTemplateIds = [];
+            $this->collectMailMessages($item, $mailMessages, $defaultTemplateIds);
+
+            return $mailMessages;
+        }
+    };
+
+    // Set the layout as both "force" and "email"
+    $component->selectedPrintLayouts = [
+        'force' => ['balance-statement'],
+        'email' => ['balance-statement'],
+    ];
+    $component->forcedPrintLayouts = [
+        'force' => ['balance-statement'],
+    ];
+
+    $mailMessages = $component->callCollectMailMessages($contact);
+
+    expect($mailMessages)->toHaveCount(1);
+
+    $attachments = data_get($mailMessages, '0.attachments');
+    $balanceAttachment = collect($attachments)->first(
+        fn ($a) => is_array($a) && data_get($a, 'view') === 'balance-statement'
+    );
+
+    // When force is active, attachment should have view/model_type/model_id (fresh generation)
+    // NOT just id/name (cached media reference)
+    expect($balanceAttachment)->not->toBeNull()
+        ->and($balanceAttachment)->toHaveKey('view')
+        ->and($balanceAttachment)->toHaveKey('model_type')
+        ->and($balanceAttachment)->toHaveKey('model_id')
+        ->and($balanceAttachment)->not->toHaveKey('id');
+});


### PR DESCRIPTION
## Summary
- When a print layout has force-recreate enabled (like balance-statement), `collectMailMessages()` now generates a fresh attachment instead of reusing the cached media from the model
- Previously, the email was assembled with the old PDF before `CreateDocumentsJob` regenerated it, causing stale documents to be sent via email

## Summary by Sourcery

Ensure email attachments use freshly generated documents when force-recreate layouts are selected instead of cached media.

Bug Fixes:
- Prevent sending stale PDF attachments by regenerating documents for force-enabled print layouts during email collection.

Tests:
- Add a feature test verifying that email attachments for force-enabled layouts are generated fresh and not taken from cached media.