### PR TITLE
update colors in ChartColorEnum to match tailwind v4

### DIFF
--- a/resources/js/components/apex-charts.js
+++ b/resources/js/components/apex-charts.js
@@ -277,7 +277,9 @@ function apexCharts($wire) {
                         Array.isArray(targetValue) &&
                         Array.isArray(sourceValue)
                     ) {
-                        target[key] = targetValue.concat(sourceValue);
+                        // Currently only colors is an array on default options (which is the target most of the time)
+                        // Therefore sourceValue should be priority and only filled with remaining default options colors
+                        target[key] = sourceValue.concat(targetValue.filter(v => !sourceValue.includes(v)));
                     } else if (isObject(targetValue) && isObject(sourceValue)) {
                         target[key] = this.mergeDeep(
                             Object.assign({}, targetValue),

--- a/resources/js/components/apex-charts.js
+++ b/resources/js/components/apex-charts.js
@@ -279,7 +279,9 @@ function apexCharts($wire) {
                     ) {
                         // Currently only colors is an array on default options (which is the target most of the time)
                         // Therefore sourceValue should be priority and only filled with remaining default options colors
-                        target[key] = sourceValue.concat(targetValue.filter(v => !sourceValue.includes(v)));
+                        target[key] = sourceValue.concat(
+                            targetValue.filter((v) => !sourceValue.includes(v)),
+                        );
                     } else if (isObject(targetValue) && isObject(sourceValue)) {
                         target[key] = this.mergeDeep(
                             Object.assign({}, targetValue),

--- a/src/Enums/ChartColorEnum.php
+++ b/src/Enums/ChartColorEnum.php
@@ -9,41 +9,57 @@ class ChartColorEnum extends FluxEnum
 {
     use EnumTrait;
 
-    final public const string Amber = '#f59e0b';
+    final public const string Amber = '#ff9900';
 
-    final public const string Blue = '#3b82f6';
+    final public const string Blue = '#0083ff';
 
-    final public const string Cyan = '#06b6d4';
+    final public const string Cyan = '#00b9da';
 
-    final public const string Emerald = '#10b981';
+    final public const string Emerald = '#00bb7e';
 
-    final public const string Fuchsia = '#d946ef';
+    final public const string Fuchsia = '#d838fa';
 
-    final public const string Green = '#22c55e';
+    final public const string Gray = '#687282';
 
-    final public const string Indigo = '#6366f1';
+    final public const string Green = '#00c753';
 
-    final public const string Lime = '#84cc16';
+    final public const string Indigo = '#2c64ff';
 
-    final public const string Orange = '#f97316';
+    final public const string Lime = '#8acd00';
 
-    final public const string Pink = '#ec4899';
+    final public const string Mauve = '#78697b';
 
-    final public const string Purple = '#a855f7';
+    final public const string Mist = '#66787c';
 
-    final public const string Red = '#ef4444';
+    final public const string Neutral = '#737373';
 
-    final public const string Rose = '#f43f5e';
+    final public const string Olive = '#7e7c67';
 
-    final public const string Sky = '#0ea5e9';
+    final public const string Orange = '#ff6800';
 
-    final public const string Slate = '#64748b';
+    final public const string Pink = '#f73799';
 
-    final public const string Teal = '#14b8a6';
+    final public const string Purple = '#9B4fff';
 
-    final public const string Violet = '#8b5cf6';
+    final public const string Red = '#ff2d35';
 
-    final public const string Yellow = '#eab308';
+    final public const string Rose = '#ff2455';
+
+    final public const string Sky = '#00a7f4';
+
+    final public const string Slate = '#5d748e';
+
+    final public const string Stone = '#79716b';
+
+    final public const string Taupe = '#7d6d67';
+
+    final public const string Teal = '#00bba7';
+
+    final public const string Violet = '#7459ff';
+
+    final public const string Yellow = '#f8af00';
+
+    final public const string Zinc = '#70717b';
 
     public static function fromColor(string $colorName): string
     {

--- a/src/Livewire/Widgets/TicketsByState.php
+++ b/src/Livewire/Widgets/TicketsByState.php
@@ -57,13 +57,16 @@ class TicketsByState extends CircleChart implements HasWidgetOptions
         $this->labels = $data
             ->map(fn (Ticket $ticket) => __(Str::headline((string) $ticket->state)))
             ->toArray();
+
         $this->series = $data->pluck('total')->toArray();
+
         $this->optionData = $data
             ->map(fn (Ticket $ticket) => [
                 'label' => __(Str::headline((string) $ticket->state)),
                 'state' => (string) $ticket->state,
             ])
             ->toArray();
+
         $this->colors = $data->map(function (Ticket $ticket) use ($allStates) {
             $stateClass = $allStates->get((string) $ticket->state);
 

--- a/src/States/Ticket/InProgress.php
+++ b/src/States/Ticket/InProgress.php
@@ -8,6 +8,6 @@ class InProgress extends TicketState
 
     public function color(): string
     {
-        return static::$color ?? 'amber';
+        return static::$color ?? 'violet';
     }
 }


### PR DESCRIPTION
change color from InProgress state to violet to be better distinguishable from the other ticket states fix apex charts using given colors first and append default colors (was the other way around)

## Summary by Sourcery

Update chart color palette and ticket state coloring to align with new design tokens and improve readability in Apex charts.

Bug Fixes:
- Ensure Apex charts prioritize explicitly provided colors and only append remaining default colors without duplicates.

Enhancements:
- Refresh ChartColorEnum constants to a new set of Tailwind v4-aligned colors, adding several new named colors.
- Change the default color for in-progress tickets to violet for better visual distinction in charts.