### PR TITLE
Add Spatie MailSettings to override default mail configuration

### DIFF
--- a/database/settings/2026_04_14_000001_create_mail_settings.php
+++ b/database/settings/2026_04_14_000001_create_mail_settings.php
@@ -6,14 +6,16 @@ return new class() extends SettingsMigration
 {
     public function up(): void
     {
-        $this->migrator->add('mail.mailer', null);
-        $this->migrator->add('mail.host', null);
-        $this->migrator->add('mail.port', null);
-        $this->migrator->add('mail.username', null);
-        $this->migrator->add('mail.password', null);
-        $this->migrator->add('mail.encryption', null);
-        $this->migrator->add('mail.from_address', null);
-        $this->migrator->add('mail.from_name', null);
+        $default = config('mail.default');
+
+        $this->migrator->add('mail.mailer', $default);
+        $this->migrator->add('mail.host', config("mail.mailers.{$default}.host"));
+        $this->migrator->add('mail.port', config("mail.mailers.{$default}.port"));
+        $this->migrator->add('mail.username', config("mail.mailers.{$default}.username"));
+        $this->migrator->add('mail.password', config("mail.mailers.{$default}.password"));
+        $this->migrator->add('mail.encryption', config("mail.mailers.{$default}.encryption"));
+        $this->migrator->add('mail.from_address', config('mail.from.address'));
+        $this->migrator->add('mail.from_name', config('mail.from.name'));
     }
 
     public function down(): void

--- a/database/settings/2026_04_14_000001_create_mail_settings.php
+++ b/database/settings/2026_04_14_000001_create_mail_settings.php
@@ -1,0 +1,30 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('mail.mailer', null);
+        $this->migrator->add('mail.host', null);
+        $this->migrator->add('mail.port', null);
+        $this->migrator->add('mail.username', null);
+        $this->migrator->add('mail.password', null);
+        $this->migrator->add('mail.encryption', null);
+        $this->migrator->add('mail.from_address', null);
+        $this->migrator->add('mail.from_name', null);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('mail.mailer');
+        $this->migrator->delete('mail.host');
+        $this->migrator->delete('mail.port');
+        $this->migrator->delete('mail.username');
+        $this->migrator->delete('mail.password');
+        $this->migrator->delete('mail.encryption');
+        $this->migrator->delete('mail.from_address');
+        $this->migrator->delete('mail.from_name');
+    }
+};

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -78,6 +78,7 @@ use FluxErp\Livewire\Settings\LedgerAccounts;
 use FluxErp\Livewire\Settings\Locations;
 use FluxErp\Livewire\Settings\Logs;
 use FluxErp\Livewire\Settings\MailAccounts;
+use FluxErp\Livewire\Settings\MailSettings;
 use FluxErp\Livewire\Settings\Notifications;
 use FluxErp\Livewire\Settings\OrderTypes;
 use FluxErp\Livewire\Settings\PaymentReminderTexts;
@@ -293,6 +294,7 @@ Route::middleware('web')
                         Route::get('/locations', Locations::class)->name('locations');
                         Route::get('/logs', Logs::class)->name('logs');
                         Route::get('/mail-accounts', MailAccounts::class)->name('mail-accounts');
+                        Route::get('/mail-settings', MailSettings::class)->name('mail-settings');
                         Route::get('/notifications', Notifications::class)->name('notifications');
                         Route::get('/order-types', OrderTypes::class)->name('order-types');
                         Route::get('/payment-reminder-texts', PaymentReminderTexts::class)->name('payment-reminder-texts');

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -320,32 +320,37 @@ class FluxServiceProvider extends ServiceProvider
     {
         try {
             $settings = app(Settings\MailSettings::class);
+            $previousConfig = [];
 
             if (! is_null($settings->mailer)) {
+                $previousConfig['mail.default'] = config('mail.default');
                 config()->set('mail.default', $settings->mailer);
             }
 
             $defaultMailer = config('mail.default');
 
-            $mailerMap = [
+            $configMap = [
                 'host' => "mail.mailers.{$defaultMailer}.host",
                 'port' => "mail.mailers.{$defaultMailer}.port",
                 'username' => "mail.mailers.{$defaultMailer}.username",
                 'password' => "mail.mailers.{$defaultMailer}.password",
                 'encryption' => "mail.mailers.{$defaultMailer}.encryption",
-            ];
-
-            $globalMap = [
                 'from_address' => 'mail.from.address',
                 'from_name' => 'mail.from.name',
             ];
 
-            foreach (array_merge($mailerMap, $globalMap) as $property => $configKey) {
+            foreach ($configMap as $property => $configKey) {
                 if (! is_null($settings->{$property})) {
+                    $previousConfig[$configKey] = config($configKey);
                     config()->set($configKey, $settings->{$property});
                 }
             }
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            foreach ($previousConfig ?? [] as $configKey => $value) {
+                config()->set($configKey, $value);
+            }
+
+            report($e);
         }
     }
 }

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -73,6 +73,8 @@ class FluxServiceProvider extends ServiceProvider
                 }
             } catch (Throwable) {
             }
+
+            $this->applyMailSettings();
         });
         Number::useLocale(app()->getLocale());
 
@@ -312,5 +314,31 @@ class FluxServiceProvider extends ServiceProvider
                 'auth.providers.users',
                 $usersProvider
             );
+    }
+
+    protected function applyMailSettings(): void
+    {
+        try {
+            $settings = app(Settings\MailSettings::class);
+        } catch (Throwable) {
+            return;
+        }
+
+        $map = [
+            'mailer' => 'mail.default',
+            'host' => 'mail.mailers.smtp.host',
+            'port' => 'mail.mailers.smtp.port',
+            'username' => 'mail.mailers.smtp.username',
+            'password' => 'mail.mailers.smtp.password',
+            'encryption' => 'mail.mailers.smtp.encryption',
+            'from_address' => 'mail.from.address',
+            'from_name' => 'mail.from.name',
+        ];
+
+        foreach ($map as $property => $configKey) {
+            if (! is_null($settings->{$property})) {
+                config()->set($configKey, $settings->{$property});
+            }
+        }
     }
 }

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -320,33 +320,32 @@ class FluxServiceProvider extends ServiceProvider
     {
         try {
             $settings = app(Settings\MailSettings::class);
-        } catch (Throwable) {
-            return;
-        }
 
-        if (! is_null($settings->mailer)) {
-            config()->set('mail.default', $settings->mailer);
-        }
-
-        $defaultMailer = config('mail.default');
-
-        $mailerMap = [
-            'host' => "mail.mailers.{$defaultMailer}.host",
-            'port' => "mail.mailers.{$defaultMailer}.port",
-            'username' => "mail.mailers.{$defaultMailer}.username",
-            'password' => "mail.mailers.{$defaultMailer}.password",
-            'encryption' => "mail.mailers.{$defaultMailer}.encryption",
-        ];
-
-        $globalMap = [
-            'from_address' => 'mail.from.address',
-            'from_name' => 'mail.from.name',
-        ];
-
-        foreach (array_merge($mailerMap, $globalMap) as $property => $configKey) {
-            if (! is_null($settings->{$property})) {
-                config()->set($configKey, $settings->{$property});
+            if (! is_null($settings->mailer)) {
+                config()->set('mail.default', $settings->mailer);
             }
+
+            $defaultMailer = config('mail.default');
+
+            $mailerMap = [
+                'host' => "mail.mailers.{$defaultMailer}.host",
+                'port' => "mail.mailers.{$defaultMailer}.port",
+                'username' => "mail.mailers.{$defaultMailer}.username",
+                'password' => "mail.mailers.{$defaultMailer}.password",
+                'encryption' => "mail.mailers.{$defaultMailer}.encryption",
+            ];
+
+            $globalMap = [
+                'from_address' => 'mail.from.address',
+                'from_name' => 'mail.from.name',
+            ];
+
+            foreach (array_merge($mailerMap, $globalMap) as $property => $configKey) {
+                if (! is_null($settings->{$property})) {
+                    config()->set($configKey, $settings->{$property});
+                }
+            }
+        } catch (Throwable) {
         }
     }
 }

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -324,18 +324,26 @@ class FluxServiceProvider extends ServiceProvider
             return;
         }
 
-        $map = [
-            'mailer' => 'mail.default',
-            'host' => 'mail.mailers.smtp.host',
-            'port' => 'mail.mailers.smtp.port',
-            'username' => 'mail.mailers.smtp.username',
-            'password' => 'mail.mailers.smtp.password',
-            'encryption' => 'mail.mailers.smtp.encryption',
+        if (! is_null($settings->mailer)) {
+            config()->set('mail.default', $settings->mailer);
+        }
+
+        $defaultMailer = config('mail.default');
+
+        $mailerMap = [
+            'host' => "mail.mailers.{$defaultMailer}.host",
+            'port' => "mail.mailers.{$defaultMailer}.port",
+            'username' => "mail.mailers.{$defaultMailer}.username",
+            'password' => "mail.mailers.{$defaultMailer}.password",
+            'encryption' => "mail.mailers.{$defaultMailer}.encryption",
+        ];
+
+        $globalMap = [
             'from_address' => 'mail.from.address',
             'from_name' => 'mail.from.name',
         ];
 
-        foreach ($map as $property => $configKey) {
+        foreach (array_merge($mailerMap, $globalMap) as $property => $configKey) {
             if (! is_null($settings->{$property})) {
                 config()->set($configKey, $settings->{$property});
             }

--- a/src/Livewire/Forms/Settings/MailSettingsForm.php
+++ b/src/Livewire/Forms/Settings/MailSettingsForm.php
@@ -8,6 +8,7 @@ use FluxErp\Support\Livewire\Attributes\SeparatorAfter;
 
 class MailSettingsForm extends SettingsForm
 {
+    #[RenderAs(type: RenderAs::SELECT_NATIVE, options: [':options' => "\\Illuminate\\Support\\Arr::except(array_keys(config('mail.mailers')), ['log', 'array', 'failover'])"])]
     public ?string $mailer = null;
 
     public ?string $host = null;

--- a/src/Livewire/Forms/Settings/MailSettingsForm.php
+++ b/src/Livewire/Forms/Settings/MailSettingsForm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FluxErp\Livewire\Forms\Settings;
+
+use FluxErp\Settings\MailSettings;
+use FluxErp\Support\Livewire\Attributes\RenderAs;
+use FluxErp\Support\Livewire\Attributes\SeparatorAfter;
+
+class MailSettingsForm extends SettingsForm
+{
+    public ?string $mailer = null;
+
+    public ?string $host = null;
+
+    public ?int $port = null;
+
+    public ?string $username = null;
+
+    #[RenderAs(type: RenderAs::PASSWORD)]
+    #[SeparatorAfter]
+    public ?string $password = null;
+
+    public ?string $encryption = null;
+
+    public ?string $from_address = null;
+
+    public ?string $from_name = null;
+
+    public function getSettingsClass(): string
+    {
+        return MailSettings::class;
+    }
+}

--- a/src/Livewire/Settings/MailSettings.php
+++ b/src/Livewire/Settings/MailSettings.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FluxErp\Livewire\Settings;
+
+use FluxErp\Livewire\Forms\Settings\MailSettingsForm;
+use FluxErp\Livewire\Support\SettingsComponent;
+
+class MailSettings extends SettingsComponent
+{
+    public MailSettingsForm $mailSettingsForm;
+
+    protected function getFormPropertyName(): string
+    {
+        return 'mailSettingsForm';
+    }
+}

--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -135,6 +135,7 @@ class MenuServiceProvider extends ServiceProvider
                 Menu::register(route: 'settings.country-regions', path: 'settings.children.general.children.country-regions');
                 Menu::register(route: 'settings.currencies', path: 'settings.children.general.children.currencies');
                 Menu::register(route: 'settings.languages', path: 'settings.children.general.children.languages');
+                Menu::register(route: 'settings.mail-settings', path: 'settings.children.general.children.mail-settings');
                 Menu::register(route: 'settings.record-origins', path: 'settings.children.general.children.record-origins');
                 Menu::register(route: 'settings.serial-number-ranges', path: 'settings.children.general.children.serial-number-ranges');
                 Menu::register(route: 'settings.tags', path: 'settings.children.general.children.tags');

--- a/src/Settings/MailSettings.php
+++ b/src/Settings/MailSettings.php
@@ -24,4 +24,11 @@ class MailSettings extends FluxSettings
     {
         return 'mail';
     }
+
+    public static function encrypted(): array
+    {
+        return [
+            'password',
+        ];
+    }
 }

--- a/src/Settings/MailSettings.php
+++ b/src/Settings/MailSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FluxErp\Settings;
+
+class MailSettings extends FluxSettings
+{
+    public ?string $mailer;
+
+    public ?string $host;
+
+    public ?int $port;
+
+    public ?string $username;
+
+    public ?string $password;
+
+    public ?string $encryption;
+
+    public ?string $from_address;
+
+    public ?string $from_name;
+
+    public static function group(): string
+    {
+        return 'mail';
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `MailSettings` Spatie Settings class with nullable properties for all MAIL_* config values (mailer, host, port, username, password, encryption, from_address, from_name)
- Non-null settings values override `config('mail.*')` in the ServiceProvider boot phase
- Includes settings migration, Livewire form with auto-render, and settings component accessible under General settings group

## Summary by Sourcery

Introduce configurable mail settings that can override default Laravel mail configuration via Spatie settings and expose them through the settings UI.

New Features:
- Add a MailSettings Spatie settings class for configurable mail transport and sender options.
- Expose a MailSettings Livewire settings page and form under the General settings group for managing mail configuration.

Enhancements:
- Apply stored MailSettings at application boot to override mail configuration values when present.
- Register the new mail settings page in the frontend routes and menu structure.