### PR TITLE
Bypass global scopes when resolving selected records in search controller

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -38,7 +38,7 @@ class SearchController extends Controller
             $optionValue = $request->input('option-value') ?: (app($model))->getKeyName();
 
             $query = resolve_static($model, 'query')
-                ->withoutGlobalScopes();
+                ->withoutGlobalScopes([SoftDeletingScope::class]);
 
             is_array($selected)
                 ? $query->whereIn($optionValue, Arr::wrap($selected))

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -37,10 +37,14 @@ class SearchController extends Controller
             $selected = $request->input('selected');
             $optionValue = $request->input('option-value') ?: (app($model))->getKeyName();
 
-            $query = resolve_static($model, 'query');
+            $query = resolve_static($model, 'query')
+                ->withoutGlobalScopes();
+
             is_array($selected)
                 ? $query->whereIn($optionValue, Arr::wrap($selected))
                 : $query->where($optionValue, $selected);
+
+            return $this->formatAndDispatch($query->get(), $model, $request);
         } elseif ($request->has('search') && $isSearchable && ! $request->input('searchFields')) {
             /** @var Builder $perPageSearch */
             $perPageSearch = count(Arr::except(
@@ -196,19 +200,22 @@ class SearchController extends Controller
             });
         }
 
+        return $this->formatAndDispatch($result, $model, $request);
+    }
+
+    protected function formatAndDispatch($result, string $model, Request $request)
+    {
         if (is_a(app($model), InteractsWithDataTables::class)) {
-            $result = $result->map(function ($item) use ($request) {
-                return array_merge(
-                    [
-                        'id' => $item->getKey(),
-                        'label' => $item->getLabel() ?? '-',
-                        'description' => $item->getDescription(),
-                        'image' => $item->getAvatarUrl(),
-                    ],
-                    $item->only($request->input('fields', [])),
-                    $item->only($request->input('appends', [])),
-                );
-            });
+            $result = $result->map(fn ($item) => array_merge(
+                [
+                    'id' => $item->getKey(),
+                    'label' => $item->getLabel() ?? '-',
+                    'description' => $item->getDescription(),
+                    'image' => $item->getAvatarUrl(),
+                ],
+                $item->only($request->input('fields', [])),
+                $item->only($request->input('appends', [])),
+            ));
         }
 
         Event::dispatch('tall-datatables-searched', [$request, $result]);

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Http\Controllers;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Http\Request;
@@ -203,7 +204,7 @@ class SearchController extends Controller
         return $this->formatAndDispatch($result, $model, $request);
     }
 
-    protected function formatAndDispatch($result, string $model, Request $request)
+    protected function formatAndDispatch(Collection $result, string $model, Request $request)
     {
         if (is_a(app($model), InteractsWithDataTables::class)) {
             $result = $result->map(fn ($item) => array_merge(

--- a/tests/Feature/Web/SearchControllerTest.php
+++ b/tests/Feature/Web/SearchControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+
+test('search controller returns soft deleted record when selected', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $address->delete();
+
+    $this->assertSoftDeleted($address);
+
+    $response = $this->post(
+        route('search', Address::class),
+        ['selected' => [$address->getKey()]]
+    );
+
+    $response->assertOk();
+    $response->assertJsonCount(1);
+    $response->assertJsonFragment(['id' => $address->getKey()]);
+});

--- a/tests/Feature/Web/SearchControllerTest.php
+++ b/tests/Feature/Web/SearchControllerTest.php
@@ -23,3 +23,30 @@ test('search controller returns soft deleted record when selected', function ():
     $response->assertJsonCount(1);
     $response->assertJsonFragment(['id' => $address->getKey()]);
 });
+
+test('search controller returns multiple selected records including soft deleted', function (): void {
+    $contact = Contact::factory()->create();
+
+    $activeAddress = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $softDeletedAddress = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+    ]);
+
+    $softDeletedAddress->delete();
+
+    $this->assertSoftDeleted($softDeletedAddress);
+
+    $response = $this->post(
+        route('search', Address::class),
+        ['selected' => [$activeAddress->getKey(), $softDeletedAddress->getKey()]]
+    );
+
+    $response->assertOk();
+    $response->assertJsonCount(2);
+    $response->assertJsonFragment(['id' => $activeAddress->getKey()]);
+    $response->assertJsonFragment(['id' => $softDeletedAddress->getKey()]);
+});


### PR DESCRIPTION
## Summary
- Async selects fetch the initially selected record via the search controller, but global scopes (SoftDeletes, etc.) prevented soft-deleted or scope-filtered records from being resolved — showing an empty select despite a stored value
- Added `withoutGlobalScopes()` and early return for the `selected` branch so stored values are always resolvable
- Extracted `formatAndDispatch()` to deduplicate the InteractsWithDataTables mapping logic

## Summary by Sourcery

Ensure the search controller can resolve and return selected records regardless of global scopes while centralizing result formatting and dispatching logic.

Bug Fixes:
- Allow async select requests to resolve and return soft-deleted or globally-scoped-out records when they are provided as selected values.

Enhancements:
- Bypass global scopes when resolving selected records in the search controller and return early once selected records are loaded.
- Extract and reuse a dedicated formatter method for InteractsWithDataTables search results before event dispatch.

Tests:
- Add a feature test verifying that the search controller returns a soft-deleted record when it is passed as a selected value.