### PR TITLE
Add Team Absence Calendar widget to main dashboard

### DIFF
--- a/resources/views/livewire/widgets/team-absence-calendar.blade.php
+++ b/resources/views/livewire/widgets/team-absence-calendar.blade.php
@@ -122,7 +122,19 @@
                                                 'mx-auto size-5 rounded',
                                                 'opacity-70' => $dayData['is_half_day'],
                                             ])
-                                            style="background-color: {{ $dayData['color'] }}"
+                                            style="
+                                                @if($dayData['pending'] ?? false)
+                                                    background: repeating-linear-gradient(
+                                                        -45deg,
+                                                        {{ $dayData['color'] }},
+                                                        {{ $dayData['color'] }} 2px,
+                                                        transparent 2px,
+                                                        transparent 5px
+                                                    );
+                                                @else
+                                                    background-color: {{ $dayData['color'] }};
+                                                @endif
+                                            "
                                         ></div>
                                     @endif
                                 </td>

--- a/resources/views/livewire/widgets/team-absence-calendar.blade.php
+++ b/resources/views/livewire/widgets/team-absence-calendar.blade.php
@@ -1,0 +1,152 @@
+<div x-data="{ expandedDepts: {} }" class="flex h-full flex-col">
+    <div class="mb-3 flex items-center justify-between">
+        <x-button
+            wire:click="previousMonth()"
+            icon="chevron-left"
+            color="secondary"
+            flat
+            circle
+            sm
+        />
+
+        <div
+            class="text-center text-sm font-semibold text-gray-900 dark:text-gray-100"
+        >
+            {{ $monthName }} {{ $year }}
+        </div>
+
+        <x-button
+            wire:click="nextMonth()"
+            icon="chevron-right"
+            color="secondary"
+            flat
+            circle
+            sm
+        />
+    </div>
+
+    <div class="flex-1 overflow-auto">
+        <x-loading wire:loading />
+        <table
+            class="dark:divide-dark-500/50 min-w-full divide-y divide-gray-200"
+        >
+            <thead class="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800">
+                <tr>
+                    <th
+                        class="sticky left-0 z-20 min-w-[120px] border-r border-b bg-gray-50 px-2 py-1 text-left text-xs font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                    >
+                        {{ __('Employee') }}
+                    </th>
+                    @foreach($calendarDays as $calDay)
+                        <th
+                            @class([
+                                'border-r border-b px-0.5 py-1 text-center text-xs font-medium dark:border-gray-700',
+                                'bg-yellow-100 dark:bg-yellow-900 border-l-2 border-r-2 border-t-2 border-yellow-400 dark:border-yellow-600' => $calDay['isToday'],
+                                'bg-gray-100 dark:bg-gray-700' => $calDay['isWeekend'] && ! $calDay['isToday'],
+                                'bg-gray-50 dark:bg-gray-800' => ! $calDay['isWeekend'] && ! $calDay['isToday'],
+                            ])
+                        >
+                            <div class="text-gray-700 dark:text-gray-300">
+                                {{ $calDay['day'] }}
+                            </div>
+                            <div class="text-gray-500 dark:text-gray-400">
+                                {{ $calDay['weekDay'] }}
+                            </div>
+                        </th>
+                    @endforeach
+                </tr>
+            </thead>
+
+            <tbody>
+                @foreach($departments as $deptIndex => $department)
+                    <tr
+                        class="cursor-pointer bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+                        x-on:click="expandedDepts[{{ $deptIndex }}] = !(expandedDepts[{{ $deptIndex }}] ?? true)"
+                    >
+                        <td
+                            colspan="{{ count($calendarDays) + 1 }}"
+                            class="border-b px-2 py-1.5 font-semibold dark:border-gray-700"
+                        >
+                            <div class="flex items-center gap-2">
+                                <x-icon
+                                    name="chevron-right"
+                                    class="h-4 w-4 text-gray-600 transition-transform dark:text-gray-400"
+                                    x-bind:class="{ 'rotate-90': expandedDepts[{{ $deptIndex }}] ?? true }"
+                                />
+                                <span class="text-xs">
+                                    {{ $department['name'] }}
+                                </span>
+                                <x-badge
+                                    :text="count($department['employees']) . ' ' . __('Employees')"
+                                    color="gray"
+                                    size="sm"
+                                />
+                            </div>
+                        </td>
+                    </tr>
+                    @foreach($department['employees'] as $employee)
+                        <tr
+                            x-cloak
+                            x-show="expandedDepts[{{ $deptIndex }}] ?? true"
+                            x-transition
+                            class="hover:bg-gray-50 dark:hover:bg-gray-800"
+                        >
+                            <td
+                                class="sticky left-0 z-[5] border-r border-b bg-white px-2 py-1 pl-8 dark:border-gray-700 dark:bg-gray-900"
+                            >
+                                <span
+                                    class="truncate text-xs text-gray-800 dark:text-gray-200"
+                                >
+                                    {{ $employee['name'] }}
+                                </span>
+                            </td>
+
+                            @foreach($calendarDays as $dateKey => $calDay)
+                                @php
+                                    $dayData = $employee['days'][$dateKey] ?? null;
+                                @endphp
+                                <td
+                                    @class([
+                                        'border-r border-b px-0.5 py-0.5 text-center dark:border-gray-700',
+                                        'border-l-2 border-r-2 border-yellow-400 bg-yellow-50 dark:border-yellow-600 dark:bg-yellow-900/30' => $calDay['isToday'],
+                                        'bg-gray-100 dark:bg-gray-700' => $calDay['isWeekend'] && ! $calDay['isToday'],
+                                        'bg-white dark:bg-gray-900' => ! $calDay['isWeekend'] && ! $calDay['isToday'],
+                                    ])
+                                    @if($dayData)
+                                        title="{{ $dayData['name'] }}"
+                                    @endif
+                                >
+                                    @if($dayData)
+                                        <div
+                                            @class([
+                                                'mx-auto size-5 rounded',
+                                                'opacity-70' => $dayData['is_half_day'],
+                                            ])
+                                            style="background-color: {{ $dayData['color'] }}"
+                                        ></div>
+                                    @endif
+                                </td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    <div
+        class="mt-2 flex flex-wrap items-center gap-3 border-t pt-2 dark:border-gray-700"
+    >
+        @foreach($absenceTypes as $type)
+            <div class="flex items-center gap-1.5">
+                <div
+                    class="size-3 shrink-0 rounded"
+                    style="background-color: {{ $type['color'] }}"
+                ></div>
+                <span class="text-xs text-gray-600 dark:text-gray-400">
+                    {{ $type['name'] }}
+                </span>
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/resources/views/livewire/widgets/team-absence-calendar.blade.php
+++ b/resources/views/livewire/widgets/team-absence-calendar.blade.php
@@ -113,7 +113,7 @@
                                         'bg-white dark:bg-gray-900' => ! $calDay['isWeekend'] && ! $calDay['isToday'],
                                     ])
                                     @if($dayData)
-                                        title="{{ $dayData['name'] }}"
+                                        title="{{ $dayData['name'] }}{{ ($dayData['is_holiday'] ?? false) && $dayData['type'] !== 'holiday' ? ' — ' . $dayData['holiday_name'] : '' }}"
                                     @endif
                                 >
                                     @if($dayData)
@@ -123,7 +123,15 @@
                                                 'opacity-70' => $dayData['is_half_day'],
                                             ])
                                             style="
-                                                @if($dayData['pending'] ?? false)
+                                                @if(($dayData['type'] ?? null) === 'split')
+                                                    background: repeating-linear-gradient(
+                                                        -45deg,
+                                                        {{ $dayData['color'] }},
+                                                        {{ $dayData['color'] }} 3px,
+                                                        {{ $dayData['holiday_color'] }} 3px,
+                                                        {{ $dayData['holiday_color'] }} 6px
+                                                    );
+                                                @elseif($dayData['pending'] ?? false)
                                                     background: repeating-linear-gradient(
                                                         -45deg,
                                                         {{ $dayData['color'] }},

--- a/src/Livewire/Widgets/TeamAbsenceCalendar.php
+++ b/src/Livewire/Widgets/TeamAbsenceCalendar.php
@@ -3,14 +3,15 @@
 namespace FluxErp\Livewire\Widgets;
 
 use FluxErp\Enums\AbsenceRequestStateEnum;
+use FluxErp\Enums\DayPartEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Livewire\HumanResources\Dashboard as HumanResourcesDashboard;
 use FluxErp\Models\AbsenceRequest;
 use FluxErp\Models\AbsenceType;
 use FluxErp\Models\Employee;
-use FluxErp\Models\EmployeeDay;
+use FluxErp\Models\Holiday;
 use FluxErp\Traits\Livewire\Widget\Widgetable;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Livewire\Component;
 
@@ -32,7 +33,7 @@ class TeamAbsenceCalendar extends Component
 
     public static function dashboardComponent(): array|string
     {
-        return Dashboard::class;
+        return [Dashboard::class, HumanResourcesDashboard::class];
     }
 
     public static function getCategory(): ?string
@@ -140,13 +141,13 @@ class TeamAbsenceCalendar extends Component
             ->where('is_active', true)
             ->orderBy('name')
             ->get(['id', 'name', 'code', 'color'])
-            ->prepend(new AbsenceType($holiday))
             ->map(fn (AbsenceType $type) => [
                 'id' => $type->id,
                 'name' => $type->name,
                 'code' => $type->code,
                 'color' => $type->color,
             ])
+            ->prepend($holiday)
             ->keyBy('id')
             ->toArray();
     }
@@ -163,88 +164,117 @@ class TeamAbsenceCalendar extends Component
             ->orderBy('name')
             ->get();
 
-        $employeeIds = $employees->pluck('id');
+        $employeeIds = $employees->pluck('id')->toArray();
 
         $absences = resolve_static(AbsenceRequest::class, 'query')
-            ->whereIn('employee_id', $employeeIds)
+            ->whereIntegerInRaw('employee_id', $employeeIds)
             ->whereIn('state', [AbsenceRequestStateEnum::Approved, AbsenceRequestStateEnum::Pending])
-            ->where(fn (Builder $query) => $query
-                ->whereBetween('start_date', [$startOfMonth, $endOfMonth])
-                ->orWhereBetween('end_date', [$startOfMonth, $endOfMonth])
-                ->orWhere(fn (Builder $query) => $query
-                    ->where('start_date', '<=', $startOfMonth)
-                    ->where('end_date', '>=', $endOfMonth)
-                )
-            )
+            ->where('start_date', '<=', $endOfMonth)
+            ->where('end_date', '>=', $startOfMonth)
             ->with('absenceType:id,name,code,color')
-            ->get(['id', 'employee_id', 'absence_type_id', 'start_date', 'end_date', 'day_part', 'state'])
+            ->get([
+                'id', 'employee_id', 'absence_type_id',
+                'start_date', 'end_date', 'day_part', 'state',
+            ])
             ->groupBy('employee_id');
 
-        $employeeHolidays = resolve_static(EmployeeDay::class, 'query')
-            ->whereIn('employee_id', $employeeIds)
-            ->whereBetween('date', [$startOfMonth, $endOfMonth])
-            ->where('is_holiday', true)
-            ->get(['employee_id', 'date'])
-            ->groupBy('employee_id')
-            ->map(fn ($days) => $days->pluck('date')->map(fn ($date) => Carbon::parse($date)->format('Y-m-d'))->toArray());
+        $holidays = resolve_static(Holiday::class, 'query')
+            ->where('is_active', true)
+            ->where(fn ($query) => $query
+                ->whereValueBetween($startOfMonth->year, ['effective_from', 'effective_until'])
+                ->orWhere(fn ($query) => $query
+                    ->whereNull('effective_from')
+                    ->where('effective_until', '>=', $startOfMonth->year)
+                )
+                ->orWhere(fn ($query) => $query
+                    ->whereNull('effective_until')
+                    ->where('effective_from', '<=', $startOfMonth->year)
+                )
+                ->orWhere(fn ($query) => $query
+                    ->whereNull('effective_from')
+                    ->whereNull('effective_until')
+                )
+            )
+            ->where(fn ($query) => $query
+                ->whereBetween('date', [$startOfMonth, $endOfMonth])
+                ->orWhere(fn ($query) => $query
+                    ->whereNull('date')
+                    ->where('month', $startOfMonth->month)
+                )
+            )
+            ->get(['id', 'name', 'date', 'month', 'day', 'is_half_day'])
+            ->keyBy(fn (Holiday $holiday) => $holiday->date
+                ? $holiday->date->format('Y-m-d')
+                : Carbon::create($startOfMonth->year, $holiday->month, $holiday->day)->format('Y-m-d')
+            );
 
-        $holiday = $this->holidayAbsenceType();
+        $holidayType = $this->holidayAbsenceType();
 
         $this->departments = $employees
             ->groupBy('employee_department_id')
-            ->map(function ($deptEmployees) use ($absences, $employeeHolidays, $holiday, $startOfMonth, $endOfMonth) {
+            ->map(function ($deptEmployees) use ($absences, $holidays, $holidayType, $startOfMonth, $endOfMonth) {
                 $department = $deptEmployees->first()->employeeDepartment;
 
                 return [
-                    'name' => $department?->name ?? __('Unknown Department'),
-                    'employees' => $deptEmployees->map(function (Employee $employee) use ($absences, $employeeHolidays, $holiday, $startOfMonth, $endOfMonth) {
-                        $employeeAbsences = $absences->get($employee->getKey(), collect());
-                        $holidays = $employeeHolidays->get($employee->getKey(), []);
+                    'name' => $department?->getLabel() ?? __('Unknown Department'),
+                    'employees' => $deptEmployees->map(
+                        function (Employee $employee) use ($absences, $holidays, $holidayType, $startOfMonth, $endOfMonth) {
+                            $employeeAbsences = $absences->get($employee->getKey()) ?? [];
+                            $days = [];
 
-                        $days = [];
+                            foreach ($holidays as $dateKey => $holiday) {
+                                $days[$dateKey] = [
+                                    'type' => $holidayType['id'],
+                                    'color' => $holidayType['color'],
+                                    'name' => $holiday->name,
+                                    'is_half_day' => $holiday->is_half_day,
+                                    'is_holiday' => true,
+                                    'holiday_name' => $holiday->name,
+                                ];
+                            }
 
-                        foreach ($holidays as $dateKey) {
-                            $days[$dateKey] = [
-                                'type' => $holiday['id'],
-                                'color' => $holiday['color'],
-                                'name' => $holiday['name'],
-                                'is_half_day' => false,
+                            foreach ($employeeAbsences as $absence) {
+                                $start = $absence->start_date->copy()->max($startOfMonth);
+                                $end = $absence->end_date->copy()->min($endOfMonth);
+
+                                while ($start->lte($end)) {
+                                    $dateKey = $start->format('Y-m-d');
+                                    $isPending = $absence->state === AbsenceRequestStateEnum::Pending;
+
+                                    if ($isPending && isset($days[$dateKey]) && ! ($days[$dateKey]['pending'] ?? false)) {
+                                        $start->addDay();
+
+                                        continue;
+                                    }
+
+                                    $existingDay = $days[$dateKey] ?? null;
+                                    $isAbsenceHalfDay = $absence->day_part
+                                        && $absence->day_part->value !== DayPartEnum::FullDay;
+                                    $holidayName = $existingDay['holiday_name'] ?? null;
+                                    $isOnHoliday = ($existingDay['type'] ?? null) === $holidayType['id'];
+
+                                    $days[$dateKey] = [
+                                        'type' => $isOnHoliday ? 'split' : 'absence',
+                                        'color' => $absence->absenceType?->color,
+                                        'name' => $absence->absenceType?->name
+                                            . ($isPending ? ' (' . __('pending') . ')' : ''),
+                                        'is_half_day' => $isAbsenceHalfDay && ! $isOnHoliday,
+                                        'pending' => $isPending,
+                                        'is_holiday' => (bool) $holidayName,
+                                        'holiday_name' => $holidayName,
+                                        'holiday_color' => $isOnHoliday ? $holidayType['color'] : null,
+                                    ];
+                                    $start->addDay();
+                                }
+                            }
+
+                            return [
+                                'id' => $employee->getKey(),
+                                'name' => $employee->name,
+                                'days' => $days,
                             ];
                         }
-
-                        foreach ($employeeAbsences as $absence) {
-                            $start = $absence->start_date->copy()->max($startOfMonth);
-                            $end = $absence->end_date->copy()->min($endOfMonth);
-
-                            while ($start->lte($end)) {
-                                $dateKey = $start->format('Y-m-d');
-                                $isPending = $absence->state === AbsenceRequestStateEnum::Pending;
-
-                                if ($isPending && isset($days[$dateKey]) && ! ($days[$dateKey]['pending'] ?? false)) {
-                                    $start->addDay();
-
-                                    continue;
-                                }
-
-                                $days[$dateKey] = [
-                                    'type' => 'absence',
-                                    'color' => $absence->absenceType?->color,
-                                    'name' => $absence->absenceType?->name
-                                        . ($isPending ? ' (' . __('pending') . ')' : ''),
-                                    'is_half_day' => $absence->day_part
-                                        && $absence->day_part->value !== 'full_day',
-                                    'pending' => $isPending,
-                                ];
-                                $start->addDay();
-                            }
-                        }
-
-                        return [
-                            'id' => $employee->getKey(),
-                            'name' => $employee->name,
-                            'days' => $days,
-                        ];
-                    })->values()->toArray(),
+                    )->values()->toArray(),
                 ];
             })
             ->sortBy('name')

--- a/src/Livewire/Widgets/TeamAbsenceCalendar.php
+++ b/src/Livewire/Widgets/TeamAbsenceCalendar.php
@@ -8,7 +8,6 @@ use FluxErp\Models\AbsenceRequest;
 use FluxErp\Models\AbsenceType;
 use FluxErp\Models\Employee;
 use FluxErp\Models\EmployeeDay;
-use FluxErp\Models\EmployeeDepartment;
 use FluxErp\Traits\Livewire\Widget\Widgetable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
@@ -93,6 +92,9 @@ class TeamAbsenceCalendar extends Component
 
     protected function loadData(): void
     {
+        $this->month = max(1, min(12, $this->month));
+        $this->year = max(1970, min(2100, $this->year));
+
         $this->monthName = Carbon::create($this->year, $this->month)
             ->locale(app()->getLocale())
             ->monthName;
@@ -100,6 +102,16 @@ class TeamAbsenceCalendar extends Component
         $this->prepareCalendarDays();
         $this->loadAbsenceTypes();
         $this->loadDepartments();
+    }
+
+    protected function holidayAbsenceType(): array
+    {
+        return [
+            'id' => 'holiday',
+            'name' => __('Holiday'),
+            'code' => '🎉',
+            'color' => '#fee685',
+        ];
     }
 
     protected function prepareCalendarDays(): void
@@ -113,7 +125,7 @@ class TeamAbsenceCalendar extends Component
             $this->calendarDays[$date->format('Y-m-d')] = [
                 'day' => $day,
                 'date' => $date->format('Y-m-d'),
-                'weekDay' => substr(__($date->format('D')), 0, 2),
+                'weekDay' => $date->locale(app()->getLocale())->shortDayName,
                 'isWeekend' => $date->isWeekend(),
                 'isToday' => $date->isToday(),
             ];
@@ -122,16 +134,13 @@ class TeamAbsenceCalendar extends Component
 
     protected function loadAbsenceTypes(): void
     {
+        $holiday = $this->holidayAbsenceType();
+
         $this->absenceTypes = resolve_static(AbsenceType::class, 'query')
             ->where('is_active', true)
             ->orderBy('name')
             ->get(['id', 'name', 'code', 'color'])
-            ->prepend(new AbsenceType([
-                'id' => 'holiday',
-                'name' => __('Holiday'),
-                'code' => '🎉',
-                'color' => '#fee685',
-            ]))
+            ->prepend(new AbsenceType($holiday))
             ->map(fn (AbsenceType $type) => [
                 'id' => $type->id,
                 'name' => $type->name,
@@ -149,6 +158,7 @@ class TeamAbsenceCalendar extends Component
 
         $employees = resolve_static(Employee::class, 'query')
             ->select(['id', 'employee_department_id', 'name'])
+            ->with('employeeDepartment:id,name')
             ->employed($endOfMonth)
             ->orderBy('name')
             ->get();
@@ -178,17 +188,16 @@ class TeamAbsenceCalendar extends Component
             ->groupBy('employee_id')
             ->map(fn ($days) => $days->pluck('date')->map(fn ($date) => Carbon::parse($date)->format('Y-m-d'))->toArray());
 
-        $departmentIds = $employees->pluck('employee_department_id')->unique()->filter();
-        $departmentNames = resolve_static(EmployeeDepartment::class, 'query')
-            ->whereIn('id', $departmentIds)
-            ->pluck('name', 'id');
+        $holiday = $this->holidayAbsenceType();
 
         $this->departments = $employees
             ->groupBy('employee_department_id')
-            ->map(function ($deptEmployees, $departmentId) use ($absences, $employeeHolidays, $departmentNames) {
+            ->map(function ($deptEmployees) use ($absences, $employeeHolidays, $holiday, $startOfMonth, $endOfMonth) {
+                $department = $deptEmployees->first()->employeeDepartment;
+
                 return [
-                    'name' => $departmentNames[$departmentId] ?? __('Unknown Department'),
-                    'employees' => $deptEmployees->map(function (Employee $employee) use ($absences, $employeeHolidays) {
+                    'name' => $department?->name ?? __('Unknown Department'),
+                    'employees' => $deptEmployees->map(function (Employee $employee) use ($absences, $employeeHolidays, $holiday, $startOfMonth, $endOfMonth) {
                         $employeeAbsences = $absences->get($employee->getKey(), collect());
                         $holidays = $employeeHolidays->get($employee->getKey(), []);
 
@@ -196,20 +205,16 @@ class TeamAbsenceCalendar extends Component
 
                         foreach ($holidays as $dateKey) {
                             $days[$dateKey] = [
-                                'type' => 'holiday',
-                                'color' => '#fee685',
-                                'name' => __('Holiday'),
+                                'type' => $holiday['id'],
+                                'color' => $holiday['color'],
+                                'name' => $holiday['name'],
                                 'is_half_day' => false,
                             ];
                         }
 
                         foreach ($employeeAbsences as $absence) {
-                            $start = $absence->start_date->copy()->max(
-                                Carbon::create($this->year, $this->month)->startOfMonth()
-                            );
-                            $end = $absence->end_date->copy()->min(
-                                Carbon::create($this->year, $this->month)->endOfMonth()
-                            );
+                            $start = $absence->start_date->copy()->max($startOfMonth);
+                            $end = $absence->end_date->copy()->min($endOfMonth);
 
                             while ($start->lte($end)) {
                                 $dateKey = $start->format('Y-m-d');

--- a/src/Livewire/Widgets/TeamAbsenceCalendar.php
+++ b/src/Livewire/Widgets/TeamAbsenceCalendar.php
@@ -2,8 +2,8 @@
 
 namespace FluxErp\Livewire\Widgets;
 
+use FluxErp\Enums\AbsenceRequestDayPartEnum;
 use FluxErp\Enums\AbsenceRequestStateEnum;
-use FluxErp\Enums\DayPartEnum;
 use FluxErp\Livewire\Dashboard\Dashboard;
 use FluxErp\Livewire\HumanResources\Dashboard as HumanResourcesDashboard;
 use FluxErp\Models\AbsenceRequest;
@@ -158,7 +158,7 @@ class TeamAbsenceCalendar extends Component
         $endOfMonth = Carbon::create($this->year, $this->month)->endOfMonth();
 
         $employees = resolve_static(Employee::class, 'query')
-            ->select(['id', 'employee_department_id', 'name'])
+            ->select(['id', 'employee_department_id', 'location_id', 'name'])
             ->with('employeeDepartment:id,name')
             ->employed($endOfMonth)
             ->orderBy('name')
@@ -173,8 +173,13 @@ class TeamAbsenceCalendar extends Component
             ->where('end_date', '>=', $startOfMonth)
             ->with('absenceType:id,name,code,color')
             ->get([
-                'id', 'employee_id', 'absence_type_id',
-                'start_date', 'end_date', 'day_part', 'state',
+                'id',
+                'employee_id',
+                'absence_type_id',
+                'start_date',
+                'end_date',
+                'day_part',
+                'state',
             ])
             ->groupBy('employee_id');
 
@@ -202,6 +207,7 @@ class TeamAbsenceCalendar extends Component
                     ->where('month', $startOfMonth->month)
                 )
             )
+            ->with('locations:id')
             ->get(['id', 'name', 'date', 'month', 'day', 'is_half_day'])
             ->keyBy(fn (Holiday $holiday) => $holiday->date
                 ? $holiday->date->format('Y-m-d')
@@ -223,6 +229,12 @@ class TeamAbsenceCalendar extends Component
                             $days = [];
 
                             foreach ($holidays as $dateKey => $holiday) {
+                                if ($holiday->locations->isNotEmpty()
+                                    && ! $holiday->locations->contains('id', $employee->location_id)
+                                ) {
+                                    continue;
+                                }
+
                                 $days[$dateKey] = [
                                     'type' => $holidayType['id'],
                                     'color' => $holidayType['color'],
@@ -249,7 +261,7 @@ class TeamAbsenceCalendar extends Component
 
                                     $existingDay = $days[$dateKey] ?? null;
                                     $isAbsenceHalfDay = $absence->day_part
-                                        && $absence->day_part->value !== DayPartEnum::FullDay;
+                                        && $absence->day_part->value !== AbsenceRequestDayPartEnum::FullDay;
                                     $holidayName = $existingDay['holiday_name'] ?? null;
                                     $isOnHoliday = ($existingDay['type'] ?? null) === $holidayType['id'];
 
@@ -274,7 +286,9 @@ class TeamAbsenceCalendar extends Component
                                 'days' => $days,
                             ];
                         }
-                    )->values()->toArray(),
+                    )
+                        ->values()
+                        ->toArray(),
                 ];
             })
             ->sortBy('name')

--- a/src/Livewire/Widgets/TeamAbsenceCalendar.php
+++ b/src/Livewire/Widgets/TeamAbsenceCalendar.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace FluxErp\Livewire\Widgets;
+
+use FluxErp\Enums\AbsenceRequestStateEnum;
+use FluxErp\Livewire\Dashboard\Dashboard;
+use FluxErp\Models\AbsenceRequest;
+use FluxErp\Models\AbsenceType;
+use FluxErp\Models\Employee;
+use FluxErp\Models\EmployeeDay;
+use FluxErp\Models\EmployeeDepartment;
+use FluxErp\Traits\Livewire\Widget\Widgetable;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Livewire\Component;
+
+class TeamAbsenceCalendar extends Component
+{
+    use Widgetable;
+
+    public int $month;
+
+    public string $monthName = '';
+
+    public int $year;
+
+    public array $calendarDays = [];
+
+    public array $departments = [];
+
+    public array $absenceTypes = [];
+
+    public static function dashboardComponent(): array|string
+    {
+        return Dashboard::class;
+    }
+
+    public static function getCategory(): ?string
+    {
+        return 'Employees';
+    }
+
+    public static function getLabel(): string
+    {
+        return __('Team Absence Calendar');
+    }
+
+    public static function getDefaultWidth(): int
+    {
+        return 4;
+    }
+
+    public static function getDefaultHeight(): int
+    {
+        return 2;
+    }
+
+    public function mount(): void
+    {
+        $this->year = now()->year;
+        $this->month = now()->month;
+
+        $this->loadData();
+    }
+
+    public function render(): View
+    {
+        return view('flux::livewire.widgets.team-absence-calendar');
+    }
+
+    public function nextMonth(): void
+    {
+        $this->month++;
+        if ($this->month > 12) {
+            $this->month = 1;
+            $this->year++;
+        }
+
+        $this->loadData();
+    }
+
+    public function previousMonth(): void
+    {
+        $this->month--;
+        if ($this->month < 1) {
+            $this->month = 12;
+            $this->year--;
+        }
+
+        $this->loadData();
+    }
+
+    protected function loadData(): void
+    {
+        $this->monthName = Carbon::create($this->year, $this->month)
+            ->locale(app()->getLocale())
+            ->monthName;
+
+        $this->prepareCalendarDays();
+        $this->loadAbsenceTypes();
+        $this->loadDepartments();
+    }
+
+    protected function prepareCalendarDays(): void
+    {
+        $this->calendarDays = [];
+        $daysInMonth = Carbon::create($this->year, $this->month)->daysInMonth;
+
+        for ($day = 1; $day <= $daysInMonth; $day++) {
+            $date = Carbon::create($this->year, $this->month, $day);
+
+            $this->calendarDays[$date->format('Y-m-d')] = [
+                'day' => $day,
+                'date' => $date->format('Y-m-d'),
+                'weekDay' => substr(__($date->format('D')), 0, 2),
+                'isWeekend' => $date->isWeekend(),
+                'isToday' => $date->isToday(),
+            ];
+        }
+    }
+
+    protected function loadAbsenceTypes(): void
+    {
+        $this->absenceTypes = resolve_static(AbsenceType::class, 'query')
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get(['id', 'name', 'code', 'color'])
+            ->prepend(new AbsenceType([
+                'id' => 'holiday',
+                'name' => __('Holiday'),
+                'code' => '🎉',
+                'color' => '#fee685',
+            ]))
+            ->map(fn (AbsenceType $type) => [
+                'id' => $type->id,
+                'name' => $type->name,
+                'code' => $type->code,
+                'color' => $type->color,
+            ])
+            ->keyBy('id')
+            ->toArray();
+    }
+
+    protected function loadDepartments(): void
+    {
+        $startOfMonth = Carbon::create($this->year, $this->month)->startOfMonth();
+        $endOfMonth = Carbon::create($this->year, $this->month)->endOfMonth();
+
+        $employees = resolve_static(Employee::class, 'query')
+            ->select(['id', 'employee_department_id', 'name'])
+            ->employed($endOfMonth)
+            ->orderBy('name')
+            ->get();
+
+        $employeeIds = $employees->pluck('id');
+
+        $absences = resolve_static(AbsenceRequest::class, 'query')
+            ->whereIn('employee_id', $employeeIds)
+            ->where('state', AbsenceRequestStateEnum::Approved)
+            ->where(fn (Builder $query) => $query
+                ->whereBetween('start_date', [$startOfMonth, $endOfMonth])
+                ->orWhereBetween('end_date', [$startOfMonth, $endOfMonth])
+                ->orWhere(fn (Builder $query) => $query
+                    ->where('start_date', '<=', $startOfMonth)
+                    ->where('end_date', '>=', $endOfMonth)
+                )
+            )
+            ->with('absenceType:id,name,code,color')
+            ->get(['id', 'employee_id', 'absence_type_id', 'start_date', 'end_date', 'day_part'])
+            ->groupBy('employee_id');
+
+        $employeeHolidays = resolve_static(EmployeeDay::class, 'query')
+            ->whereIn('employee_id', $employeeIds)
+            ->whereBetween('date', [$startOfMonth, $endOfMonth])
+            ->where('is_holiday', true)
+            ->get(['employee_id', 'date'])
+            ->groupBy('employee_id')
+            ->map(fn ($days) => $days->pluck('date')->map(fn ($date) => Carbon::parse($date)->format('Y-m-d'))->toArray());
+
+        $departmentIds = $employees->pluck('employee_department_id')->unique()->filter();
+        $departmentNames = resolve_static(EmployeeDepartment::class, 'query')
+            ->whereIn('id', $departmentIds)
+            ->pluck('name', 'id');
+
+        $this->departments = $employees
+            ->groupBy('employee_department_id')
+            ->map(function ($deptEmployees, $departmentId) use ($absences, $employeeHolidays, $departmentNames) {
+                return [
+                    'name' => $departmentNames[$departmentId] ?? __('Unknown Department'),
+                    'employees' => $deptEmployees->map(function (Employee $employee) use ($absences, $employeeHolidays) {
+                        $employeeAbsences = $absences->get($employee->getKey(), collect());
+                        $holidays = $employeeHolidays->get($employee->getKey(), []);
+
+                        $days = [];
+
+                        foreach ($holidays as $dateKey) {
+                            $days[$dateKey] = [
+                                'type' => 'holiday',
+                                'color' => '#fee685',
+                                'name' => __('Holiday'),
+                                'is_half_day' => false,
+                            ];
+                        }
+
+                        foreach ($employeeAbsences as $absence) {
+                            $start = $absence->start_date->copy()->max(
+                                Carbon::create($this->year, $this->month)->startOfMonth()
+                            );
+                            $end = $absence->end_date->copy()->min(
+                                Carbon::create($this->year, $this->month)->endOfMonth()
+                            );
+
+                            while ($start->lte($end)) {
+                                $dateKey = $start->format('Y-m-d');
+                                $days[$dateKey] = [
+                                    'type' => 'absence',
+                                    'color' => $absence->absenceType?->color,
+                                    'name' => $absence->absenceType?->name,
+                                    'is_half_day' => $absence->day_part
+                                        && $absence->day_part->value !== 'full_day',
+                                ];
+                                $start->addDay();
+                            }
+                        }
+
+                        return [
+                            'id' => $employee->getKey(),
+                            'name' => $employee->name,
+                            'days' => $days,
+                        ];
+                    })->values()->toArray(),
+                ];
+            })
+            ->sortBy('name')
+            ->values()
+            ->toArray();
+    }
+}

--- a/src/Livewire/Widgets/TeamAbsenceCalendar.php
+++ b/src/Livewire/Widgets/TeamAbsenceCalendar.php
@@ -167,7 +167,7 @@ class TeamAbsenceCalendar extends Component
 
         $absences = resolve_static(AbsenceRequest::class, 'query')
             ->whereIn('employee_id', $employeeIds)
-            ->where('state', AbsenceRequestStateEnum::Approved)
+            ->whereIn('state', [AbsenceRequestStateEnum::Approved, AbsenceRequestStateEnum::Pending])
             ->where(fn (Builder $query) => $query
                 ->whereBetween('start_date', [$startOfMonth, $endOfMonth])
                 ->orWhereBetween('end_date', [$startOfMonth, $endOfMonth])
@@ -177,7 +177,7 @@ class TeamAbsenceCalendar extends Component
                 )
             )
             ->with('absenceType:id,name,code,color')
-            ->get(['id', 'employee_id', 'absence_type_id', 'start_date', 'end_date', 'day_part'])
+            ->get(['id', 'employee_id', 'absence_type_id', 'start_date', 'end_date', 'day_part', 'state'])
             ->groupBy('employee_id');
 
         $employeeHolidays = resolve_static(EmployeeDay::class, 'query')
@@ -218,12 +218,22 @@ class TeamAbsenceCalendar extends Component
 
                             while ($start->lte($end)) {
                                 $dateKey = $start->format('Y-m-d');
+                                $isPending = $absence->state === AbsenceRequestStateEnum::Pending;
+
+                                if ($isPending && isset($days[$dateKey]) && ! ($days[$dateKey]['pending'] ?? false)) {
+                                    $start->addDay();
+
+                                    continue;
+                                }
+
                                 $days[$dateKey] = [
                                     'type' => 'absence',
                                     'color' => $absence->absenceType?->color,
-                                    'name' => $absence->absenceType?->name,
+                                    'name' => $absence->absenceType?->name
+                                        . ($isPending ? ' (' . __('pending') . ')' : ''),
                                     'is_half_day' => $absence->day_part
                                         && $absence->day_part->value !== 'full_day',
+                                    'pending' => $isPending,
                                 ];
                                 $start->addDay();
                             }


### PR DESCRIPTION
## Summary by Sourcery

Add a dashboard widget that displays a team-wide monthly absence calendar by department and employee.

New Features:
- Introduce a Livewire TeamAbsenceCalendar widget for the main dashboard.
- Display employees grouped by department with per-day absence and holiday indicators in a monthly calendar view.
- Provide interactive month navigation and a legend for absence and holiday types within the widget.