### PR TITLE
Fix Alpine JS errors in variant edit modal

### DIFF
--- a/resources/views/livewire/product/variant-list.blade.php
+++ b/resources/views/livewire/product/variant-list.blade.php
@@ -17,43 +17,41 @@
                 <div class="grow">
                     <livewire:product.product-option-group-list />
                 </div>
-                <div
-                    x-collapse
-                    x-show="Object.values($wire.productOptions).length > 0"
-                    class="w-1/2"
-                >
-                    <x-card>
-                        <x-slot:header>
-                            <span x-text="productOptionGroup?.name"></span>
-                        </x-slot:header>
-                        <template
-                            x-for="productOption in $wire.productOptions"
-                            :key="productOption.id"
-                        >
-                            <div class="flex gap-1.5">
-                                <x-checkbox
-                                    x-bind:id="
-                                        'product-option' + productOption.id
-                                    "
-                                    x-bind:value="productOption.id"
-                                    x-model.number="
-                                        $wire.selectedOptions[
-                                            productOption
-                                                .product_option_group_id
-                                        ]
-                                    "
-                                />
-                                <label
-                                    x-text="productOption.name"
-                                    class="block text-sm font-medium text-gray-700 dark:text-gray-50"
-                                    x-bind:for="
-                                        'product-option' + productOption.id
-                                    "
-                                ></label>
-                            </div>
-                        </template>
-                    </x-card>
-                </div>
+                <template x-if="$wire.productOptions.length > 0">
+                    <div class="w-1/2">
+                        <x-card>
+                            <x-slot:header>
+                                <span x-text="productOptionGroup?.name"></span>
+                            </x-slot:header>
+                            <template
+                                x-for="productOption in $wire.productOptions"
+                                x-bind:key="productOption.id"
+                            >
+                                <div class="flex items-center gap-1.5">
+                                    <x-checkbox
+                                        x-bind:id="
+                                            'product-option' + productOption.id
+                                        "
+                                        x-bind:value="productOption.id"
+                                        x-model.number="
+                                            $wire.selectedOptions[
+                                                productOption
+                                                    .product_option_group_id
+                                            ]
+                                        "
+                                    />
+                                    <label
+                                        x-text="productOption.name"
+                                        class="block text-sm font-medium text-gray-700 dark:text-gray-50"
+                                        x-bind:for="
+                                            'product-option' + productOption.id
+                                        "
+                                    ></label>
+                                </div>
+                            </template>
+                        </x-card>
+                    </div>
+                </template>
             </div>
         </div>
         <div
@@ -115,12 +113,12 @@
                         >
                             <x-toggle
                                 x-bind:checked="
-                                    $wire.variants.restore.every(
+                                    $wire.variants?.restore?.every(
                                         (v) => v.selected,
                                     )
                                 "
                                 x-on:change="
-                                    $wire.variants.restore.forEach(
+                                    $wire.variants?.restore?.forEach(
                                         (v, i) =>
                                             ($wire.variants.restore[
                                                 i

--- a/tests/Browser/Workflows/ProductDetailInteractionsTest.php
+++ b/tests/Browser/Workflows/ProductDetailInteractionsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use FluxErp\Models\Product;
+use FluxErp\Models\ProductOption;
+use FluxErp\Models\ProductOptionGroup;
 
 beforeEach(function (): void {
     $this->product = Product::factory()->create([
@@ -90,4 +92,73 @@ test('product serial numbers page loads', function (): void {
     visit(route('products.serial-numbers'))
         ->assertNoSmoke()
         ->assertPresent('[tall-datatable]');
+});
+
+test('variant edit modal shows product options without js errors', function (): void {
+    $group = ProductOptionGroup::factory()->create(['name' => 'Color']);
+    ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Red',
+    ]);
+    ProductOption::factory()->create([
+        'product_option_group_id' => $group->getKey(),
+        'name' => 'Blue',
+    ]);
+
+    $page = visit(route('products.id', ['id' => $this->product->getKey()]) . '?tab=product.variant-list');
+
+    // Wait for the variant list component to load
+    $page->script(<<<'JS'
+        () => new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Edit Variants button not found')), 15000);
+            const check = () => {
+                const btn = Array.from(document.querySelectorAll('button')).find(b =>
+                    b.textContent?.includes('Edit Variants') || b.textContent?.includes('Varianten bearbeiten')
+                );
+                if (btn) {
+                    clearTimeout(timeout);
+                    resolve();
+                } else {
+                    setTimeout(check, 300);
+                }
+            };
+            check();
+        })
+    JS);
+
+    // Click the "Edit Variants" button to open the modal
+    $page->script(<<<'JS'
+        () => {
+            const btn = Array.from(document.querySelectorAll('button')).find(b =>
+                b.textContent?.includes('Edit Variants') || b.textContent?.includes('Varianten bearbeiten')
+            );
+            btn.click();
+        }
+    JS);
+
+    $page->wait(2);
+
+    // Click the product option group row in the modal to load its options
+    $page->script(<<<'JS'
+        () => new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Product option group row not found')), 10000);
+            const check = () => {
+                const rows = document.querySelectorAll('tbody tr');
+                for (const row of rows) {
+                    if (row.textContent?.includes('Color')) {
+                        row.click();
+                        clearTimeout(timeout);
+                        resolve();
+                        return;
+                    }
+                }
+                setTimeout(check, 200);
+            };
+            check();
+        })
+    JS);
+
+    // Wait for product options to load and verify no JS errors
+    $page->wait(2)
+        ->assertNoJavascriptErrors();
 });


### PR DESCRIPTION
## Summary
- Use `x-if` instead of `x-show` for product options container to prevent Alpine from evaluating `x-for` template expressions when the loop scope is not yet established
- Add optional chaining for `$wire.variants?.restore` access in the restore toggle to handle the initial empty state
- Add browser test covering variant modal product option group interaction

## Summary by Sourcery

Fix Alpine.js runtime errors in the product variant edit modal and add coverage for the interaction in browser tests.

Bug Fixes:
- Prevent Alpine.js from evaluating product option loop expressions before the product options context is available in the variant edit modal.
- Avoid errors when accessing the variants restore collection by guarding Livewire state with optional chaining in the restore toggle.

Tests:
- Add a browser workflow test that opens the variant edit modal, selects a product option group, and asserts no JavaScript errors occur during interaction.