### PR TITLE
Fix overtime reduction (Überstundenabbau) not deducting from overtime…

### DIFF
--- a/src/Actions/EmployeeDay/CloseEmployeeDay.php
+++ b/src/Actions/EmployeeDay/CloseEmployeeDay.php
@@ -151,7 +151,7 @@ class CloseEmployeeDay extends FluxAction
         }
 
         // ((sick hours + vacation hours + absence hours) - target hours) + actual hours = overtime
-        $totalOvertime = bcadd(
+        $plusMinusOvertimeHours = bcadd(
             bcsub(
                 bcadd(
                     $data['sick_hours_used'],
@@ -170,7 +170,6 @@ class CloseEmployeeDay extends FluxAction
             $data
         );
 
-        $plusMinusOvertimeHours = $totalOvertime;
 
         return collect(array_merge(
             [

--- a/src/Actions/EmployeeDay/CloseEmployeeDay.php
+++ b/src/Actions/EmployeeDay/CloseEmployeeDay.php
@@ -14,7 +14,6 @@ use FluxErp\Models\Holiday;
 use FluxErp\Models\WorkTime;
 use FluxErp\Rulesets\EmployeeDay\CloseEmployeeDayRuleset;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class CloseEmployeeDay extends FluxAction
@@ -95,7 +94,6 @@ class CloseEmployeeDay extends FluxAction
             'sick_days_used' => 0,
             'vacation_hours_used' => 0,
             'vacation_days_used' => 0,
-            'overtime_used' => 0,
             'plus_minus_absence_hours' => 0,
         ];
 
@@ -138,12 +136,10 @@ class CloseEmployeeDay extends FluxAction
                     $data['vacation_hours_used'] = bcadd($data['vacation_hours_used'], $hours);
                 }
             } elseif (data_get($absenceRequest, 'absenceType.affects_overtime')) {
-                $hours = $absenceRequest->calculateWorkHoursAffected($date);
+                // Overtime absences (e.g. Überstundenabbau) are not added to the total
+                // like sick/vacation hours. The deficit from not working (actual - target)
+                // already represents the overtime deduction.
                 $usedAbsenceRequests->push($absenceRequest);
-
-                if (bccomp($hours, 0) === 1) {
-                    $data['overtime_used'] = bcadd($data['overtime_used'], $hours);
-                }
             } else {
                 $hours = $absenceRequest->calculateWorkHoursAffected($date);
                 $usedAbsenceRequests->push($absenceRequest);
@@ -174,7 +170,6 @@ class CloseEmployeeDay extends FluxAction
             $data
         );
 
-        Arr::pull($data, 'overtime_used');
         $plusMinusOvertimeHours = $totalOvertime;
 
         return collect(array_merge(

--- a/src/Actions/EmployeeDay/CloseEmployeeDay.php
+++ b/src/Actions/EmployeeDay/CloseEmployeeDay.php
@@ -170,7 +170,6 @@ class CloseEmployeeDay extends FluxAction
             $data
         );
 
-
         return collect(array_merge(
             [
                 'holiday_id' => $holiday?->id,

--- a/src/Actions/EmployeeDay/CloseEmployeeDay.php
+++ b/src/Actions/EmployeeDay/CloseEmployeeDay.php
@@ -174,7 +174,8 @@ class CloseEmployeeDay extends FluxAction
             $data
         );
 
-        $plusMinusOvertimeHours = bcadd($totalOvertime, Arr::pull($data, 'overtime_used'));
+        Arr::pull($data, 'overtime_used');
+        $plusMinusOvertimeHours = $totalOvertime;
 
         return collect(array_merge(
             [

--- a/tests/Unit/Action/EmployeeDay/CloseEmployeeDayTest.php
+++ b/tests/Unit/Action/EmployeeDay/CloseEmployeeDayTest.php
@@ -76,13 +76,12 @@ test('overtime used is added to total overtime when affects_overtime is true', f
 
     // With 8 target hours and 0 actual hours:
     // totalOvertime = (0 + 0 + 0 - 8) + 0 = -8
-    // overtime_used = 8 (from the absence request)
-    // plusMinusOvertimeHours should be -8 + 8 = 0 (NOT -8 - 8 = -16)
+    // overtime_used is NOT added back — the deficit IS the overtime deduction
+    // plusMinusOvertimeHours = -8 (overtime balance decreases by 8h)
 
     expect($dayData->get('target_hours'))->toBe('8.00');
     expect($dayData->get('actual_hours'))->toBe('0.00');
-    // The key assertion: plus_minus_overtime_hours should be 0, not -16
-    expect($dayData->get('plus_minus_overtime_hours'))->toBe('0.00');
+    expect($dayData->get('plus_minus_overtime_hours'))->toBe('-8.00');
 });
 
 test('overtime is negative when no absence compensates for missing work', function (): void {
@@ -263,9 +262,9 @@ test('percentage deduction is applied when calculating overtime used', function 
     $dayData = CloseEmployeeDay::calculateDayData($this->employee, $testDate);
 
     // 8h target, 0h actual, percentage_deduction=0.50
-    // overtime_used = 8h * 0.50 = 4h
+    // overtime_used = 8h * 0.50 = 4h (not used in overtime calculation)
     // totalOvertime = (0 + 0 + 0 - 8) + 0 = -8
-    // plusMinusOvertimeHours = -8 + 4 = -4
+    // plusMinusOvertimeHours = -8 (full day absent = full deficit)
     expect($dayData->get('target_hours'))->toBe('8.00');
-    expect($dayData->get('plus_minus_overtime_hours'))->toBe('-4.00');
+    expect($dayData->get('plus_minus_overtime_hours'))->toBe('-8.00');
 });


### PR DESCRIPTION
… balance.

The CloseEmployeeDay function was incorrectly adding overtime_used back to totalOvertime. This neutralized the deficit from not working, treating it the same as sick leave or vacation. As a result, taking a day of Überstundenabbau had no effect on the overtime balance.

## Summary by Sourcery

Correct overtime balance calculation so that overtime reduction days decrease the employee's overtime instead of being neutralized.

Bug Fixes:
- Stop adding used overtime back into the daily overtime balance when closing an employee day, ensuring Überstundenabbau properly reduces total overtime.

Tests:
- Update employee day closing tests to assert that overtime reduction days and partial overtime deductions result in a negative overtime balance equal to the missed work hours.