### PR TITLE
Fix categories DataTable showing no data

### DIFF
--- a/resources/views/livewire/datatables/generate-widget-wizard.blade.php
+++ b/resources/views/livewire/datatables/generate-widget-wizard.blade.php
@@ -1,0 +1,286 @@
+<div class="mx-auto max-w-3xl py-6">
+    <div class="mb-6">
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            {{ __('Generate Widget') }}
+        </h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ __('Step :current of :total', ['current' => $step, 'total' => 4]) }}
+        </p>
+    </div>
+
+    <x-card>
+        {{-- Step 1: Filter Review --}}
+        <div x-show="$wire.step === 1" x-cloak>
+            <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-gray-100">
+                {{ __('Active Filters') }}
+            </h3>
+            @if (count($userFilters) > 0)
+                <div class="flex flex-wrap gap-2">
+                    @foreach ($userFilters as $groupIndex => $group)
+                        @if ($groupIndex > 0)
+                            <x-badge color="emerald" :text="__('or')" />
+                        @endif
+                        @foreach ($group as $filterIndex => $filter)
+                            <x-badge
+                                color="primary"
+                                :text="data_get($filter, 'column', '') . ' ' . data_get($filter, 'operator', '') . ' ' . (is_array(data_get($filter, 'value')) ? implode(', ', data_get($filter, 'value')) : data_get($filter, 'value', ''))"
+                            />
+                            @if (! $loop->last)
+                                <x-badge color="red" :text="__('and')" />
+                            @endif
+                        @endforeach
+                    @endforeach
+                </div>
+            @else
+                <p class="text-sm italic text-gray-500 dark:text-gray-400">
+                    {{ __('No filters set — all data will be included.') }}
+                </p>
+            @endif
+        </div>
+
+        {{-- Step 2: Widget Type Selection --}}
+        <div x-show="$wire.step === 2" x-cloak>
+            <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-gray-100">
+                {{ __('Select Widget Type') }}
+            </h3>
+            <div class="grid grid-cols-2 gap-4">
+                @php
+                    $types = [
+                        ['key' => 'value_box', 'icon' => 'calculator', 'label' => __('Value Box'), 'description' => __('Single aggregate value')],
+                        ['key' => 'bar_chart', 'icon' => 'chart-bar', 'label' => __('Bar Chart'), 'description' => __('Grouped by column')],
+                        ['key' => 'line_chart', 'icon' => 'chart-bar-square', 'label' => __('Line Chart'), 'description' => __('Over time')],
+                        ['key' => 'value_list', 'icon' => 'list-bullet', 'label' => __('List'), 'description' => __('Top N entries')],
+                    ];
+                @endphp
+                @foreach ($types as $type)
+                    <div
+                        class="cursor-pointer rounded-lg border-2 p-4 transition-colors hover:border-primary-300 dark:hover:border-primary-700"
+                        x-bind:class="$wire.widgetType === '{{ $type['key'] }}' ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20' : 'border-gray-200 dark:border-gray-700'"
+                        x-on:click="$wire.set('widgetType', '{{ $type['key'] }}')"
+                    >
+                        <div class="flex flex-col items-center gap-2 text-center">
+                            <x-icon :name="$type['icon']" class="h-8 w-8 text-gray-600 dark:text-gray-400" />
+                            <span class="font-medium text-gray-900 dark:text-gray-100">{{ $type['label'] }}</span>
+                            <span class="text-sm text-gray-500 dark:text-gray-400">{{ $type['description'] }}</span>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- Step 3: Data Configuration --}}
+        <div x-show="$wire.step === 3" x-cloak>
+            <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-gray-100">
+                {{ __('Data Configuration') }}
+            </h3>
+            <div class="flex flex-col gap-4">
+                {{-- Value Box --}}
+                <div x-show="$wire.widgetType === 'value_box'" x-cloak>
+                    <div class="flex flex-col gap-4">
+                        <x-select.native
+                            wire:model="aggregate"
+                            :label="__('Aggregate Function')"
+                            :options="[
+                                ['value' => 'sum', 'label' => __('Sum')],
+                                ['value' => 'avg', 'label' => __('Average')],
+                                ['value' => 'min', 'label' => __('Minimum')],
+                                ['value' => 'max', 'label' => __('Maximum')],
+                                ['value' => 'count', 'label' => __('Count')],
+                            ]"
+                            select="label:label|value:value"
+                        />
+                        <div x-show="$wire.aggregate !== 'count'" x-cloak>
+                            <x-select.native
+                                wire:model="valueColumn"
+                                :label="__('Value Column')"
+                                :options="$this->getNumericColumns()"
+                                select="label:label|value:name"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Bar Chart --}}
+                <div x-show="$wire.widgetType === 'bar_chart'" x-cloak>
+                    <div class="flex flex-col gap-4">
+                        <x-select.native
+                            wire:model="groupColumn"
+                            :label="__('Group By Column')"
+                            :options="$availableColumns"
+                            select="label:label|value:name"
+                        />
+                        <x-select.native
+                            wire:model="aggregate"
+                            :label="__('Aggregate Function')"
+                            :options="[
+                                ['value' => 'sum', 'label' => __('Sum')],
+                                ['value' => 'avg', 'label' => __('Average')],
+                                ['value' => 'min', 'label' => __('Minimum')],
+                                ['value' => 'max', 'label' => __('Maximum')],
+                                ['value' => 'count', 'label' => __('Count')],
+                            ]"
+                            select="label:label|value:value"
+                        />
+                        <div x-show="$wire.aggregate !== 'count'" x-cloak>
+                            <x-select.native
+                                wire:model="valueColumn"
+                                :label="__('Value Column')"
+                                :options="$this->getNumericColumns()"
+                                select="label:label|value:name"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Line Chart --}}
+                <div x-show="$wire.widgetType === 'line_chart'" x-cloak>
+                    <div class="flex flex-col gap-4">
+                        <x-select.native
+                            wire:model="dateColumn"
+                            :label="__('Date Column')"
+                            :options="$this->getDateColumns()"
+                            select="label:label|value:name"
+                        />
+                        <x-select.native
+                            wire:model="aggregate"
+                            :label="__('Aggregate Function')"
+                            :options="[
+                                ['value' => 'sum', 'label' => __('Sum')],
+                                ['value' => 'avg', 'label' => __('Average')],
+                                ['value' => 'min', 'label' => __('Minimum')],
+                                ['value' => 'max', 'label' => __('Maximum')],
+                                ['value' => 'count', 'label' => __('Count')],
+                            ]"
+                            select="label:label|value:value"
+                        />
+                        <div x-show="$wire.aggregate !== 'count'" x-cloak>
+                            <x-select.native
+                                wire:model="valueColumn"
+                                :label="__('Value Column')"
+                                :options="$this->getNumericColumns()"
+                                select="label:label|value:name"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Value List --}}
+                <div x-show="$wire.widgetType === 'value_list'" x-cloak>
+                    <div class="flex flex-col gap-4">
+                        <div>
+                            <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {{ __('Select Columns') }}
+                            </label>
+                            <div class="flex flex-wrap gap-3">
+                                @foreach ($availableColumns as $column)
+                                    <x-toggle
+                                        wire:model="selectedColumns"
+                                        :value="data_get($column, 'name')"
+                                        :label="data_get($column, 'label')"
+                                    />
+                                @endforeach
+                            </div>
+                        </div>
+                        <x-select.native
+                            wire:model="sortColumn"
+                            :label="__('Sort Column')"
+                            :options="$availableColumns"
+                            select="label:label|value:name"
+                        />
+                        <x-select.native
+                            wire:model="sortDirection"
+                            :label="__('Sort Direction')"
+                            :options="[
+                                ['value' => 'desc', 'label' => __('Descending')],
+                                ['value' => 'asc', 'label' => __('Ascending')],
+                            ]"
+                            select="label:label|value:value"
+                        />
+                        <x-number
+                            wire:model="limit"
+                            :label="__('Limit')"
+                            min="1"
+                            max="100"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Step 4: Metadata --}}
+        <div x-show="$wire.step === 4" x-cloak>
+            <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-gray-100">
+                {{ __('Widget Settings') }}
+            </h3>
+            <div class="flex flex-col gap-4">
+                <x-input
+                    wire:model="name"
+                    :label="__('Name')"
+                    required
+                />
+                <x-select.native
+                    wire:model="targetDashboard"
+                    :label="__('Target Dashboard')"
+                    :options="collect($this->getAvailableDashboards)->map(fn ($label, $value) => ['value' => $value, 'label' => $label])->values()->toArray()"
+                    select="label:label|value:value"
+                    required
+                />
+                <x-toggle
+                    wire:model.live="timeframeAware"
+                    :label="__('Bind to Dashboard Timeframe')"
+                />
+                <div x-show="$wire.timeframeAware" x-cloak>
+                    <x-select.native
+                        wire:model="timeframeDateColumn"
+                        :label="__('Date Column for Timeframe')"
+                        :options="$this->getDateColumns()"
+                        select="label:label|value:name"
+                    />
+                </div>
+                @can('widget.generate-share')
+                    <x-toggle
+                        wire:model="isShared"
+                        :label="__('Share with all users')"
+                    />
+                @endcan
+            </div>
+        </div>
+
+        <x-slot:footer>
+            <div class="flex w-full items-center justify-between">
+                <div>
+                    @if ($step > 1)
+                        <x-button
+                            :text="__('Back')"
+                            color="secondary"
+                            flat
+                            wire:click="previousStep"
+                        />
+                    @endif
+                </div>
+                <div class="flex gap-2">
+                    <x-button
+                        :text="__('Cancel')"
+                        color="secondary"
+                        flat
+                        href="{{ url()->previous() }}"
+                        wire:navigate
+                    />
+                    @if ($step < 4)
+                        <x-button
+                            :text="__('Next')"
+                            color="primary"
+                            wire:click="nextStep"
+                        />
+                    @else
+                        <x-button
+                            :text="__('Create Widget')"
+                            color="primary"
+                            wire:click="save"
+                        />
+                    @endif
+                </div>
+            </div>
+        </x-slot:footer>
+    </x-card>
+</div>

--- a/resources/views/livewire/datatables/sidebar-widget-tab.blade.php
+++ b/resources/views/livewire/datatables/sidebar-widget-tab.blade.php
@@ -1,0 +1,52 @@
+<div class="flex flex-col gap-4">
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+        {{ __('Generate a dashboard widget from the current filter configuration.') }}
+    </p>
+
+    <div
+        x-cloak
+        x-show="($wire.userFilters || []).length > 0"
+    >
+        <p class="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ __('Active filters') }}
+        </p>
+        <div class="flex flex-wrap gap-1.5">
+            <template x-for="(orFilters, orIndex) in ($wire.userFilters || [])">
+                <div class="flex flex-wrap items-center gap-1.5">
+                    <template x-if="orIndex > 0">
+                        <x-badge flat color="emerald" :text="__('or')" />
+                    </template>
+                    <template x-for="(filter, index) in orFilters">
+                        <div class="flex items-center gap-1">
+                            <x-badge flat color="indigo">
+                                <x-slot:text>
+                                    <span x-text="filterBadge(filter)"></span>
+                                </x-slot>
+                            </x-badge>
+                            <template x-if="orFilters.length - 1 !== index">
+                                <x-badge flat color="red" :text="__('and')" />
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <div
+        x-cloak
+        x-show="($wire.userFilters || []).length === 0"
+    >
+        <p class="text-xs italic text-gray-400 dark:text-gray-500">
+            {{ __('No filters set — all data will be included.') }}
+        </p>
+    </div>
+
+    <x-button
+        color="primary"
+        sm
+        icon="chart-bar"
+        :text="__('Save as Widget')"
+        wire:click="openWidgetWizard"
+    />
+</div>

--- a/resources/views/livewire/widgets/generated-widget-error.blade.php
+++ b/resources/views/livewire/widgets/generated-widget-error.blade.php
@@ -1,0 +1,4 @@
+<div class="flex flex-col items-center justify-center gap-2 p-4 text-center text-red-500">
+    <x-icon name="exclamation-triangle" class="h-8 w-8" />
+    <span class="text-sm">{{ $message ?? __('Widget configuration error.') }}</span>
+</div>

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -151,6 +151,7 @@ Route::middleware('web')
 
         Route::middleware(['auth:web', 'permission'])->group(function (): void {
             Route::get('/', Dashboard::class)->name('dashboard');
+            Route::get('/widgets/create', \FluxErp\Livewire\DataTables\GenerateWidgetWizard::class)->name('widgets.create');
 
             Route::get('/private-storage/{path}', function (string $path) {
                 return response()

--- a/src/Console/Commands/Init/InitPermissions.php
+++ b/src/Console/Commands/Init/InitPermissions.php
@@ -177,6 +177,16 @@ class InitPermissions extends Command
             );
             unset($this->currentPermissions[$permission->id]);
         }
+
+        $sharePermission = resolve_static(
+            Permission::class,
+            'findOrCreate',
+            [
+                'name' => 'widget.generate-share',
+                'guardName' => 'web',
+            ]
+        );
+        unset($this->currentPermissions[$sharePermission->id]);
     }
 
     protected function registerTabPermissions(): void

--- a/src/Livewire/DataTables/BaseDataTable.php
+++ b/src/Livewire/DataTables/BaseDataTable.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\DataTables;
 use FluxErp\Actions\DataTable\ShareFilter;
 use FluxErp\Jobs\ExportDataTableJob;
 use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\DataTable\HasWidgetGeneration;
 use Illuminate\Http\Response;
 use Livewire\Attributes\Renderless;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -14,7 +15,7 @@ use TeamNiftyGmbH\DataTable\Traits\HasEloquentListeners;
 
 abstract class BaseDataTable extends DataTable
 {
-    use Actions, HasEloquentListeners;
+    use Actions, HasEloquentListeners, HasWidgetGeneration;
 
     #[Renderless]
     public function export(array $columns = [], string $format = 'xlsx', bool $formatted = true): Response|BinaryFileResponse|StreamedResponse

--- a/src/Livewire/DataTables/CategoryList.php
+++ b/src/Livewire/DataTables/CategoryList.php
@@ -18,8 +18,7 @@ class CategoryList extends BaseDataTable
 
     protected function getBuilder(Builder $builder): Builder
     {
-        return resolve_static(Category::class, 'familyTree')
-            ->whereNull('parent_id');
+        return $builder->whereNull('parent_id');
     }
 
     protected function getLeftAppends(): array
@@ -31,23 +30,55 @@ class CategoryList extends BaseDataTable
 
     protected function getResultFromQuery(Builder $query): array
     {
-        $tree = to_flat_tree($query->get()->toArray());
+        // Get filtered root IDs from the query (respects user filters),
+        // then load the tree with recursive children via familyTree()
+        $rootIds = $query->pluck($this->modelTable . '.' . $this->modelKeyName);
 
-        $returnKeys = array_merge($this->getReturnKeys(), ['depth']);
+        $categories = resolve_static(Category::class, 'familyTree')
+            ->whereKey($rootIds)
+            ->get();
 
-        foreach ($tree as &$item) {
-            $item = Arr::only(Arr::dot($item), $returnKeys);
-            $item['indentation'] = '';
+        $tree = to_flat_tree($categories->toArray());
+
+        // Collect ALL models recursively (parents + all nested children)
+        $allModels = collect();
+        $collectRecursive = function ($items) use (&$collectRecursive, &$allModels): void {
+            foreach ($items as $item) {
+                $allModels->push($item);
+
+                if ($item->relationLoaded('children')) {
+                    $collectRecursive($item->children);
+                }
+            }
+        };
+
+        $collectRecursive($categories);
+        $modelsById = $allModels->keyBy(fn ($m) => $m->getKey());
+
+        $data = [];
+        foreach ($tree as $item) {
+            $model = $modelsById[$item['id']] ?? null;
+
+            if ($model) {
+                $row = $this->itemToArray($model);
+            } else {
+                $row = Arr::only(Arr::dot($item), $this->getReturnKeys());
+            }
+
+            $row['depth'] = $item['depth'];
+            $row['indentation'] = '';
 
             if ($item['depth'] > 0) {
                 $indent = $item['depth'] * 20;
-                $item['indentation'] = <<<HTML
-                    <div class="text-right indent-icon" style="width:{$indent}px;">
-                    </div>
-                    HTML;
+                $row['indentation'] = '<div class="shrink-0" style="min-width:' . $indent . 'px"></div>';
             }
+
+            $data[] = $row;
         }
 
-        return $tree;
+        return [
+            'data' => $data,
+            'total' => count($data),
+        ];
     }
 }

--- a/src/Livewire/DataTables/GenerateWidgetWizard.php
+++ b/src/Livewire/DataTables/GenerateWidgetWizard.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace FluxErp\Livewire\DataTables;
+
+use FluxErp\Livewire\Support\Dashboard;
+use FluxErp\Livewire\Widgets\Generated\GeneratedBarChart;
+use FluxErp\Livewire\Widgets\Generated\GeneratedLineChart;
+use FluxErp\Livewire\Widgets\Generated\GeneratedValueBox;
+use FluxErp\Livewire\Widgets\Generated\GeneratedValueList;
+use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\DataTable\HasWidgetGeneration;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Renderless;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use Throwable;
+
+class GenerateWidgetWizard extends Component
+{
+    use Actions;
+
+    public int $step = 1;
+
+    #[Url]
+    public ?string $datatable = null;
+
+    #[Locked]
+    public array $userFilters = [];
+
+    #[Locked]
+    public array $availableColumns = [];
+
+    public ?string $widgetType = null;
+
+    public ?string $valueColumn = null;
+
+    public ?string $aggregate = 'sum';
+
+    public ?string $groupColumn = null;
+
+    public ?string $dateColumn = null;
+
+    public array $selectedColumns = [];
+
+    public ?string $sortColumn = null;
+
+    public string $sortDirection = 'desc';
+
+    public int $limit = 10;
+
+    public string $name = '';
+
+    public ?string $targetDashboard = null;
+
+    public bool $timeframeAware = false;
+
+    public ?string $timeframeDateColumn = null;
+
+    public bool $isShared = false;
+
+    public function mount(): void
+    {
+        if (! $this->datatable || ! class_exists($this->datatable)) {
+            $this->redirectRoute('dashboard', navigate: true);
+
+            return;
+        }
+
+        if (! in_array(HasWidgetGeneration::class, class_uses_recursive($this->datatable))) {
+            $this->redirectRoute('dashboard', navigate: true);
+
+            return;
+        }
+
+        $datatable = app()->make($this->datatable);
+        $this->availableColumns = $datatable->buildAvailableColumns();
+
+        $filters = session()->pull('widget-wizard-filters', []);
+        $this->userFilters = $filters;
+    }
+
+    public function render(): View
+    {
+        return view('flux::livewire.datatables.generate-widget-wizard');
+    }
+
+    public function nextStep(): void
+    {
+        match ($this->step) {
+            2 => $this->validate(['widgetType' => 'required|in:value_box,bar_chart,line_chart,value_list']),
+            3 => $this->validateStepThree(),
+            default => null,
+        };
+
+        $this->step = min($this->step + 1, 4);
+    }
+
+    public function previousStep(): void
+    {
+        $this->step = max($this->step - 1, 1);
+    }
+
+    public function save(): void
+    {
+        $this->validate([
+            'name' => 'required|string|max:255',
+            'targetDashboard' => 'required|string',
+        ]);
+
+        auth()->user()->widgets()->create([
+            'component_name' => $this->resolveComponentName(),
+            'dashboard_component' => $this->targetDashboard,
+            'name' => $this->name,
+            'config' => array_filter([
+                'type' => $this->widgetType,
+                'datatable' => $this->datatable,
+                'name' => $this->name,
+                'filters' => $this->userFilters,
+                'value_column' => $this->valueColumn,
+                'aggregate' => $this->aggregate,
+                'group_column' => $this->groupColumn,
+                'date_column' => $this->widgetType === 'line_chart'
+                    ? $this->dateColumn
+                    : ($this->timeframeAware ? $this->timeframeDateColumn : null),
+                'timeframe_aware' => $this->timeframeAware,
+                'columns' => $this->selectedColumns ?: null,
+                'sort_column' => $this->sortColumn,
+                'sort_direction' => $this->sortDirection,
+                'limit' => $this->widgetType === 'value_list' ? $this->limit : null,
+                'is_shared' => $this->isShared,
+            ], fn ($v) => ! is_null($v)),
+            'width' => 2,
+            'height' => 2,
+            'order_column' => 0,
+            'order_row' => 0,
+        ]);
+
+        $this->toast()
+            ->success(__('Widget created successfully.'))
+            ->send();
+
+        $this->redirectRoute('dashboard', navigate: true);
+    }
+
+    public function getNumericColumns(): array
+    {
+        return array_values(array_filter(
+            $this->availableColumns,
+            fn (array $column) => data_get($column, 'type') === 'numeric'
+        ));
+    }
+
+    public function getDateColumns(): array
+    {
+        return array_values(array_filter(
+            $this->availableColumns,
+            fn (array $column) => data_get($column, 'type') === 'date'
+        ));
+    }
+
+    #[Computed]
+    public function getAvailableDashboards(): array
+    {
+        $dashboards = [];
+        $livewireNamespace = 'FluxErp\\Livewire\\';
+        $directoryPath = flux_path('src/Livewire');
+
+        try {
+            if (is_dir($directoryPath)) {
+                $iterator = Finder::create()
+                    ->in($directoryPath)
+                    ->files()
+                    ->name('*.php')
+                    ->sortByName();
+
+                foreach ($iterator as $file) {
+                    $relativePath = ltrim(Str::replace($directoryPath, '', $file->getRealPath()), '/');
+                    $class = $livewireNamespace . str_replace(['/', '.php'], ['\\', ''], $relativePath);
+
+                    if (! class_exists($class)) {
+                        continue;
+                    }
+
+                    $reflection = new ReflectionClass($class);
+
+                    if (! $reflection->isAbstract() && $reflection->isSubclassOf(Dashboard::class)) {
+                        $dashboards[$class] = __(class_basename($class));
+                    }
+                }
+            }
+        } catch (Throwable) {
+            // Fallback
+        }
+
+        if (empty($dashboards)) {
+            $dashboards[\FluxErp\Livewire\Dashboard\Dashboard::class] = __('Dashboard');
+        }
+
+        return $dashboards;
+    }
+
+    protected function resolveComponentName(): string
+    {
+        $classMap = [
+            'value_box' => GeneratedValueBox::class,
+            'bar_chart' => GeneratedBarChart::class,
+            'line_chart' => GeneratedLineChart::class,
+            'value_list' => GeneratedValueList::class,
+        ];
+
+        $class = $classMap[$this->widgetType] ?? GeneratedValueBox::class;
+
+        return app('livewire.finder')->normalizeName($class);
+    }
+
+    protected function validateStepThree(): void
+    {
+        $rules = match ($this->widgetType) {
+            'value_box' => [
+                'valueColumn' => 'required_unless:aggregate,count',
+                'aggregate' => 'required|in:sum,avg,min,max,count',
+            ],
+            'bar_chart' => [
+                'groupColumn' => 'required|string',
+                'valueColumn' => 'required_unless:aggregate,count',
+                'aggregate' => 'required|in:sum,avg,min,max,count',
+            ],
+            'line_chart' => [
+                'dateColumn' => 'required|string',
+                'valueColumn' => 'required_unless:aggregate,count',
+                'aggregate' => 'required|in:sum,avg,min,max,count',
+            ],
+            'value_list' => [
+                'selectedColumns' => 'required|array|min:1',
+                'sortColumn' => 'nullable|string',
+                'sortDirection' => 'required|in:asc,desc',
+                'limit' => 'required|integer|min:1|max:100',
+            ],
+            default => [],
+        };
+
+        $this->validate($rules);
+    }
+}

--- a/src/Livewire/Widgets/Generated/GeneratedBarChart.php
+++ b/src/Livewire/Widgets/Generated/GeneratedBarChart.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets\Generated;
+
+use FluxErp\Contracts\HasWidgetOptions;
+use FluxErp\Livewire\Support\Widgets\Charts\BarChart;
+use FluxErp\Traits\Livewire\Widget\HasGeneratedWidgetConfig;
+use FluxErp\Traits\Livewire\Widget\IsTimeFrameAwareWidget;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Renderless;
+
+class GeneratedBarChart extends BarChart implements HasWidgetOptions
+{
+    use HasGeneratedWidgetConfig, IsTimeFrameAwareWidget {
+        HasGeneratedWidgetConfig::dashboardComponent insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getCategory insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getLabel insteadof IsTimeFrameAwareWidget;
+    }
+
+    public function render(): View|Factory
+    {
+        return $this->renderWithErrorCheck(parent::render());
+    }
+
+    #[Renderless]
+    public function calculateChart(): void
+    {
+        $query = $this->buildFilteredQuery();
+
+        if (is_null($query)) {
+            return;
+        }
+
+        $aggregate = $this->getAggregate();
+        $valueColumn = $this->validateColumnName($this->getValueColumn());
+        $groupColumn = $this->validateColumnName($this->getGroupColumn());
+        $dateColumn = $this->validateColumnName($this->getDateColumn());
+
+        if (is_null($groupColumn)) {
+            return;
+        }
+
+        if ($aggregate !== 'count' && is_null($valueColumn)) {
+            return;
+        }
+
+        if ($this->isTimeframeAware() && $dateColumn) {
+            $query->whereBetween($dateColumn, [$this->getStart(), $this->getEnd()]);
+        }
+
+        $aggregateExpression = $aggregate === 'count'
+            ? DB::raw('COUNT(*) as aggregate_value')
+            : DB::raw("{$aggregate}({$valueColumn}) as aggregate_value");
+
+        $results = $query
+            ->reorder()
+            ->select([$groupColumn, $aggregateExpression])
+            ->groupBy($groupColumn)
+            ->orderByDesc('aggregate_value')
+            ->get();
+
+        $this->series = [
+            [
+                'name' => $this->title() ?? static::getLabel(),
+                'data' => $results->pluck('aggregate_value')->toArray(),
+            ],
+        ];
+
+        $this->xaxis = [
+            'categories' => $results->pluck($groupColumn)->toArray(),
+        ];
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->skipRender();
+        $this->calculateChart();
+        $this->updateData();
+    }
+
+    public function options(): array
+    {
+        return [];
+    }
+
+    protected function getOptions(): array
+    {
+        $options = parent::getOptions();
+        unset($options['config'], $options['configError'], $options['configErrorMessage']);
+
+        return $options;
+    }
+}

--- a/src/Livewire/Widgets/Generated/GeneratedLineChart.php
+++ b/src/Livewire/Widgets/Generated/GeneratedLineChart.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets\Generated;
+
+use FluxErp\Contracts\HasWidgetOptions;
+use FluxErp\Livewire\Support\Widgets\Charts\LineChart;
+use FluxErp\Traits\Livewire\Widget\HasGeneratedWidgetConfig;
+use FluxErp\Traits\Livewire\Widget\IsTimeFrameAwareWidget;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Renderless;
+
+class GeneratedLineChart extends LineChart implements HasWidgetOptions
+{
+    use HasGeneratedWidgetConfig, IsTimeFrameAwareWidget {
+        HasGeneratedWidgetConfig::dashboardComponent insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getCategory insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getLabel insteadof IsTimeFrameAwareWidget;
+    }
+
+    public function render(): View|Factory
+    {
+        return $this->renderWithErrorCheck(parent::render());
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->skipRender();
+        $this->calculateChart();
+        $this->updateData();
+    }
+
+    #[Renderless]
+    public function calculateChart(): void
+    {
+        $query = $this->buildFilteredQuery();
+
+        if (is_null($query)) {
+            return;
+        }
+
+        $aggregate = $this->getAggregate();
+        $valueColumn = $this->validateColumnName($this->getValueColumn());
+        $dateColumn = $this->validateColumnName($this->getDateColumn() ?? 'created_at');
+
+        if (is_null($dateColumn)) {
+            return;
+        }
+
+        if ($aggregate !== 'count' && is_null($valueColumn)) {
+            return;
+        }
+
+        if ($this->isTimeframeAware() && $dateColumn) {
+            $query->whereBetween($dateColumn, [$this->getStart(), $this->getEnd()]);
+        }
+
+        $unit = $this->getUnit() ?? 'month';
+        $dateFormat = match ($unit) {
+            'day' => '%Y-%m-%d',
+            'month' => '%Y-%m',
+            'year' => '%Y',
+            default => '%Y-%m',
+        };
+
+        $aggregateExpression = match ($aggregate) {
+            'sum' => "SUM({$valueColumn})",
+            'avg' => "AVG({$valueColumn})",
+            'min' => "MIN({$valueColumn})",
+            'max' => "MAX({$valueColumn})",
+            default => 'COUNT(*)',
+        };
+
+        $results = $query
+            ->reorder()
+            ->select(DB::raw("DATE_FORMAT({$dateColumn}, '{$dateFormat}') as period, {$aggregateExpression} as aggregate_value"))
+            ->groupBy('period')
+            ->orderBy('period')
+            ->get();
+
+        $this->series = [
+            [
+                'name' => $this->title() ?? static::getLabel(),
+                'data' => $results->pluck('aggregate_value')->map(fn ($value) => round((float) $value, 2))->toArray(),
+            ],
+        ];
+
+        $this->xaxis = [
+            'categories' => $results->pluck('period')->toArray(),
+        ];
+    }
+
+    public function options(): array
+    {
+        return [];
+    }
+
+    protected function getOptions(): array
+    {
+        $options = parent::getOptions();
+        unset($options['config'], $options['configError'], $options['configErrorMessage']);
+
+        return $options;
+    }
+}

--- a/src/Livewire/Widgets/Generated/GeneratedValueBox.php
+++ b/src/Livewire/Widgets/Generated/GeneratedValueBox.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets\Generated;
+
+use FluxErp\Contracts\HasWidgetOptions;
+use FluxErp\Livewire\Support\Widgets\ValueBox;
+use FluxErp\Traits\Livewire\Widget\HasGeneratedWidgetConfig;
+use FluxErp\Traits\Livewire\Widget\IsTimeFrameAwareWidget;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Renderless;
+
+class GeneratedValueBox extends ValueBox implements HasWidgetOptions
+{
+    use HasGeneratedWidgetConfig, IsTimeFrameAwareWidget {
+        HasGeneratedWidgetConfig::dashboardComponent insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getCategory insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getLabel insteadof IsTimeFrameAwareWidget;
+    }
+
+    public function render(): View
+    {
+        return $this->renderWithErrorCheck(parent::render());
+    }
+
+    #[Renderless]
+    public function calculateSum(): void
+    {
+        $query = $this->buildFilteredQuery();
+
+        if (is_null($query)) {
+            return;
+        }
+
+        $aggregate = $this->getAggregate();
+        $column = $this->getValueColumn();
+        $dateColumn = $this->getDateColumn();
+
+        if ($this->isTimeframeAware() && $dateColumn) {
+            $query->whereBetween($dateColumn, [$this->getStart(), $this->getEnd()]);
+        }
+
+        $rawSum = $aggregate === 'count'
+            ? $query->count()
+            : $query->{$aggregate}($column);
+
+        $this->sum = $column && $aggregate !== 'count'
+            ? $this->formatColumnValue($column, $rawSum)
+            : $rawSum;
+
+        if ($this->isTimeframeAware() && $dateColumn) {
+            $previousQuery = $this->buildFilteredQuery();
+
+            if (is_null($previousQuery)) {
+                return;
+            }
+
+            $previousQuery->whereBetween($dateColumn, [$this->getStartPrevious(), $this->getEndPrevious()]);
+
+            $rawPrevious = $aggregate === 'count'
+                ? $previousQuery->count()
+                : $previousQuery->{$aggregate}($column);
+
+            $this->previousSum = $column && $aggregate !== 'count'
+                ? $this->formatColumnValue($column, $rawPrevious)
+                : $rawPrevious;
+
+            $this->growthRate = $rawPrevious != 0
+                ? round((($rawSum - $rawPrevious) / abs($rawPrevious)) * 100, 2)
+                : null;
+        }
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->calculateSum();
+    }
+
+    public function options(): array
+    {
+        return [];
+    }
+
+    protected function icon(): string
+    {
+        return 'calculator';
+    }
+}

--- a/src/Livewire/Widgets/Generated/GeneratedValueList.php
+++ b/src/Livewire/Widgets/Generated/GeneratedValueList.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets\Generated;
+
+use FluxErp\Contracts\HasWidgetOptions;
+use FluxErp\Livewire\Support\Widgets\ValueList;
+use FluxErp\Traits\Livewire\Widget\HasGeneratedWidgetConfig;
+use FluxErp\Traits\Livewire\Widget\IsTimeFrameAwareWidget;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Renderless;
+
+class GeneratedValueList extends ValueList implements HasWidgetOptions
+{
+    use HasGeneratedWidgetConfig, IsTimeFrameAwareWidget {
+        HasGeneratedWidgetConfig::dashboardComponent insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getCategory insteadof IsTimeFrameAwareWidget;
+        HasGeneratedWidgetConfig::getLabel insteadof IsTimeFrameAwareWidget;
+    }
+
+    public function render(): View
+    {
+        return $this->renderWithErrorCheck(parent::render());
+    }
+
+    #[Renderless]
+    public function calculateByTimeFrame(): void
+    {
+        $this->skipRender();
+        $this->calculateList();
+    }
+
+    #[Renderless]
+    public function calculateList(): void
+    {
+        $query = $this->buildFilteredQuery();
+
+        if (is_null($query)) {
+            return;
+        }
+
+        $columns = $this->getConfigValue('columns', []);
+        $sortColumn = $this->getConfigValue('sort_column');
+        $sortDirection = $this->getConfigValue('sort_direction', 'desc');
+        $limit = $this->getConfigValue('limit', $this->limit);
+        $dateColumn = $this->getDateColumn();
+
+        if ($this->isTimeframeAware() && $dateColumn) {
+            $query->whereBetween($dateColumn, [$this->getStart(), $this->getEnd()]);
+        }
+
+        $model = $query->getModel();
+        $selectColumns = array_merge([$model->getKeyName()], $columns);
+
+        $query->select($selectColumns);
+
+        if ($sortColumn) {
+            $query->orderBy($sortColumn, $sortDirection);
+        }
+
+        $results = $query->limit($limit)->get();
+
+        $this->items = $results->map(function ($item) use ($columns) {
+            $label = count($columns) > 0 ? (string) $item->{$columns[0]} : '';
+            $value = count($columns) > 0 ? (string) $item->{$columns[count($columns) - 1]} : '';
+            $subLabel = count($columns) > 2 ? (string) $item->{$columns[1]} : null;
+
+            return [
+                'label' => $label,
+                'subLabel' => $subLabel,
+                'value' => $value,
+                'growthRate' => null,
+            ];
+        })->toArray();
+    }
+
+    #[Renderless]
+    public function options(): array
+    {
+        return [];
+    }
+}

--- a/src/Traits/Livewire/Dashboard/RendersWidgets.php
+++ b/src/Traits/Livewire/Dashboard/RendersWidgets.php
@@ -6,8 +6,10 @@ use FluxErp\Enums\ComparisonTypeEnum;
 use FluxErp\Enums\TimeFrameEnum;
 use FluxErp\Facades\Widget;
 use FluxErp\Models\Permission;
+use FluxErp\Models\Widget as WidgetModel;
 use FluxErp\Traits\Livewire\EnsureUsedInLivewire;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Js;
 use Livewire\Attributes\Renderless;
@@ -171,16 +173,20 @@ trait RendersWidgets
 
     protected function availableWidgetsTree(): array
     {
+        $generatedPrefix = 'widgets.generated.';
+
         $toNode = fn (array $widget) => [
             'id' => 'widget-' . $widget['component_name'],
             'label' => __($widget['label']),
             'component_name' => $widget['component_name'],
         ];
 
-        $widgets = collect($this->availableWidgets);
+        $widgets = collect($this->availableWidgets)
+            ->filter(fn (array $widget) => ! str_starts_with($widget['component_name'], $generatedPrefix));
 
         $categorized = $widgets
             ->whereNotNull('category')
+            ->where('category', '!=', 'generated')
             ->groupBy('category')
             ->sortKeys()
             ->map(fn ($children, $category) => [
@@ -200,7 +206,51 @@ trait RendersWidgets
             ->sortBy('label', SORT_STRING | SORT_FLAG_CASE)
             ->values();
 
-        return $categorized->merge($uncategorized)->all();
+        $tree = $categorized->merge($uncategorized);
+
+        $generatedWidgets = $this->getGeneratedWidgetsForTree($generatedPrefix);
+
+        if ($generatedWidgets->isNotEmpty()) {
+            $tree->push([
+                'id' => 'category-generated-widgets',
+                'label' => __('Generated Widgets'),
+                'children' => $generatedWidgets
+                    ->sortBy('label', SORT_STRING | SORT_FLAG_CASE)
+                    ->values()
+                    ->all(),
+            ]);
+        }
+
+        return $tree->all();
+    }
+
+    protected function getGeneratedWidgetsForTree(string $generatedPrefix): Collection
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return collect();
+        }
+
+        $userMorphClass = $user->getMorphClass();
+        $userId = $user->getKey();
+
+        return resolve_static(WidgetModel::class, 'query')
+            ->where('component_name', 'like', $generatedPrefix . '%')
+            ->where('dashboard_component', static::class)
+            ->where(function ($query) use ($userMorphClass, $userId): void {
+                $query->where(function ($query) use ($userMorphClass, $userId): void {
+                    $query->where('widgetable_type', $userMorphClass)
+                        ->where('widgetable_id', $userId);
+                })->orWhere('config->is_shared', true);
+            })
+            ->get()
+            ->unique('component_name')
+            ->map(fn (WidgetModel $widget) => [
+                'id' => 'widget-generated-' . $widget->getKey(),
+                'label' => data_get($widget->config, 'name', $widget->name ?? $widget->component_name),
+                'component_name' => $widget->component_name,
+            ]);
     }
 
     protected function filterWidgets(array $widgets): array
@@ -209,6 +259,18 @@ trait RendersWidgets
             $widgets,
             function (array $widget) {
                 $name = $widget['component_name'];
+
+                if (str_starts_with($name, 'widgets.generated.') || str_contains($name, '.generated.')) {
+                    try {
+                        $permissionExists = ! is_null(
+                            resolve_static(Permission::class, 'findByName', ['name' => 'widget.' . $name])
+                        );
+                    } catch (PermissionDoesNotExist) {
+                        $permissionExists = false;
+                    }
+
+                    return ! $permissionExists || auth()->user()->can('widget.' . $name);
+                }
 
                 if (
                     collect(Arr::wrap(data_get($widget, 'dashboard_component')))

--- a/src/Traits/Livewire/DataTable/HasWidgetGeneration.php
+++ b/src/Traits/Livewire/DataTable/HasWidgetGeneration.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace FluxErp\Traits\Livewire\DataTable;
+
+use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
+
+use Spatie\ModelInfo\Attributes\Attribute;
+use Spatie\ModelInfo\ModelInfo;
+use TeamNiftyGmbH\DataTable\DataTable;
+
+
+trait HasWidgetGeneration
+{
+    public static function getWidgetModel(): string
+    {
+        return app(static::class)->getModel();
+    }
+
+    public function bootHasWidgetGeneration(): void
+    {
+        if (! $this instanceof DataTable) {
+            throw new InvalidArgumentException('This trait can only be used in a DataTable');
+        }
+    }
+
+    public function buildWidgetQuery(array $userFilters): Builder
+    {
+        $originalUserFilters = $this->userFilters;
+        $originalSearch = $this->search;
+        $originalSessionFilter = $this->sessionFilter;
+
+        if (! $this->modelKeyName || ! $this->modelTable) {
+            $model = app($this->getModel());
+            $this->modelKeyName = $this->modelKeyName ?: $model->getKeyName();
+            $this->modelTable = $this->modelTable ?: $model->getTable();
+        }
+
+        try {
+            $this->userFilters = $userFilters;
+            $this->search = '';
+            $this->sessionFilter = [];
+
+            $query = $this->buildSearch(unpaginated: true);
+        } finally {
+            $this->userFilters = $originalUserFilters;
+            $this->search = $originalSearch;
+            $this->sessionFilter = $originalSessionFilter;
+        }
+
+        return $query;
+    }
+
+    public function openWidgetWizard(): void
+    {
+        session()->put('widget-wizard-filters', $this->userFilters);
+
+        $this->redirectRoute('widgets.create', ['datatable' => static::class], navigate: true);
+    }
+
+    public function buildAvailableColumns(): array
+    {
+        $numericTypes = ['integer', 'bigint', 'smallint', 'tinyint', 'mediumint', 'decimal', 'float', 'double'];
+        $dateTypes = ['date', 'datetime', 'timestamp'];
+
+        $modelInfo = ModelInfo::forModel($this->getModel());
+
+        return $modelInfo->attributes
+            ->filter(fn (Attribute $attribute) => ! $attribute->virtual && ! $attribute->appended)
+            ->map(function (Attribute $attribute) use ($numericTypes, $dateTypes) {
+                $dbType = strtolower($attribute->type ?? '');
+
+                if (in_array($dbType, $numericTypes)) {
+                    $type = 'numeric';
+                } elseif (in_array($dbType, $dateTypes)) {
+                    $type = 'date';
+                } else {
+                    $type = 'string';
+                }
+
+                return [
+                    'name' => $attribute->name,
+                    'label' => __(str($attribute->name)->headline()->toString()),
+                    'type' => $type,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    protected function getCustomSidebarTabs(): array
+    {
+        return [
+            [
+                'id' => 'save-as-widget',
+                'label' => __('Widget'),
+                'view' => 'flux::livewire.datatables.sidebar-widget-tab',
+            ],
+        ];
+    }
+}

--- a/src/Traits/Livewire/Widget/HasGeneratedWidgetConfig.php
+++ b/src/Traits/Livewire/Widget/HasGeneratedWidgetConfig.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace FluxErp\Traits\Livewire\Widget;
+
+use FluxErp\Traits\Livewire\DataTable\HasWidgetGeneration;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Locked;
+use Livewire\Livewire;
+use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
+use Throwable;
+
+trait HasGeneratedWidgetConfig
+{
+    use Widgetable;
+
+    #[Locked]
+    public ?array $config = null;
+
+    public bool $configError = false;
+
+    public ?string $configErrorMessage = null;
+
+    public static function dashboardComponent(): array
+    {
+        return [];
+    }
+
+    public static function getCategory(): ?string
+    {
+        return 'generated';
+    }
+
+    public static function getLabel(): string
+    {
+        if (app()->runningInConsole()) {
+            return Str::headline(class_basename(static::class));
+        }
+
+        return __(Str::headline(class_basename(static::class)));
+    }
+
+    protected function title(): ?string
+    {
+        return data_get($this->config, 'name') ?? static::getLabel();
+    }
+
+    protected function buildFilteredQuery(): ?Builder
+    {
+        $datatableClass = data_get($this->config, 'datatable');
+
+        if (! $datatableClass || ! class_exists($datatableClass)) {
+            $this->configError = true;
+            $this->configErrorMessage = __('Invalid DataTable configuration.');
+
+            return null;
+        }
+
+        if (! in_array(HasWidgetGeneration::class, class_uses_recursive($datatableClass))) {
+            $this->configError = true;
+            $this->configErrorMessage = __('DataTable does not support widget generation.');
+
+            return null;
+        }
+
+        try {
+            $datatable = Livewire::new($datatableClass);
+            $userFilters = data_get($this->config, 'filters', []);
+
+            return $datatable->buildWidgetQuery($userFilters);
+        } catch (Throwable $e) {
+            $this->configError = true;
+            $this->configErrorMessage = $e->getMessage();
+
+            return null;
+        }
+    }
+
+    protected function getConfigValue(string $key, mixed $default = null): mixed
+    {
+        return data_get($this->config, $key, $default);
+    }
+
+    protected function getAggregate(): ?string
+    {
+        return $this->getConfigValue('aggregate', 'count');
+    }
+
+    protected function getValueColumn(): ?string
+    {
+        return $this->getConfigValue('value_column');
+    }
+
+    protected function getGroupColumn(): ?string
+    {
+        return $this->getConfigValue('group_column');
+    }
+
+    protected function getDateColumn(): ?string
+    {
+        return $this->getConfigValue('date_column');
+    }
+
+    protected function isTimeframeAware(): bool
+    {
+        return (bool) $this->getConfigValue('timeframe_aware', false);
+    }
+
+    protected function validateColumnName(?string $column): ?string
+    {
+        if (is_null($column)) {
+            return null;
+        }
+
+        if (! preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $column)) {
+            $this->configError = true;
+            $this->configErrorMessage = __('Invalid column name in configuration.');
+
+            return null;
+        }
+
+        return $column;
+    }
+
+    protected function formatColumnValue(string $column, mixed $value): string
+    {
+        $datatableClass = data_get($this->config, 'datatable');
+
+        if (! $datatableClass || ! class_exists($datatableClass)) {
+            return (string) $value;
+        }
+
+        try {
+            $datatable = Livewire::new($datatableClass);
+            $registry = app(FormatterRegistry::class);
+            $customFormatters = $datatable->getFormatters();
+            $model = app($datatable->getModel());
+            $modelCasts = $model->getCasts();
+
+            $baseCol = str_contains($column, '.') ? last(explode('.', $column)) : $column;
+
+            if (isset($customFormatters[$column]) && is_string($customFormatters[$column])) {
+                $formatter = $registry->resolve($customFormatters[$column]);
+            } elseif (isset($customFormatters[$column]) && is_array($customFormatters[$column])) {
+                $formatter = $registry->resolveWithOptions($customFormatters[$column][0] ?? 'string', $customFormatters[$column][1] ?? []);
+            } else {
+                $stringCasts = array_filter($modelCasts, 'is_string');
+                $formatter = $registry->resolveForColumn($baseCol, $stringCasts);
+            }
+
+            return $formatter->format($value, []);
+        } catch (Throwable) {
+            return (string) $value;
+        }
+    }
+
+    protected function renderWithErrorCheck(View $defaultView): View
+    {
+        if ($this->configError) {
+            return view('flux::livewire.widgets.generated-widget-error', [
+                'message' => $this->configErrorMessage,
+            ]);
+        }
+
+        return $defaultView;
+    }
+}


### PR DESCRIPTION
## Summary
- `getBuilder()` was replacing the DataTable's configured builder with a new query from `familyTree()`, losing select/join/sort configuration
- `getResultFromQuery()` returned a flat array instead of the paginated format the DataTable frontend expects
- Formatter was not applied to child categories (showing `1` instead of checkmarks)

Fix: use filtered query IDs to load the tree via `familyTree()`, run each model through `itemToArray()` for proper formatting, wrap result in expected `['data' => ..., 'total' => ...]` format

## Summary by Sourcery

Fix category DataTable tree results and introduce a configurable, filter-based widget generation workflow for dashboards.

New Features:
- Add a multi-step Generate Widget wizard component and route to create dashboard widgets from DataTable filter configurations.
- Introduce traits for DataTables and widgets to support widget generation, configuration handling, and error rendering.
- Expose a sidebar tab in DataTables to launch the widget generation flow and persist current filters.
- Display dynamically generated widgets in the dashboard widget tree, including shared widgets and per-user widgets.

Bug Fixes:
- Preserve the original DataTable query configuration in the category list and return results in the paginated format expected by the frontend, including proper formatting for child categories.

Enhancements:
- Extend dashboard widget tree building to exclude generated widgets from normal categories and group them under a dedicated Generated Widgets category with permission checks.
- Add a new permission for sharing generated widgets and ensure it is created during permission initialization.
- Include widget generation capabilities in the base DataTable class via a reusable trait.