### PR TITLE
Skip nested transaction wrapping in FluxAction::execute()

### DIFF
--- a/src/Actions/FluxAction.php
+++ b/src/Actions/FluxAction.php
@@ -210,7 +210,16 @@ abstract class FluxAction
             }
         }
 
-        DB::transaction(fn () => $this->result = $this->performAction(), 5);
+        // Only wrap in a transaction if not already inside one. Nested actions
+        // (e.g. CreateOrder calling CreateOrderPosition) would otherwise create
+        // deeply nested savepoints whose retry logic can desynchronize Laravel's
+        // transaction counter — breaking RefreshDatabase rollback in tests and
+        // risking inconsistent state on deadlock retry in production.
+        if (DB::transactionLevel() === 0) {
+            DB::transaction(fn () => $this->result = $this->performAction(), 5);
+        } else {
+            $this->result = $this->performAction();
+        }
 
         if ($current) {
             if (method_exists(auth(), 'login')) {


### PR DESCRIPTION
When a FluxAction calls other FluxActions (e.g. CreateOrder calling CreateOrderPosition), each execute() wrapped performAction() in DB::transaction(fn(), 5), creating deeply nested savepoints with retry logic. This can desynchronize Laravel's transaction counter, causing:

RefreshDatabase rollback to silently fail in tests (state bleeds) Inconsistent savepoint state on deadlock retry in production Now execute() checks DB::transactionLevel() and only creates a new transaction when not already inside one. Nested actions join the outer transaction instead of creating savepoints.

## Summary by Sourcery

Bug Fixes:
- Prevent nested Flux actions from creating deeply nested transaction savepoints that can break test rollbacks and deadlock retry behavior.