### PR TITLE
Fix null tenant crash in PrintableView::hydrateSharedData()

### DIFF
--- a/src/View/Printing/PrintableView.php
+++ b/src/View/Printing/PrintableView.php
@@ -252,16 +252,18 @@ abstract class PrintableView extends Component
 
         $tenant = $model?->tenant ?? Tenant::query()->first();
 
-        if (($logo = $tenant->getFirstMedia('logo')) && file_exists($logo->getPath())) {
-            $tenant->logo = File::mimeType($logo->getPath()) === 'image/svg+xml'
-                ? $logo->getUrl('png')
-                : $logo->getUrl();
-        }
+        if ($tenant) {
+            if (($logo = $tenant->getFirstMedia('logo')) && file_exists($logo->getPath())) {
+                $tenant->logo = File::mimeType($logo->getPath()) === 'image/svg+xml'
+                    ? $logo->getUrl('png')
+                    : $logo->getUrl();
+            }
 
-        if (($logoSmall = $tenant->getFirstMedia('logo_small')) && file_exists($logoSmall->getPath())) {
-            $tenant->logo_small = File::mimeType($logoSmall->getPath()) === 'image/svg+xml'
-                ? $logoSmall->getUrl('png')
-                : $logoSmall->getUrl();
+            if (($logoSmall = $tenant->getFirstMedia('logo_small')) && file_exists($logoSmall->getPath())) {
+                $tenant->logo_small = File::mimeType($logoSmall->getPath()) === 'image/svg+xml'
+                    ? $logoSmall->getUrl('png')
+                    : $logoSmall->getUrl();
+            }
         }
 
         $signaturePath = null;

--- a/src/View/Printing/PrintableView.php
+++ b/src/View/Printing/PrintableView.php
@@ -250,20 +250,20 @@ abstract class PrintableView extends Component
     {
         $model = $this->getModel();
 
-        $tenant = $model?->tenant ?? Tenant::query()->first();
+        $tenant = $model?->tenant
+            ?? resolve_static(Tenant::class, 'default')
+            ?? resolve_static(Tenant::class, 'query')->first();
 
-        if ($tenant) {
-            if (($logo = $tenant->getFirstMedia('logo')) && file_exists($logo->getPath())) {
-                $tenant->logo = File::mimeType($logo->getPath()) === 'image/svg+xml'
-                    ? $logo->getUrl('png')
-                    : $logo->getUrl();
-            }
+        if (($logo = $tenant?->getFirstMedia('logo')) && file_exists($logo->getPath())) {
+            $tenant->logo = File::mimeType($logo->getPath()) === 'image/svg+xml'
+                ? $logo->getUrl('png')
+                : $logo->getUrl();
+        }
 
-            if (($logoSmall = $tenant->getFirstMedia('logo_small')) && file_exists($logoSmall->getPath())) {
-                $tenant->logo_small = File::mimeType($logoSmall->getPath()) === 'image/svg+xml'
-                    ? $logoSmall->getUrl('png')
-                    : $logoSmall->getUrl();
-            }
+        if (($logoSmall = $tenant?->getFirstMedia('logo_small')) && file_exists($logoSmall->getPath())) {
+            $tenant->logo_small = File::mimeType($logoSmall->getPath()) === 'image/svg+xml'
+                ? $logoSmall->getUrl('png')
+                : $logoSmall->getUrl();
         }
 
         $signaturePath = null;


### PR DESCRIPTION
When the model has no tenant relation (e.g., ContractTemplate preview) and Tenant::query()->first() returns null (no tenant in DB or filtered by UserTenantScope), calling getFirstMedia() on null causes a 500 error.

## Summary by Sourcery

Bug Fixes:
- Prevent a 500 error by skipping logo retrieval when the resolved tenant model is null.