### PR TITLE
Fix order position view switch from list back to table

### DIFF
--- a/src/Livewire/Order/OrderPositions.php
+++ b/src/Livewire/Order/OrderPositions.php
@@ -579,8 +579,14 @@ class OrderPositions extends OrderPositionList
             $this->data = [];
         }
 
-        $this->initialized = $view !== 'table';
         $this->orderPositionsView = $view;
+
+        if ($view === 'table') {
+            $this->loadData();
+            $this->forceRender();
+        } else {
+            $this->initialized = true;
+        }
 
         $this->cacheState();
     }


### PR DESCRIPTION
## Summary
- When switching from list/sortable view back to table view in order positions, the table was empty and required a page refresh
- Root cause: `switchView()` set `initialized = false` without calling `loadData()`, and the DataTable's `x-init.once` only fires on first mount
- Fix: Call `loadData()` and `forceRender()` when switching back to table view

## Summary by Sourcery

Bug Fixes:
- Fix order positions table appearing empty after switching back from list view by reloading data and forcing a re-render.