### PR TITLE
Add jq to CI Docker image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG NODE_VERSION=22
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git curl zip unzip libpng-dev libjpeg-dev libfreetype6-dev \
+      git curl zip unzip jq libpng-dev libjpeg-dev libfreetype6-dev \
       libzip-dev libicu-dev libonig-dev libexif-dev libmagickwand-dev libxslt1-dev \
       gnupg ca-certificates \
     && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
@@ -26,8 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y nodejs gh \
-    && npx playwright install-deps \
-    && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright install --with-deps chromium \
+    && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 RUN git config --global --add safe.directory '*'
 


### PR DESCRIPTION
## Summary
- Add `jq` to the `apt-get install` list in the CI Dockerfile
- The translation audit workflow uses `jq` to build the locale matrix, but `jq` was missing from the `flux-ci` container, causing the Discover Locales job to fail with `jq: not found` (exit code 127)