### PR TITLE
Fix login link storing serialized User model in cache

### DIFF
--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -21,7 +21,13 @@ class LoginLinkController extends Controller
         }
 
         try {
-            Auth::guard($login['guard'])->login($login['user']);
+            $user = isset($login['user_type'], $login['user_id'])
+                ? morphed_model($login['user_type'])::query()->whereKey($login['user_id'])->first()
+                : ($login['user'] ?? null);
+
+            if ($user) {
+                Auth::guard($login['guard'])->login($user);
+            }
         } catch (Exception) {
         }
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -275,7 +275,8 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
         $expires = now()->addMinutes(15);
         Cache::put('login_token_' . $plaintextToken,
             [
-                'user' => $this,
+                'user_type' => $this->getMorphClass(),
+                'user_id' => $this->getKey(),
                 'guard' => 'web',
                 'intended_url' => Session::get('url.intended', route('dashboard')),
             ],

--- a/tests/Feature/Http/LoginLinkTest.php
+++ b/tests/Feature/Http/LoginLinkTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\URL;
+
+test('login link authenticates user from cached id instead of serialized model', function (): void {
+    $token = 'test-token-' . uniqid();
+
+    Cache::put('login_token_' . $token, [
+        'user_type' => $this->user->getMorphClass(),
+        'user_id' => $this->user->getKey(),
+        'guard' => 'web',
+        'intended_url' => route('dashboard'),
+    ], now()->addMinutes(15));
+
+    $url = URL::temporarySignedRoute(
+        'login-link',
+        now()->addMinutes(15),
+        ['token' => $token]
+    );
+
+    auth()->logout();
+
+    $response = $this->get($url);
+
+    $response->assertRedirect(route('dashboard'));
+    $this->assertAuthenticatedAs($this->user);
+});
+
+test('login link fails gracefully with invalid token', function (): void {
+    $url = URL::temporarySignedRoute(
+        'login-link',
+        now()->addMinutes(15),
+        ['token' => 'nonexistent']
+    );
+
+    $response = $this->get($url);
+
+    $response->assertOk();
+    $response->assertViewIs('flux::login-link-failed');
+});


### PR DESCRIPTION
## Summary
- `generateLoginLink()` stored the full User model in the cache via `serialize()`, causing `__PHP_Incomplete_Class` errors when the cached object could not be deserialized (Octane worker restart, autoloader issues)
- Now stores `user_type` + `user_id` instead and resolves the model fresh from the database
- Controller is backwards compatible with old cached tokens that still contain `user` key

## Summary by Sourcery

Fix login-link authentication to avoid caching serialized user models and ensure robust handling of login tokens.

Bug Fixes:
- Resolve login-link failures caused by cached serialized User models that cannot be deserialized.

Enhancements:
- Change login-link caching to store user type and ID and resolve the user from the database at login time.
- Maintain backward compatibility by still supporting existing cached tokens that contain a serialized user model.

Tests:
- Add feature tests covering successful authentication via login link using cached user identifiers and graceful handling of invalid or missing tokens.