### PR TITLE
Fix categories DataTable showing no data

### DIFF
--- a/src/Livewire/DataTables/CategoryList.php
+++ b/src/Livewire/DataTables/CategoryList.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\DataTables;
 use FluxErp\Models\Category;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class CategoryList extends BaseDataTable
 {
@@ -40,24 +41,11 @@ class CategoryList extends BaseDataTable
 
         $tree = to_flat_tree($categories->toArray());
 
-        // Collect ALL models recursively (parents + all nested children)
-        $allModels = collect();
-        $collectRecursive = function ($items) use (&$collectRecursive, &$allModels): void {
-            foreach ($items as $item) {
-                $allModels->push($item);
-
-                if ($item->relationLoaded('children')) {
-                    $collectRecursive($item->children);
-                }
-            }
-        };
-
-        $collectRecursive($categories);
-        $modelsById = $allModels->keyBy(fn ($m) => $m->getKey());
+        $modelsById = $this->collectModelsById($categories);
 
         $data = [];
         foreach ($tree as $item) {
-            $model = $modelsById->get($item['id']);
+            $model = $modelsById[$item['id']] ?? null;
 
             if ($model) {
                 $row = $this->itemToArray($model);
@@ -80,5 +68,18 @@ class CategoryList extends BaseDataTable
             'data' => $data,
             'total' => count($data),
         ];
+    }
+
+    protected function collectModelsById(Collection $items, array &$result = []): array
+    {
+        foreach ($items as $item) {
+            $result[$item->getKey()] = $item;
+
+            if ($item->relationLoaded('children')) {
+                $this->collectModelsById($item->children, $result);
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Livewire/DataTables/CategoryList.php
+++ b/src/Livewire/DataTables/CategoryList.php
@@ -18,8 +18,7 @@ class CategoryList extends BaseDataTable
 
     protected function getBuilder(Builder $builder): Builder
     {
-        return resolve_static(Category::class, 'familyTree')
-            ->whereNull('parent_id');
+        return $builder->whereNull('parent_id');
     }
 
     protected function getLeftAppends(): array
@@ -31,23 +30,55 @@ class CategoryList extends BaseDataTable
 
     protected function getResultFromQuery(Builder $query): array
     {
-        $tree = to_flat_tree($query->get()->toArray());
+        // Get filtered root IDs from the query (respects user filters),
+        // then load the tree with recursive children via familyTree()
+        $rootIds = $query->pluck($this->modelTable . '.' . $this->modelKeyName);
 
-        $returnKeys = array_merge($this->getReturnKeys(), ['depth']);
+        $categories = resolve_static(Category::class, 'familyTree')
+            ->whereKey($rootIds)
+            ->get();
 
-        foreach ($tree as &$item) {
-            $item = Arr::only(Arr::dot($item), $returnKeys);
-            $item['indentation'] = '';
+        $tree = to_flat_tree($categories->toArray());
+
+        // Collect ALL models recursively (parents + all nested children)
+        $allModels = collect();
+        $collectRecursive = function ($items) use (&$collectRecursive, &$allModels): void {
+            foreach ($items as $item) {
+                $allModels->push($item);
+
+                if ($item->relationLoaded('children')) {
+                    $collectRecursive($item->children);
+                }
+            }
+        };
+
+        $collectRecursive($categories);
+        $modelsById = $allModels->keyBy(fn ($m) => $m->getKey());
+
+        $data = [];
+        foreach ($tree as $item) {
+            $model = $modelsById->get($item['id']);
+
+            if ($model) {
+                $row = $this->itemToArray($model);
+            } else {
+                $row = Arr::only(Arr::dot($item), $this->getReturnKeys());
+            }
+
+            $row['depth'] = $item['depth'];
+            $row['indentation'] = '';
 
             if ($item['depth'] > 0) {
                 $indent = $item['depth'] * 20;
-                $item['indentation'] = <<<HTML
-                    <div class="text-right indent-icon" style="width:{$indent}px;">
-                    </div>
-                    HTML;
+                $row['indentation'] = '<div class="shrink-0" style="min-width:' . $indent . 'px"></div>';
             }
+
+            $data[] = $row;
         }
 
-        return $tree;
+        return [
+            'data' => $data,
+            'total' => count($data),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- `getBuilder()` was replacing the DataTable's configured builder with a new query from `familyTree()`, losing select/join/sort configuration
- `getResultFromQuery()` returned a flat array instead of the paginated format the DataTable frontend expects
- Formatter was not applied to child categories

Fix: use filtered query IDs to load the tree via `familyTree()`, run each model through `itemToArray()` for proper formatting, wrap result in expected format

Depends on Team-Nifty-GmbH/tall-datatables#219 for leftAppend rendering

## Summary by Sourcery

Fix category DataTable to use the existing filtered query as the root set and return results in the paginated format expected by the frontend.

Bug Fixes:
- Preserve the DataTable's configured query builder while restricting categories to root items.
- Ensure category trees are loaded via the familyTree relationship while still respecting user-applied filters.
- Apply the standard item-to-array formatting to all categories, including nested children, and return results with the expected data/total structure.