### PR TITLE
Fix translation audit workflow

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Find locale JSON files
         id: find
         run: |
-          locales=$(ls lang/*.json 2>/dev/null | xargs -I{} basename {} .json | jq -R . | jq -s -c .)
+          locales=$(php -r 'echo json_encode(array_map(fn($f) => basename($f, ".json"), glob("lang/*.json")));')
           echo "locales=$locales" >> $GITHUB_OUTPUT
           echo "Found locales: $locales"
 


### PR DESCRIPTION
## Summary
- Replace `jq` with `php` in the Discover Locales job since the `flux-ci` container does not ship `jq`
- Uses `glob()` + `basename()` + `json_encode()` to produce the same JSON matrix output

## Summary by Sourcery

CI:
- Adjust the translation audit GitHub Actions workflow to generate the locales matrix via a PHP script rather than jq, ensuring it runs in the flux-ci container.