### PR TITLE
Fix calendar week display: unknown option and title accumulation

### DIFF
--- a/resources/js/components/calendar.js
+++ b/resources/js/components/calendar.js
@@ -594,8 +594,12 @@ const calendar = () => {
                 },
             };
 
-            const { activeCalendars, showCalendars, calendarWeekAbbreviation, ...filteredConfig } =
-                this.config;
+            const {
+                activeCalendars,
+                showCalendars,
+                calendarWeekAbbreviation,
+                ...filteredConfig
+            } = this.config;
 
             this.calendar = new Calendar(calendarEl, {
                 ...defaultConfig,

--- a/resources/js/components/calendar.js
+++ b/resources/js/components/calendar.js
@@ -496,19 +496,19 @@ const calendar = () => {
                         const startWeek = start.isoWeek();
                         const endWeek = end.isoWeek();
 
-                        const cw = this.config.calendarWeekAbbreviation || 'CW';
+                        const cw = calendarWeekAbbreviation || 'CW';
                         const cwText =
                             startWeek === endWeek
                                 ? `(${cw} ${startWeek})`
                                 : `(${cw} ${startWeek}\u2013${endWeek})`;
 
-                        titleEl.textContent =
-                            titleEl.textContent.replace(
-                                new RegExp(`\\s*\\(${cw}.*?\\)`),
-                                '',
-                            ) +
-                            ' ' +
-                            cwText;
+                        let cwSpan = titleEl.querySelector('.fc-cw-suffix');
+                        if (!cwSpan) {
+                            cwSpan = document.createElement('span');
+                            cwSpan.className = 'fc-cw-suffix';
+                            titleEl.appendChild(cwSpan);
+                        }
+                        cwSpan.textContent = ' ' + cwText;
                     }
 
                     this.dispatchCalendarEvents('datesSet', info);
@@ -594,7 +594,7 @@ const calendar = () => {
                 },
             };
 
-            const { activeCalendars, showCalendars, ...filteredConfig } =
+            const { activeCalendars, showCalendars, calendarWeekAbbreviation, ...filteredConfig } =
                 this.config;
 
             this.calendar = new Calendar(calendarEl, {


### PR DESCRIPTION
## Summary
- Exclude `calendarWeekAbbreviation` from FullCalendar config spread to prevent `Unknown option` console warning
- Use a separate `<span>` element for the CW suffix instead of modifying `textContent` directly, preventing title accumulation when navigating between months (e.g. "April 2026Mai 2026Juni 2026...")

## Summary by Sourcery

Fix calendar week display and configuration handling in the calendar component.

Bug Fixes:
- Prevent FullCalendar from receiving the unsupported calendarWeekAbbreviation option to avoid console warnings.
- Ensure the calendar title’s calendar-week suffix is rendered in a dedicated span element to prevent duplicated or accumulated month titles when navigating.