### PR TITLE
Add Accept-Language header support and API locale fallback

### DIFF
--- a/src/Http/Middleware/Localization.php
+++ b/src/Http/Middleware/Localization.php
@@ -8,6 +8,7 @@ use FluxErp\Models\Language;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Number;
 use Throwable;
 
@@ -15,24 +16,36 @@ class Localization
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        if (! app()->runningUnitTests()) {
-            try {
-                $userLanguage = Auth::user()?->language?->language_code;
-            } catch (Throwable) {
-                $userLanguage = null;
-            }
+        try {
+            $userLanguage = Auth::user()?->language?->language_code;
+        } catch (Throwable) {
+            $userLanguage = null;
+        }
 
-            app()->setlocale(
-                $request->header('content-language') ??
-                $userLanguage ??
-                resolve_static(Language::class, 'default')?->language_code ??
-                config('app.locale')
+        $locale = $request->header('content-language') ?? $userLanguage;
+
+        if (! $locale && $request->header('accept-language')) {
+            $availableLocales = Cache::memo()->rememberForever(
+                'available_language_codes',
+                fn () => resolve_static(Language::class, 'query')
+                    ->pluck('language_code')
             );
 
-            Number::useLocale(app()->getLocale());
-            Carbon::setLocale(app()->getLocale());
-            BaseCarbon::setLocale(app()->getLocale());
+            $locale = collect($request->getLanguages())
+                ->flatMap(fn (string $lang) => array_filter([$lang, strstr($lang, '_', true) ?: null]))
+                ->unique()
+                ->first(fn (string $lang) => $availableLocales->contains($lang));
         }
+
+        app()->setLocale(
+            $locale
+            ?? resolve_static(Language::class, 'default')?->language_code
+            ?? config('app.locale')
+        );
+
+        Number::useLocale(app()->getLocale());
+        Carbon::setLocale(app()->getLocale());
+        BaseCarbon::setLocale(app()->getLocale());
 
         return $next($request);
     }

--- a/src/Traits/Model/HasAttributeTranslations.php
+++ b/src/Traits/Model/HasAttributeTranslations.php
@@ -25,33 +25,6 @@ trait HasAttributeTranslations
         return app(static::class)->translatableAttributes();
     }
 
-    protected static function resolveLanguageId(): ?int
-    {
-        $languageId = Session::get('selectedLanguageId');
-        $default = resolve_static(Language::class, 'default');
-
-        if (is_null($languageId)) {
-            $locale = app()->getLocale();
-
-            if ($locale === $default?->language_code) {
-                return null;
-            }
-
-            $languageId = Cache::memo()->rememberForever(
-                'language_id_' . $locale,
-                fn () => resolve_static(Language::class, 'query')
-                    ->where('language_code', $locale)
-                    ->value('id')
-            );
-        }
-
-        if ($languageId === $default?->getKey()) {
-            return null;
-        }
-
-        return $languageId;
-    }
-
     protected static function bootHasAttributeTranslations(): void
     {
         static::retrieved(function (Model $model): void {
@@ -134,6 +107,33 @@ trait HasAttributeTranslations
                 }
             }
         });
+    }
+
+    protected static function resolveLanguageId(): ?int
+    {
+        $languageId = Session::get('selectedLanguageId');
+        $default = resolve_static(Language::class, 'default');
+
+        if (is_null($languageId)) {
+            $locale = app()->getLocale();
+
+            if ($locale === $default?->language_code) {
+                return null;
+            }
+
+            $languageId = Cache::memo()->rememberForever(
+                'language_id_' . $locale,
+                fn () => resolve_static(Language::class, 'query')
+                    ->where('language_code', $locale)
+                    ->value('id')
+            );
+        }
+
+        if ($languageId === $default?->getKey()) {
+            return null;
+        }
+
+        return $languageId;
     }
 
     public function attributeTranslationRules(): array

--- a/src/Traits/Model/HasAttributeTranslations.php
+++ b/src/Traits/Model/HasAttributeTranslations.php
@@ -10,6 +10,7 @@ use FluxErp\Support\Collection\TranslatableCollection;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\Rule;
 
@@ -24,14 +25,39 @@ trait HasAttributeTranslations
         return app(static::class)->translatableAttributes();
     }
 
+    protected static function resolveLanguageId(): ?int
+    {
+        $languageId = Session::get('selectedLanguageId');
+        $default = resolve_static(Language::class, 'default');
+
+        if (is_null($languageId)) {
+            $locale = app()->getLocale();
+
+            if ($locale === $default?->language_code) {
+                return null;
+            }
+
+            $languageId = Cache::memo()->rememberForever(
+                'language_id_' . $locale,
+                fn () => resolve_static(Language::class, 'query')
+                    ->where('language_code', $locale)
+                    ->value('id')
+            );
+        }
+
+        if ($languageId === $default?->getKey()) {
+            return null;
+        }
+
+        return $languageId;
+    }
+
     protected static function bootHasAttributeTranslations(): void
     {
         static::retrieved(function (Model $model): void {
-            $languageId = Session::get('selectedLanguageId');
+            $languageId = static::resolveLanguageId();
 
-            if (is_null($languageId)
-                || $languageId === resolve_static(Language::class, 'default')?->id
-            ) {
+            if (is_null($languageId)) {
                 return;
             }
 
@@ -39,12 +65,9 @@ trait HasAttributeTranslations
         });
 
         static::saving(function (Model $model): void {
-            $languageId = Session::get('selectedLanguageId');
+            $languageId = static::resolveLanguageId();
 
-            if (is_null($languageId)
-                || $languageId === resolve_static(Language::class, 'default')?->id
-                || $model->translations !== null
-            ) {
+            if (is_null($languageId) || $model->translations !== null) {
                 return;
             }
 
@@ -133,7 +156,7 @@ trait HasAttributeTranslations
         return $this->morphMany(AttributeTranslation::class, 'model');
     }
 
-    public function getAttributeTranslation(string $attribute, int $languageId): string
+    public function getAttributeTranslation(string $attribute, int $languageId): ?string
     {
         return $this->attributeTranslations()
             ->where('language_id', $languageId)
@@ -148,7 +171,7 @@ trait HasAttributeTranslations
 
     public function localize(?int $languageId = null): static
     {
-        $languageId ??= Session::get('selectedLanguageId');
+        $languageId ??= static::resolveLanguageId();
 
         if (is_null($languageId)) {
             return $this;

--- a/tests/Feature/Http/Middleware/LocalizationTest.php
+++ b/tests/Feature/Http/Middleware/LocalizationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use FluxErp\Http\Middleware\Localization;
+use FluxErp\Models\Language;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+test('sets locale from content-language header', function (): void {
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('content-language', 'fr');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('fr');
+    expect(Carbon::getLocale())->toBe('fr');
+});
+
+test('sets locale from accept-language header', function (): void {
+    Language::factory()->create(['language_code' => 'es']);
+
+    auth()->logout();
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('Accept-Language', 'es');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('es');
+    expect(Carbon::getLocale())->toBe('es');
+});
+
+test('matches base language from accept-language header', function (): void {
+    Language::factory()->create(['language_code' => 'de']);
+
+    auth()->logout();
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('Accept-Language', 'de-DE,de;q=0.9,en;q=0.5');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('de');
+});
+
+test('prefers content-language over accept-language header', function (): void {
+    Language::factory()->create(['language_code' => 'es']);
+
+    auth()->logout();
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('content-language', 'fr');
+    $request->headers->set('Accept-Language', 'es');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('fr');
+});
+
+test('prefers user language over accept-language header', function (): void {
+    $language = Language::factory()->create(['language_code' => 'it']);
+    Language::factory()->create(['language_code' => 'es']);
+
+    $this->user->update(['language_id' => $language->getKey()]);
+    $this->user->load('language');
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('Accept-Language', 'es');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('it');
+});
+
+test('falls back to default language', function (): void {
+    $this->defaultLanguage->update(['language_code' => 'pt']);
+    Cache::memo()->forget('default_' . morph_alias(Language::class));
+
+    auth()->logout();
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->remove('accept-language');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('pt');
+});
+
+test('passes request to next middleware', function (): void {
+    $called = false;
+    $request = Request::create('/test', 'GET');
+
+    $response = app(Localization::class)->handle($request, function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+    expect($response->getContent())->toBe('ok');
+});

--- a/tests/Unit/Traits/HasAttributeTranslationsTest.php
+++ b/tests/Unit/Traits/HasAttributeTranslationsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use FluxErp\Models\Language;
 use FluxErp\Models\Product;
 
 test('getTranslatableAttributes returns array', function (): void {
@@ -23,4 +24,41 @@ test('model can be localized', function (): void {
     $product->localize($this->defaultLanguage->getKey());
 
     expect($product->name)->toBe('Translated Name');
+});
+
+test('retrieved hook localizes model based on app locale when session is empty', function (): void {
+    $language = Language::factory()->create(['language_code' => 'fr']);
+
+    $product = Product::factory()->create(['name' => 'English Name']);
+
+    $product->attributeTranslations()->create([
+        'language_id' => $language->getKey(),
+        'attribute' => 'name',
+        'value' => 'Nom Français',
+    ]);
+
+    // No session set, but app locale is set to the language code
+    app()->setLocale('fr');
+
+    $freshProduct = Product::query()->find($product->getKey());
+
+    expect($freshProduct->name)->toBe('Nom Français');
+});
+
+test('localize falls back to app locale when no language id given and session is empty', function (): void {
+    $language = Language::factory()->create(['language_code' => 'de']);
+
+    $product = Product::factory()->create(['name' => 'English Name']);
+
+    $product->attributeTranslations()->create([
+        'language_id' => $language->getKey(),
+        'attribute' => 'name',
+        'value' => 'Deutscher Name',
+    ]);
+
+    app()->setLocale('de');
+
+    $product->localize();
+
+    expect($product->name)->toBe('Deutscher Name');
 });


### PR DESCRIPTION
## Summary
- Extend Localization middleware with Accept-Language header parsing and base-language matching (e.g. `de-DE` → `de`), cached via `Cache::memo()`
- Add locale-based fallback in `HasAttributeTranslations` for API contexts where no session exists, with cached language ID lookups
- Fix `getAttributeTranslation` return type to `?string`

## Summary by Sourcery

Add header-based locale resolution and locale-based translation fallback for models when no session language is set.

New Features:
- Resolve application locale from content-language or accept-language headers, including base-language matching and user/default fallbacks.
- Allow models using HasAttributeTranslations to infer the active language from the application locale when no session language ID is available.

Bug Fixes:
- Adjust getAttributeTranslation to return null when no translation exists instead of always returning a string.

Enhancements:
- Cache language code and ID lookups to avoid repeated database queries during localization.
- Ensure number and date localization consistently follow the resolved application locale.

Tests:
- Add unit tests for HasAttributeTranslations locale fallback behavior without a session language.
- Add feature tests for Localization middleware covering header precedence, base-language matching, default fallback, and middleware chaining.