### PR TITLE
Fix translation audit workflow shell compatibility

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -113,6 +113,7 @@ jobs:
           ./vendor/bin/testbench schema:dump
 
       - name: Static analysis - scan code for literal keys
+        shell: bash
         run: |
           php -r '
           $locale = getenv("TRANSLATION_AUDIT_LOCALE");
@@ -168,6 +169,7 @@ jobs:
           '
 
       - name: Static analysis - cross-locale comparison
+        shell: bash
         run: |
           php -r '
           $locale = getenv("TRANSLATION_AUDIT_LOCALE");
@@ -224,6 +226,7 @@ jobs:
         continue-on-error: true
 
       - name: Generate summary
+        shell: bash
         run: |
           php -r '
           $locale = getenv("TRANSLATION_AUDIT_LOCALE");


### PR DESCRIPTION
## Summary
- Add `shell: bash` to the three inline PHP steps in the translation audit workflow
- The container defaults to `sh` which interprets `$isIgnored()` and other PHP syntax as shell constructs, causing `Syntax error: "(" unexpected`

## Summary by Sourcery

CI:
- Set Bash as the explicit shell for inline PHP static analysis and summary steps in the translation audit workflow to avoid shell syntax errors.