### PR TITLE
Raise memory limit to 512M during print rendering

### DIFF
--- a/src/Actions/Printing.php
+++ b/src/Actions/Printing.php
@@ -31,18 +31,26 @@ class Printing extends FluxAction
 
     public function performAction(): HtmlString|PrintableView
     {
-        $this->model = morphed_model($this->data['model_type'])::query()
-            ->whereKey($this->data['model_id'])
-            ->first();
+        $previousMemoryLimit = ini_set('memory_limit', '512M');
 
-        $this->printable = $this->model
-            ->print()
-            ->preview($this->getData('preview') && ! $this->getData('html'));
-        $printClass = $this->printable->getViewClass($this->getData('view'));
-        $params = $this->getData('params') ?? [];
+        try {
+            $this->model = morphed_model($this->data['model_type'])::query()
+                ->whereKey($this->data['model_id'])
+                ->first();
 
-        return $this->getData('html')
-            ? $this->printable->renderView($printClass, ...$params)
-            : $this->printable->printView($printClass, ...$params);
+            $this->printable = $this->model
+                ->print()
+                ->preview($this->getData('preview') && ! $this->getData('html'));
+            $printClass = $this->printable->getViewClass($this->getData('view'));
+            $params = $this->getData('params') ?? [];
+
+            return $this->getData('html')
+                ? $this->printable->renderView($printClass, ...$params)
+                : $this->printable->printView($printClass, ...$params);
+        } finally {
+            if ($previousMemoryLimit !== false) {
+                ini_set('memory_limit', $previousMemoryLimit);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Print preview for orders with many positions exhausts the default 128MB memory limit
- Temporarily increase memory limit to 512MB scoped to the `performAction()` method
- Previous limit is always restored via `finally` block, even on exceptions

## Summary by Sourcery

Bug Fixes:
- Prevent print preview rendering from exhausting the default PHP memory limit for orders with many positions.