### PR TITLE
Fix NaN in order discount display

### DIFF
--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -1003,10 +1003,10 @@
                                                             $nuxbe.format.money(
                                                                 ($wire.order
                                                                     .total_position_discount_flat ??
-                                                                    0,
+                                                                    0) * -1,
                                                                 {
                                                                     colored: true,
-                                                                }) * -1,
+                                                                },
                                                             )
                                                         "
                                                     ></span>
@@ -1098,10 +1098,10 @@
                                                                 x-html="
                                                                     $nuxbe.format.money(
                                                                         (discount.discount_flat ??
-                                                                            0,
+                                                                            0) * -1,
                                                                         {
                                                                             colored: true,
-                                                                        }) * -1,
+                                                                        },
                                                                     )
                                                                 "
                                                             ></span>
@@ -1150,9 +1150,8 @@
                                                         $nuxbe.format.money(
                                                             ($wire.order
                                                                 .total_discount_flat ??
-                                                                0,
-                                                            { colored: true }) *
-                                                                -1,
+                                                                0) * -1,
+                                                            { colored: true },
                                                         )
                                                     "
                                                 ></span>

--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -1098,7 +1098,8 @@
                                                                 x-html="
                                                                     $nuxbe.format.money(
                                                                         (discount.discount_flat ??
-                                                                            0) * -1,
+                                                                            0) *
+                                                                            -1,
                                                                         {
                                                                             colored: true,
                                                                         },


### PR DESCRIPTION
## Summary
- Fix `* -1` multiplication being applied to formatted HTML string instead of numeric value
- Affected: position discount, per-discount, and total discount display in order detail view
- `$nuxbe.format.money()` returns HTML — multiplying that by -1 produces NaN

## Summary by Sourcery

Bug Fixes:
- Fix NaN appearing in position, per-discount, and total discount fields in the order detail view by ensuring only numeric values are multiplied by -1 before money formatting.