### PR TITLE
Fix cache serialization in Localization middleware

### DIFF
--- a/src/Http/Middleware/Localization.php
+++ b/src/Http/Middleware/Localization.php
@@ -25,11 +25,12 @@ class Localization
         $locale = $request->header('content-language') ?? $userLanguage;
 
         if (! $locale && $request->header('accept-language')) {
-            $availableLocales = Cache::memo()->rememberForever(
+            $availableLocales = collect(Cache::memo()->rememberForever(
                 'available_language_codes',
                 fn () => resolve_static(Language::class, 'query')
                     ->pluck('language_code')
-            );
+                    ->toArray()
+            ));
 
             $locale = collect($request->getLanguages())
                 ->flatMap(fn (string $lang) => array_filter([$lang, strstr($lang, '_', true) ?: null]))

--- a/tests/Feature/Http/Middleware/LocalizationTest.php
+++ b/tests/Feature/Http/Middleware/LocalizationTest.php
@@ -86,6 +86,23 @@ test('falls back to default language', function (): void {
     expect(app()->getLocale())->toBe('pt');
 });
 
+test('caches language codes as array not collection', function (): void {
+    Language::factory()->create(['language_code' => 'ja']);
+
+    auth()->logout();
+    Cache::forget('available_language_codes');
+    Cache::memo()->flush();
+
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('Accept-Language', 'ja');
+    app(Localization::class)->handle($request, function (): void {});
+
+    $cached = Cache::get('available_language_codes');
+
+    expect($cached)->toBeArray()
+        ->and($cached)->toContain('ja');
+});
+
 test('passes request to next middleware', function (): void {
     $called = false;
     $request = Request::create('/test', 'GET');


### PR DESCRIPTION
## Summary
- Cache language codes as array instead of Collection in `Localization` middleware
- Prevents `__PHP_Incomplete_Class` errors when `serializable_classes=false` (Laravel 13 default)
- Adds test verifying cached value is an array

## Summary by Sourcery

Ensure localization middleware caches available language codes in a serialization-safe format and add coverage around the caching behavior.

Bug Fixes:
- Store cached available language codes as a plain array instead of a Collection to avoid serialization issues with Laravel defaults.

Tests:
- Add a feature test verifying that available language codes are cached as an array and contain the expected language code.