### PR TITLE
add scope filters to SearchController

### DIFF
--- a/resources/views/livewire/order/additional-addresses.blade.php
+++ b/resources/views/livewire/order/additional-addresses.blade.php
@@ -17,15 +17,8 @@
                                   'name',
                                 ],
                                 'with' => 'contact.media',
-                                'whereRelation' => [
-                                    'tenants',
-                                    'tenant_id',
-                                    '=',
-                                    $tenantId,
-                                ],
-                                'doesntHave' => [
-                                    'tenants',
-                                    'or',
+                                'scopes' => [
+                                    'whereHasTenant' => [$tenantId],
                                 ],
                             ],
                         ]"

--- a/src/Http/Controllers/CalendarSearchController.php
+++ b/src/Http/Controllers/CalendarSearchController.php
@@ -10,74 +10,74 @@ class CalendarSearchController extends Controller
 {
     public function __invoke(Request $request)
     {
-        $onlyGroupCalendars = $request->get('onlyGroups', false);
+        $onlyGroupCalendars = $request->input('onlyGroups', false);
 
         $query = auth()->user()->calendars();
-        if (! blank($request->get('selected')) && blank($request->get('search'))) {
-            $selected = $request->get('selected');
+        if (! blank($request->input('selected')) && blank($request->input('search'))) {
+            $selected = $request->input('selected');
 
             $query->whereKey(Arr::wrap($selected));
         } elseif ($request->has('search')) {
             $query->where(function (Builder $query) use ($request): void {
-                foreach (Arr::wrap($request->get('searchFields')) as $field) {
-                    $query->orWhere($field, 'like', '%' . $request->get('search') . '%');
+                foreach (Arr::wrap($request->input('searchFields')) as $field) {
+                    $query->orWhere($field, 'like', '%' . $request->input('search') . '%');
                 }
             });
         }
 
         if ($request->has('with')) {
-            $query->with($request->get('with'));
+            $query->with($request->input('with'));
         }
 
         if ($request->has('limit')) {
-            $query->limit($request->get('limit'));
+            $query->limit($request->input('limit'));
         } else {
             $query->limit(10);
         }
 
         if ($request->has('orderBy')) {
-            $query->orderBy($request->get('orderBy'));
+            $query->orderBy($request->input('orderBy'));
         }
 
         if ($request->has('orderDirection')) {
-            $query->orderBy($request->get('orderDirection'));
+            $query->orderBy($request->input('orderDirection'));
         }
 
         if ($request->has('where')) {
-            $query->where($request->get('where'));
+            $query->where($request->input('where'));
         }
 
         if ($request->has('whereIn')) {
-            foreach ($request->get('whereIn') as $whereIn) {
+            foreach ($request->input('whereIn') as $whereIn) {
                 $whereIn[1] = Arr::wrap($whereIn[1]);
                 $query->whereIn(...$whereIn);
             }
         }
 
         if ($request->has('whereNotIn')) {
-            foreach ($request->get('whereNotIn') as $whereNotIn) {
+            foreach ($request->input('whereNotIn') as $whereNotIn) {
                 $query->whereNotIn(...$whereNotIn);
             }
         }
 
         if ($request->has('whereNull')) {
-            $query->whereNull($request->get('whereNull'));
+            $query->whereNull($request->input('whereNull'));
         }
 
         if ($request->has('whereNotNull')) {
-            $query->whereNotNull($request->get('whereNotNull'));
+            $query->whereNotNull($request->input('whereNotNull'));
         }
 
         if ($request->has('select')) {
-            $query->select($request->get('select'));
+            $query->select($request->input('select'));
         }
 
         if ($request->has('whereDoesntHave')) {
-            $query->whereDoesntHave($request->get('whereDoesntHave'));
+            $query->whereDoesntHave($request->input('whereDoesntHave'));
         }
 
         if ($request->has('whereHas')) {
-            $query->whereHas($request->get('whereHas'));
+            $query->whereHas($request->input('whereHas'));
         }
 
         if ($onlyGroupCalendars) {

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Http\Controllers;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -25,22 +26,22 @@ class SearchController extends Controller
 
         if (
             ! class_exists($model)
-            || (! $isSearchable && ! $request->get('searchFields'))
+            || (! $isSearchable && ! $request->input('searchFields'))
         ) {
             abort(404);
         }
 
         Event::dispatch('tall-datatables-searching', $request);
 
-        if (! blank($request->get('selected')) && blank($request->get('search'))) {
-            $selected = $request->get('selected');
-            $optionValue = $request->get('option-value') ?: (app($model))->getKeyName();
+        if (! blank($request->input('selected')) && blank($request->input('search'))) {
+            $selected = $request->input('selected');
+            $optionValue = $request->input('option-value') ?: (app($model))->getKeyName();
 
             $query = resolve_static($model, 'query');
             is_array($selected)
                 ? $query->whereIn($optionValue, Arr::wrap($selected))
                 : $query->where($optionValue, $selected);
-        } elseif ($request->has('search') && $isSearchable && ! $request->get('searchFields')) {
+        } elseif ($request->has('search') && $isSearchable && ! $request->input('searchFields')) {
             /** @var Builder $perPageSearch */
             $perPageSearch = count(Arr::except(
                 app($model)->getGlobalScopes(),
@@ -50,15 +51,15 @@ class SearchController extends Controller
                 ]
             )) === 0 ? 20 : 1000;
 
-            $query = ! is_string($request->get('search'))
+            $query = ! is_string($request->input('search'))
                 ? resolve_static($model, 'query')->limit(20)
-                : resolve_static($model, 'search', ['query' => $request->get('search')])
+                : resolve_static($model, 'search', ['query' => $request->input('search')])
                     ->toEloquentBuilder(perPage: $perPageSearch);
         } elseif ($request->has('search')) {
             $query = resolve_static($model, 'query');
             $query->where(function (Builder $query) use ($request): void {
-                foreach (Arr::wrap($request->get('searchFields')) as $field) {
-                    $query->orWhere($field, 'like', '%' . $request->get('search') . '%');
+                foreach (Arr::wrap($request->input('searchFields')) as $field) {
+                    $query->orWhere($field, 'like', '%' . $request->input('search') . '%');
                 }
             });
         } else {
@@ -67,78 +68,78 @@ class SearchController extends Controller
         }
 
         if ($request->has('with')) {
-            $query->with($request->get('with'));
+            $query->with($request->input('with'));
         }
 
         if ($request->has('limit')) {
-            $query->limit($request->get('limit'));
+            $query->limit($request->input('limit'));
         } else {
             $query->limit(10);
         }
 
         if ($request->has('orderBy')) {
-            $query->orderBy($request->get('orderBy'), $request->get('orderDirection', 'asc'));
+            $query->orderBy($request->input('orderBy'), $request->input('orderDirection', 'asc'));
         }
 
         if ($request->has('where')) {
-            $query->where($request->get('where'));
+            $query->where($request->input('where'));
         }
 
         if ($request->has('whereIn')) {
-            foreach ($request->get('whereIn') as $whereIn) {
+            foreach ($request->input('whereIn') as $whereIn) {
                 $whereIn[1] = Arr::wrap($whereIn[1]);
                 $query->whereIn(...$whereIn);
             }
         }
 
         if ($request->has('whereNotIn')) {
-            foreach ($request->get('whereNotIn') as $whereNotIn) {
+            foreach ($request->input('whereNotIn') as $whereNotIn) {
                 $query->whereNotIn(...$whereNotIn);
             }
         }
 
         if ($request->has('whereNull')) {
-            $query->whereNull(...$request->get('whereNull'));
+            $query->whereNull(...$request->input('whereNull'));
         }
 
         if ($request->has('whereNotNull')) {
-            $query->whereNotNull(...$request->get('whereNotNull'));
+            $query->whereNotNull(...$request->input('whereNotNull'));
         }
 
         if ($request->has('whereBetween')) {
-            $query->whereBetween(...$request->get('whereBetween'));
+            $query->whereBetween(...$request->input('whereBetween'));
         }
 
         if ($request->has('whereNotBetween')) {
-            $query->whereNotBetween(...$request->get('whereNotBetween'));
+            $query->whereNotBetween(...$request->input('whereNotBetween'));
         }
 
         if ($request->has('whereDate')) {
-            $query->whereDate(...$request->get('whereDate'));
+            $query->whereDate(...$request->input('whereDate'));
         }
 
         if ($request->has('whereMonth')) {
-            $query->whereMonth(...$request->get('whereMonth'));
+            $query->whereMonth(...$request->input('whereMonth'));
         }
 
         if ($request->has('whereDay')) {
-            $query->whereDay(...$request->get('whereDay'));
+            $query->whereDay(...$request->input('whereDay'));
         }
 
         if ($request->has('whereYear')) {
-            $query->whereYear(...$request->get('whereYear'));
+            $query->whereYear(...$request->input('whereYear'));
         }
 
         if ($request->has('whereTime')) {
-            $query->whereTime(...$request->get('whereTime'));
+            $query->whereTime(...$request->input('whereTime'));
         }
 
         if ($request->has('select')) {
-            $query->select($request->get('select'));
+            $query->select($request->input('select'));
         }
 
         if ($request->has('whereDoesntHave')) {
-            $whereDoesntHave = $request->get('whereDoesntHave');
+            $whereDoesntHave = $request->input('whereDoesntHave');
             if (is_array($whereDoesntHave) && array_is_list($whereDoesntHave)) {
                 foreach ($whereDoesntHave as $relation) {
                     $query->whereDoesntHave($relation);
@@ -149,7 +150,7 @@ class SearchController extends Controller
         }
 
         if ($request->has('whereHas')) {
-            $whereHas = $request->get('whereHas');
+            $whereHas = $request->input('whereHas');
             if (is_array($whereHas) && array_is_list($whereHas)) {
                 foreach ($whereHas as $relation) {
                     $query->whereHas($relation);
@@ -160,22 +161,38 @@ class SearchController extends Controller
         }
 
         if ($request->has('whereRelation')) {
-            $query->whereRelation(...$request->get('whereRelation'));
+            $query->whereRelation(...$request->input('whereRelation'));
         }
 
         if ($request->has('whereDoesntHaveRelation')) {
-            $query->whereDoesntHaveRelation(...$request->get('whereDoesntHaveRelation'));
+            $query->whereDoesntHaveRelation(...$request->input('whereDoesntHaveRelation'));
         }
 
         if ($request->has('doesntHave')) {
-            $query->doesntHave(...$request->get('doesntHave'));
+            $query->doesntHave(...$request->input('doesntHave'));
+        }
+
+        // Add local scopes to query
+        $scopes = $request->input('scopes');
+        if (is_array($scopes) && $scopes) {
+            /** @var Model $modelInstance */
+            $modelInstance = app($model);
+            foreach ($scopes as $scope => $params) {
+                if ($modelInstance->hasNamedScope($scope)) {
+                    if (is_array($params)) {
+                        $query->{$scope}(...$params);
+                    } else {
+                        $query->{$scope}($params);
+                    }
+                }
+            }
         }
 
         $result = $query->latest()->get();
 
         if ($request->has('appends')) {
             $result->each(function ($item) use ($request): void {
-                $item->append(array_intersect($item->getAppends(), $request->get('appends')));
+                $item->append(array_intersect($item->getAppends(), $request->input('appends')));
             });
         }
 
@@ -188,8 +205,8 @@ class SearchController extends Controller
                         'description' => $item->getDescription(),
                         'image' => $item->getAvatarUrl(),
                     ],
-                    $item->only($request->get('fields', [])),
-                    $item->only($request->get('appends', [])),
+                    $item->only($request->input('fields', [])),
+                    $item->only($request->input('appends', [])),
                 );
             });
         }

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -15,7 +15,7 @@ class Authenticate extends BaseAuthenticate
     public function handle($request, Closure $next, ...$guards): mixed
     {
         // if a token is set in get parameters, set it as the bearer token
-        if ($request->get('token')) {
+        if ($request->input('token')) {
             request()->headers->add(['Authorization' => 'Bearer ' . $request->token]);
             $guards = ['token'];
         }

--- a/src/Traits/Model/HasTenants.php
+++ b/src/Traits/Model/HasTenants.php
@@ -3,7 +3,6 @@
 namespace FluxErp\Traits\Model;
 
 use FluxErp\Models\Tenant;
-use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -42,8 +41,7 @@ trait HasTenants
         return $tenants;
     }
 
-    #[Scope]
-    protected function whereHasTenant(Builder $query, array|int|string|Model|Collection|null $tenant): void
+    protected function scopeWhereHasTenant(Builder $query, array|int|string|Model|Collection|null $tenant): void
     {
         if (is_null($tenant)) {
             $query->whereDoesntHave('tenants');


### PR DESCRIPTION
fix additional-addresses address search
replace deprecated Request "get" method with "input"

## Summary by Sourcery

Add support for applying model local scopes to search queries and align request access with Laravel’s preferred input API.

New Features:
- Allow search endpoints to apply named Eloquent scopes passed via request parameters.

Bug Fixes:
- Correct additional-addresses order address search to filter contacts by tenant using a dedicated tenant scope.

Enhancements:
- Rename the tenant filter helper to a proper Eloquent local scope for reuse across models.
- Standardize controllers and middleware to use Request::input() instead of the deprecated get() accessor.