### PR TITLE
Add drag-and-drop sorting to DataTables for Industries, OrderTypes and Discounts

### DIFF
--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -10,16 +10,13 @@ return new class() extends Migration
     public function up(): void
     {
         Schema::table('order_types', function (Blueprint $table): void {
-            $table->unsignedInteger('order_column')->nullable()->after('is_visible_in_sidebar');
+            $table->unsignedInteger('order_column')->nullable()->after('order_type_enum');
         });
 
+        DB::statement('SET @rownum := 0');
         DB::table('order_types')
             ->orderBy('id')
-            ->get(['id'])
-            ->each(fn (object $row, int $index) => DB::table('order_types')
-                ->where('id', $row->id)
-                ->update(['order_column' => $index + 1])
-            );
+            ->update(['order_column' => DB::raw('(@rownum := @rownum + 1)')]);
     }
 
     public function down(): void

--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -10,13 +10,13 @@ return new class() extends Migration
     public function up(): void
     {
         Schema::table('order_types', function (Blueprint $table): void {
-            $table->unsignedInteger('order_column')->default(0)->after('is_visible_in_sidebar');
+            $table->unsignedInteger('order_column')->nullable()->after('is_visible_in_sidebar');
         });
 
         DB::table('order_types')
             ->orderBy('id')
             ->get(['id'])
-            ->each(fn ($row, $index) => DB::table('order_types')
+            ->each(fn (object $row, int $index) => DB::table('order_types')
                 ->where('id', $row->id)
                 ->update(['order_column' => $index + 1])
             );

--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_types', function (Blueprint $table): void {
+            $table->unsignedInteger('order_column')->default(0)->after('is_visible_in_sidebar');
+        });
+
+        DB::table('order_types')
+            ->orderBy('id')
+            ->get(['id'])
+            ->each(fn ($row, $index) => DB::table('order_types')
+                ->where('id', $row->id)
+                ->update(['order_column' => $index + 1])
+            );
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_types', function (Blueprint $table): void {
+            $table->dropColumn('order_column');
+        });
+    }
+};

--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -13,10 +13,12 @@ return new class() extends Migration
             $table->unsignedInteger('order_column')->nullable()->after('order_type_enum');
         });
 
-        DB::statement('SET @rownum := 0');
         DB::table('order_types')
+            ->whereRaw('0 = (@rownum := 0)')
             ->orderBy('id')
-            ->update(['order_column' => DB::raw('(@rownum := @rownum + 1)')]);
+            ->update([
+                'order_column' => DB::raw('@rownum := @rownum + 1'),
+            ]);
     }
 
     public function down(): void

--- a/resources/views/livewire/order/order-list.blade.php
+++ b/resources/views/livewire/order/order-list.blade.php
@@ -182,6 +182,7 @@
                 :options="resolve_static(\FluxErp\Models\OrderType::class, 'query')
                     ->where('order_type_enum', \FluxErp\Enums\OrderTypeEnum::CollectiveOrder->value)
                     ->where('is_active', true)
+                    ->ordered()
                     ->get(['id', 'name'])
                     ->toArray()
                 "
@@ -194,6 +195,7 @@
                 :options="resolve_static(\FluxErp\Models\OrderType::class, 'query')
                     ->where('order_type_enum', \FluxErp\Enums\OrderTypeEnum::SplitOrder->value)
                     ->where('is_active', true)
+                    ->ordered()
                     ->get(['id', 'name'])
                     ->toArray()
                 "

--- a/src/Livewire/Contact/Accounting/Discounts.php
+++ b/src/Livewire/Contact/Accounting/Discounts.php
@@ -135,8 +135,10 @@ class Discounts extends DiscountList
         try {
             UpdateDiscount::make([
                 'id' => $recordId,
-                'order_column' => $newPosition + 1,
+                'order_column' => max(0, $newPosition) + 1,
             ])
+                ->validate()
+                ->checkPermission()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/Contact/Accounting/Discounts.php
+++ b/src/Livewire/Contact/Accounting/Discounts.php
@@ -130,6 +130,19 @@ class Discounts extends DiscountList
         return true;
     }
 
+    public function sortRows(int|string $recordId, int $newPosition): void
+    {
+        try {
+            UpdateDiscount::make([
+                'id' => $recordId,
+                'order_column' => $newPosition + 1,
+            ])
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+        }
+    }
+
     protected function getBuilder(Builder $builder): Builder
     {
         return parent::getBuilder($builder)
@@ -137,6 +150,12 @@ class Discounts extends DiscountList
                 'contacts',
                 'contacts.id',
                 $this->contactId
-            );
+            )
+            ->ordered();
+    }
+
+    protected function isSortable(): bool
+    {
+        return true;
     }
 }

--- a/src/Livewire/Contact/Accounting/Discounts.php
+++ b/src/Livewire/Contact/Accounting/Discounts.php
@@ -135,10 +135,10 @@ class Discounts extends DiscountList
         try {
             UpdateDiscount::make([
                 'id' => $recordId,
-                'order_column' => max(0, $newPosition) + 1,
+                'order_column' => max(1, $newPosition + 1),
             ])
-                ->validate()
                 ->checkPermission()
+                ->validate()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -337,6 +337,7 @@ class PurchaseInvoiceList extends BaseDataTable
                     ->toArray(),
                 'orderTypes' => resolve_static(OrderType::class, 'query')
                     ->whereIn('order_type_enum', $purchaseOrderTypes)
+                    ->ordered()
                     ->get(['id', 'name'])
                     ->toArray(),
                 'paymentTypes' => resolve_static(PaymentType::class, 'query')

--- a/src/Livewire/HumanResources/WorkTimes.php
+++ b/src/Livewire/HumanResources/WorkTimes.php
@@ -201,6 +201,7 @@ class WorkTimes extends WorkTimeList
                 'orderTypes' => resolve_static(OrderType::class, 'query')
                     ->where('is_hidden', false)
                     ->where('is_active', true)
+                    ->ordered()
                     ->get(['id', 'name', 'order_type_enum'])
                     ->filter(fn (OrderType $orderType) => ! $orderType->order_type_enum->isPurchase())
                     ->toArray(),

--- a/src/Livewire/Order/CreateChildOrder.php
+++ b/src/Livewire/Order/CreateChildOrder.php
@@ -81,6 +81,7 @@ class CreateChildOrder extends Component
                 $this->type === OrderTypeEnum::SplitOrder->value,
                 fn (Builder $query) => $query->where('is_hidden', false)
             )
+            ->ordered()
             ->get(['id', 'name'])
             ->toArray();
 

--- a/src/Livewire/Order/OrderList.php
+++ b/src/Livewire/Order/OrderList.php
@@ -361,6 +361,7 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
                 'orderTypes' => resolve_static(OrderType::class, 'query')
                     ->where('is_hidden', false)
                     ->where('is_active', true)
+                    ->ordered()
                     ->get(['id', 'name'])
                     ->toArray(),
             ]

--- a/src/Livewire/Settings/Industries.php
+++ b/src/Livewire/Settings/Industries.php
@@ -9,6 +9,7 @@ use FluxErp\Livewire\DataTables\IndustryList;
 use FluxErp\Livewire\Forms\IndustryForm;
 use FluxErp\Models\Industry;
 use FluxErp\Traits\Livewire\DataTable\AllowRecordMerging;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
@@ -96,6 +97,29 @@ class Industries extends IndustryList
 
         $this->loadData();
 
+        return true;
+    }
+
+    public function sortRows(int|string $recordId, int $newPosition): void
+    {
+        try {
+            UpdateIndustry::make([
+                'id' => $recordId,
+                'order_column' => $newPosition + 1,
+            ])
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+        }
+    }
+
+    protected function getBuilder(Builder $builder): Builder
+    {
+        return parent::getBuilder($builder)->ordered();
+    }
+
+    protected function isSortable(): bool
+    {
         return true;
     }
 }

--- a/src/Livewire/Settings/Industries.php
+++ b/src/Livewire/Settings/Industries.php
@@ -105,10 +105,10 @@ class Industries extends IndustryList
         try {
             UpdateIndustry::make([
                 'id' => $recordId,
-                'order_column' => max(0, $newPosition) + 1,
+                'order_column' => max(1, $newPosition + 1),
             ])
-                ->validate()
                 ->checkPermission()
+                ->validate()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/Settings/Industries.php
+++ b/src/Livewire/Settings/Industries.php
@@ -105,8 +105,10 @@ class Industries extends IndustryList
         try {
             UpdateIndustry::make([
                 'id' => $recordId,
-                'order_column' => $newPosition + 1,
+                'order_column' => max(0, $newPosition) + 1,
             ])
+                ->validate()
+                ->checkPermission()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/Settings/OrderTypes.php
+++ b/src/Livewire/Settings/OrderTypes.php
@@ -32,8 +32,10 @@ class OrderTypes extends OrderTypeList
         try {
             UpdateOrderType::make([
                 'id' => $recordId,
-                'order_column' => $newPosition + 1,
+                'order_column' => max(0, $newPosition) + 1,
             ])
+                ->validate()
+                ->checkPermission()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/Settings/OrderTypes.php
+++ b/src/Livewire/Settings/OrderTypes.php
@@ -32,10 +32,10 @@ class OrderTypes extends OrderTypeList
         try {
             UpdateOrderType::make([
                 'id' => $recordId,
-                'order_column' => max(0, $newPosition) + 1,
+                'order_column' => max(1, $newPosition + 1),
             ])
-                ->validate()
                 ->checkPermission()
+                ->validate()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);

--- a/src/Livewire/Settings/OrderTypes.php
+++ b/src/Livewire/Settings/OrderTypes.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Livewire\Settings;
 
+use FluxErp\Actions\OrderType\UpdateOrderType;
 use FluxErp\Livewire\DataTables\OrderTypeList;
 use FluxErp\Livewire\Forms\OrderTypeForm;
 use FluxErp\Models\Order;
@@ -11,6 +12,9 @@ use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\AllowRecordMerging;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class OrderTypes extends OrderTypeList
 {
@@ -22,6 +26,24 @@ class OrderTypes extends OrderTypeList
     public bool $isSelectable = true;
 
     protected ?string $includeBefore = 'flux::livewire.settings.order-types';
+
+    public function sortRows(int|string $recordId, int $newPosition): void
+    {
+        try {
+            UpdateOrderType::make([
+                'id' => $recordId,
+                'order_column' => $newPosition + 1,
+            ])
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+        }
+    }
+
+    protected function getBuilder(Builder $builder): Builder
+    {
+        return parent::getBuilder($builder)->ordered();
+    }
 
     protected function getViewData(): array
     {
@@ -42,5 +64,10 @@ class OrderTypes extends OrderTypeList
                     ->toArray(),
             ]
         );
+    }
+
+    protected function isSortable(): bool
+    {
+        return true;
     }
 }

--- a/src/Livewire/Widgets/Address.php
+++ b/src/Livewire/Widgets/Address.php
@@ -71,6 +71,7 @@ class Address extends Component
             ->withCount([
                 'orders' => fn (Builder $query) => $query->where('contact_id', data_get($this->address, 'contact_id')),
             ])
+            ->ordered()
             ->get()
             ->toArray();
     }

--- a/src/Livewire/Widgets/OrdersByTypeChart.php
+++ b/src/Livewire/Widgets/OrdersByTypeChart.php
@@ -45,6 +45,7 @@ class OrdersByTypeChart extends LineChart implements HasWidgetOptions
     {
         $orderTypes = resolve_static(OrderType::class, 'query')
             ->where('is_active', true)
+            ->ordered()
             ->get([
                 'id',
                 'name',

--- a/src/Models/OrderType.php
+++ b/src/Models/OrderType.php
@@ -13,14 +13,20 @@ use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\LogsActivity;
 use FluxErp\Traits\Model\SoftDeletes;
+use FluxErp\Traits\Model\SortableTrait;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\EloquentSortable\Sortable;
 
-class OrderType extends FluxModel
+class OrderType extends FluxModel implements Sortable
 {
     use Filterable, HasAttributeTranslations, HasPackageFactory, HasTenantAssignment, HasTenants, HasUserModification,
-        HasUuid, LogsActivity, SoftDeletes;
+        HasUuid, LogsActivity, SoftDeletes, SortableTrait;
+
+    public array $sortable = [
+        'sort_when_creating' => true,
+    ];
 
     public static function hasPermission(): bool
     {

--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -43,6 +43,7 @@ class MenuServiceProvider extends ServiceProvider
                 foreach (resolve_static(OrderType::class, 'query')
                     ->where('is_visible_in_sidebar', true)
                     ->where('is_active', true)
+                    ->ordered()
                     ->get(['id', 'name']) as $orderType
                 ) {
                     Menu::register(

--- a/src/Rulesets/Industry/UpdateIndustryRuleset.php
+++ b/src/Rulesets/Industry/UpdateIndustryRuleset.php
@@ -16,7 +16,8 @@ class UpdateIndustryRuleset extends FluxRuleset
                 'integer',
                 app(ModelExists::class, ['model' => Industry::class]),
             ],
-            'name' => 'required|string|max:255',
+            'name' => 'sometimes|required|string|max:255',
+            'order_column' => 'sometimes|integer|min:1',
         ];
     }
 }

--- a/src/Rulesets/OrderType/CreateOrderTypeRuleset.php
+++ b/src/Rulesets/OrderType/CreateOrderTypeRuleset.php
@@ -40,6 +40,7 @@ class CreateOrderTypeRuleset extends FluxRuleset
             'is_active' => 'boolean',
             'is_hidden' => 'boolean',
             'is_visible_in_sidebar' => 'boolean',
+            'order_column' => 'nullable|integer|min:1',
 
             'tenants' => 'array|nullable',
             'tenants.*' => [

--- a/src/Rulesets/OrderType/CreateOrderTypeRuleset.php
+++ b/src/Rulesets/OrderType/CreateOrderTypeRuleset.php
@@ -37,10 +37,10 @@ class CreateOrderTypeRuleset extends FluxRuleset
                 'required',
                 Rule::enum(OrderTypeEnum::class),
             ],
+            'order_column' => 'nullable|integer|min:1',
             'is_active' => 'boolean',
             'is_hidden' => 'boolean',
             'is_visible_in_sidebar' => 'boolean',
-            'order_column' => 'nullable|integer|min:1',
 
             'tenants' => 'array|nullable',
             'tenants.*' => [

--- a/src/Rulesets/OrderType/UpdateOrderTypeRuleset.php
+++ b/src/Rulesets/OrderType/UpdateOrderTypeRuleset.php
@@ -35,10 +35,10 @@ class UpdateOrderTypeRuleset extends FluxRuleset
             'post_stock_print_layouts.*' => 'required|string',
             'reserve_stock_print_layouts' => 'array|nullable',
             'reserve_stock_print_layouts.*' => 'required|string',
+            'order_column' => 'sometimes|integer|min:1',
             'is_active' => 'boolean',
             'is_hidden' => 'boolean',
             'is_visible_in_sidebar' => 'boolean',
-            'order_column' => 'sometimes|integer|min:1',
 
             'tenants' => 'array|nullable',
             'tenants.*' => [

--- a/src/Rulesets/OrderType/UpdateOrderTypeRuleset.php
+++ b/src/Rulesets/OrderType/UpdateOrderTypeRuleset.php
@@ -38,6 +38,7 @@ class UpdateOrderTypeRuleset extends FluxRuleset
             'is_active' => 'boolean',
             'is_hidden' => 'boolean',
             'is_visible_in_sidebar' => 'boolean',
+            'order_column' => 'sometimes|integer|min:1',
 
             'tenants' => 'array|nullable',
             'tenants.*' => [

--- a/tests/Livewire/Contact/Accounting/DiscountsTest.php
+++ b/tests/Livewire/Contact/Accounting/DiscountsTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Livewire\Contact\Accounting\Discounts;
 use FluxErp\Models\Contact;
+use FluxErp\Models\Discount;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -9,4 +10,23 @@ test('renders successfully', function (): void {
 
     Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
         ->assertOk();
+});
+
+test('sort rows updates order', function (): void {
+    $contact = Contact::factory()->create();
+
+    $discounts = Discount::factory()->count(3)->create([
+        'model_type' => morph_alias(Contact::class),
+        'model_id' => $contact->getKey(),
+    ]);
+
+    $contact->discounts()->attach($discounts->pluck('id'));
+
+    $last = $discounts->last();
+
+    Livewire::test(Discounts::class, ['contactId' => $contact->getKey()])
+        ->call('sortRows', $last->getKey(), 0)
+        ->assertHasNoErrors();
+
+    expect($last->fresh()->order_column)->toBe(1);
 });

--- a/tests/Livewire/Settings/IndustriesTest.php
+++ b/tests/Livewire/Settings/IndustriesTest.php
@@ -1,9 +1,22 @@
 <?php
 
 use FluxErp\Livewire\Settings\Industries;
+use FluxErp\Models\Industry;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Industries::class)
         ->assertOk();
+});
+
+test('sort rows updates order', function (): void {
+    $industries = Industry::factory()->count(3)->create();
+
+    $last = $industries->last();
+
+    Livewire::test(Industries::class)
+        ->call('sortRows', $last->getKey(), 0)
+        ->assertHasNoErrors();
+
+    expect($last->fresh()->order_column)->toBe(1);
 });

--- a/tests/Livewire/Settings/OrderTypesTest.php
+++ b/tests/Livewire/Settings/OrderTypesTest.php
@@ -1,9 +1,22 @@
 <?php
 
 use FluxErp\Livewire\Settings\OrderTypes;
+use FluxErp\Models\OrderType;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(OrderTypes::class)
         ->assertOk();
+});
+
+test('sort rows updates order', function (): void {
+    $orderTypes = OrderType::factory()->count(3)->create();
+
+    $last = $orderTypes->last();
+
+    Livewire::test(OrderTypes::class)
+        ->call('sortRows', $last->getKey(), 0)
+        ->assertHasNoErrors();
+
+    expect($last->fresh()->order_column)->toBe(1);
 });


### PR DESCRIPTION
## Summary
- Add `SortableTrait` and `order_column` migration for `OrderType` model (with backfill for existing rows)
- Implement `isSortable()` and `sortRows()` via FluxActions in `Settings\Industries`, `Settings\OrderTypes` and `Contact\Accounting\Discounts`
- Add `->ordered()` to all OrderType list queries (sidebar, selects, dropdowns, widgets, blade templates)
- Add `order_column` to Create/Update OrderType and Update Industry rulesets

## Summary by Sourcery

Add sortable ordering support for industries, order types, and discounts and ensure order types are consistently retrieved in the defined order across the application.

New Features:
- Enable drag-and-drop row sorting for industries, order types, and contact discounts via Livewire data tables.
- Introduce ordered retrieval of order types in menus, widgets, lists, and selection inputs using a dedicated sortable column.

Enhancements:
- Make the OrderType model sortable using a dedicated order_column and a sortable trait.
- Extend validation rulesets to accept an optional order_column for industries and order types updates and creates.

Tests:
- Add Livewire tests to verify that sortRows correctly updates the order_column for industries, order types, and discounts.