### PR TITLE
fix CreateOrderPosition

### DIFF
--- a/src/Actions/OrderPosition/CreateOrderPosition.php
+++ b/src/Actions/OrderPosition/CreateOrderPosition.php
@@ -89,7 +89,7 @@ class CreateOrderPosition extends FluxAction
             data_set($this->data, 'ean_code', $product->ean, false);
             data_set($this->data, 'unit_gram_weight', $product->weight_gram, false);
 
-            if ($product->bundle_type_enum === BundleTypeEnum::Group) {
+            if (! $this->getData('origin_position_id') && $product->bundle_type_enum === BundleTypeEnum::Group) {
                 $this->data['is_free_text'] = true;
             }
         }
@@ -207,9 +207,7 @@ class CreateOrderPosition extends FluxAction
                     $errors += [
                         'origin_position_id' => [__('validation.required', ['attribute' => 'origin_position_id'])],
                     ];
-                }
-
-                if (! resolve_static(OrderPosition::class, 'query')
+                } elseif (! resolve_static(OrderPosition::class, 'query')
                     ->whereKey($originPositionId)
                     ->where('order_id', $order->parent_id)
                     ->exists()
@@ -217,35 +215,38 @@ class CreateOrderPosition extends FluxAction
                     $errors += [
                         'origin_position_id' => ['Order position does not exists in parent order.'],
                     ];
-                }
-
-                $maxAmount = data_get(
-                    array_find(
-                        $this->calculateMaxAmounts(
-                            DB::select(
-                                'WITH RECURSIVE siblings AS (
+                } else {
+                    $maxAmount = data_get(
+                        array_find(
+                            $this->calculateMaxAmounts(
+                                DB::select(
+                                    'WITH RECURSIVE siblings AS (
                                     SELECT id, origin_position_id, signed_amount
                                     FROM order_positions
                                     WHERE id = ' . $originPositionId
-                                . ' AND order_id = ' . $order->parent_id
-                                . ' UNION ALL
+                                    . ' AND order_id = ' . $order->parent_id
+                                    . ' AND deleted_at IS NULL'
+                                    . ' UNION ALL
                                     SELECT op.id, op.origin_position_id, op.signed_amount
                                     FROM order_positions op
                                     INNER JOIN siblings s ON s.id = op.origin_position_id
                                     WHERE op.deleted_at IS NULL
                                 )
                                 SELECT * FROM siblings'
-                            )
+                                )
+                            ),
+                            fn (array $value) => $value['id'] === $originPositionId
                         ),
-                        fn (array $value) => $value['id'] === $originPositionId
-                    ),
-                    'signed_amount'
-                );
+                        'signed_amount'
+                    );
 
-                if (bccomp($this->getData('amount') ?? 1, $maxAmount ?? 0) === 1) {
-                    $errors += [
-                        'amount' => [__('validation.max.numeric', ['attribute' => __('amount'), 'max' => $maxAmount])],
-                    ];
+                    if (bccomp($this->getData('amount') ?? 1, $maxAmount ?? 0) === 1) {
+                        $errors += [
+                            'amount' => [
+                                __('validation.max.numeric', ['attribute' => __('amount'), 'max' => $maxAmount]),
+                            ],
+                        ];
+                    }
                 }
             }
         }

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -3,6 +3,7 @@
 use FluxErp\Actions\OrderPosition\CreateOrderPosition;
 use FluxErp\Actions\OrderPosition\DeleteOrderPosition;
 use FluxErp\Actions\OrderPosition\UpdateOrderPosition;
+use FluxErp\Enums\BundleTypeEnum;
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
@@ -12,6 +13,7 @@ use FluxErp\Models\OrderPosition;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
+use FluxErp\Models\Product;
 use FluxErp\Models\VatRate;
 use FluxErp\Models\Warehouse;
 
@@ -83,4 +85,115 @@ test('delete order position', function (): void {
         ->validate()->execute();
 
     expect($result)->toBeTrue();
+});
+
+test('group bundle product is not marked as free text when origin_position_id is set', function (): void {
+    $product = Product::factory()->create([
+        'bundle_type_enum' => BundleTypeEnum::Group,
+    ]);
+
+    $retoureType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Retoure,
+        'is_active' => true,
+    ]);
+
+    $parentOrder = $this->order;
+    $parentPosition = OrderPosition::factory()->create([
+        'order_id' => $parentOrder->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'amount' => 5,
+        'signed_amount' => 5,
+    ]);
+
+    $childOrder = Order::factory()->create([
+        'order_type_id' => $retoureType->getKey(),
+        'parent_id' => $parentOrder->getKey(),
+        'address_invoice_id' => $parentOrder->address_invoice_id,
+        'contact_id' => $parentOrder->contact_id,
+        'payment_type_id' => $parentOrder->payment_type_id,
+        'price_list_id' => $parentOrder->price_list_id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $parentOrder->currency_id,
+        'language_id' => $parentOrder->language_id,
+        'is_locked' => false,
+    ]);
+
+    $position = CreateOrderPosition::make([
+        'order_id' => $childOrder->getKey(),
+        'product_id' => $product->getKey(),
+        'origin_position_id' => $parentPosition->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+    ])
+        ->validate()
+        ->execute();
+
+    expect($position->is_free_text)->toBeFalse();
+});
+
+test('origin position validation excludes soft deleted positions', function (): void {
+    $retoureType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Retoure,
+        'is_active' => true,
+    ]);
+
+    $parentOrder = $this->order;
+    $deletedPosition = OrderPosition::factory()->create([
+        'order_id' => $parentOrder->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'amount' => 5,
+        'deleted_at' => now(),
+    ]);
+
+    $childOrder = Order::factory()->create([
+        'order_type_id' => $retoureType->getKey(),
+        'parent_id' => $parentOrder->getKey(),
+        'address_invoice_id' => $parentOrder->address_invoice_id,
+        'contact_id' => $parentOrder->contact_id,
+        'payment_type_id' => $parentOrder->payment_type_id,
+        'price_list_id' => $parentOrder->price_list_id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $parentOrder->currency_id,
+        'language_id' => $parentOrder->language_id,
+        'is_locked' => false,
+    ]);
+
+    CreateOrderPosition::assertValidationErrors([
+        'order_id' => $childOrder->getKey(),
+        'origin_position_id' => $deletedPosition->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+    ], 'origin_position_id');
+});
+
+test('amount validation only runs when origin position exists in parent order', function (): void {
+    $retoureType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Retoure,
+        'is_active' => true,
+    ]);
+
+    $parentOrder = $this->order;
+    $childOrder = Order::factory()->create([
+        'order_type_id' => $retoureType->getKey(),
+        'parent_id' => $parentOrder->getKey(),
+        'address_invoice_id' => $parentOrder->address_invoice_id,
+        'contact_id' => $parentOrder->contact_id,
+        'payment_type_id' => $parentOrder->payment_type_id,
+        'price_list_id' => $parentOrder->price_list_id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $parentOrder->currency_id,
+        'language_id' => $parentOrder->language_id,
+        'is_locked' => false,
+    ]);
+
+    // Missing origin_position_id should fail on origin_position_id, not on amount
+    CreateOrderPosition::assertValidationErrors([
+        'order_id' => $childOrder->getKey(),
+        'name' => 'Test Position',
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'unit_price' => 10,
+        'amount' => 999,
+    ], 'origin_position_id');
 });


### PR DESCRIPTION
## Summary by Sourcery

Fix validation and behavior for creating order positions linked to an origin position.

Bug Fixes:
- Avoid marking group bundle products as free-text positions when an origin position is provided.
- Ensure origin position existence and parent order checks are mutually exclusive with further amount validation logic.
- Restrict origin position lookup and recursive sibling calculation to non-deleted order positions and only run max-amount validation when a valid origin position exists.