### PR TITLE
Fix salutation() double-cast causing TypeError

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -531,12 +531,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
             SalutationEnum::class,
             'salutation',
             [
-                'case' => resolve_static(
-                    SalutationEnum::class,
-                    'tryFrom',
-                    ['value' => $this->salutation]
-                )
-                    ->value ?? SalutationEnum::NoSalutation,
+                'case' => $this->salutation?->value ?? SalutationEnum::NoSalutation,
                 'address' => $this,
             ]
         );

--- a/tests/Unit/Enums/FluxEnumCastTest.php
+++ b/tests/Unit/Enums/FluxEnumCastTest.php
@@ -16,6 +16,18 @@ test('cast returns null for null value', function (): void {
     expect($address->salutation)->toBeNull();
 });
 
+test('salutation method works with cast enum value', function (): void {
+    $address = Address::factory()->make(['salutation' => 'mr', 'firstname' => 'John', 'lastname' => 'Doe']);
+
+    expect($address->salutation())->toBeString();
+});
+
+test('salutation method works with null value', function (): void {
+    $address = Address::factory()->make(['salutation' => null]);
+
+    expect($address->salutation())->toBeString();
+});
+
 test('cast returns fallback object for unknown value', function (): void {
     $address = Address::factory()->make();
     $address->setRawAttributes(array_merge($address->getAttributes(), ['salutation' => 'custom_value']));


### PR DESCRIPTION
## Summary
- The `salutation` column is cast to `SalutationEnum` via `casts()`, so `$this->salutation` is already an `stdClass`
- The `salutation()` method was passing this `stdClass` to `tryFrom()` which expects `string|int|null`, causing `TypeError`
- Use the already-cast value directly: `$this->salutation?->value`

Fixes Flare error #8612839

## Summary by Sourcery

Bug Fixes:
- Resolve a TypeError by using the already cast salutation value instead of re-calling the enum factory.