### PR TITLE
Bump spatie/laravel-model-states to ^2.14 for PHP 8.5 compat

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -12,6 +12,7 @@ use FluxErp\Enums\SalutationEnum;
 use FluxErp\Models\Pivots\AddressAddressTypeOrder;
 use FluxErp\States\Address\AdvertisingState;
 use FluxErp\Support\Collection\AddressCollection;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Calendar\HasCalendars;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Communicatable;
@@ -46,7 +47,6 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
-use Spatie\ModelStates\HasStates;
 use Spatie\Permission\Traits\HasRoles;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -8,6 +8,7 @@ use FluxErp\Actions\Lead\UpdateLead;
 use FluxErp\Casts\Money;
 use FluxErp\Contracts\Calendarable;
 use FluxErp\Contracts\Targetable;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Calendar\HasCalendarEvents;
 use FluxErp\Traits\Model\Categorizable;
 use FluxErp\Traits\Model\Commentable;
@@ -28,7 +29,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
-use Spatie\ModelStates\HasStates;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -28,6 +28,7 @@ use FluxErp\States\Order\PaymentState\PartialPaid;
 use FluxErp\States\Order\PaymentState\PaymentState;
 use FluxErp\Support\Calculation\Rounding;
 use FluxErp\Support\Collection\OrderCollection;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\CascadeSoftDeletes;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Communicatable;
@@ -70,7 +71,6 @@ use Illuminate\Support\Number;
 use Illuminate\Support\Traits\Conditionable;
 use RoundingMode;
 use Spatie\MediaLibrary\HasMedia;
-use Spatie\ModelStates\HasStates;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
 class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDataTables, IsSubscribable, OffersPrinting, Targetable

--- a/src/Models/Project.php
+++ b/src/Models/Project.php
@@ -8,6 +8,7 @@ use FluxErp\Casts\TimeDuration;
 use FluxErp\Contracts\Calendarable;
 use FluxErp\Contracts\IsSubscribable;
 use FluxErp\States\Project\ProjectState;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Filterable;
 use FluxErp\Traits\Model\HasPackageFactory;
@@ -27,7 +28,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
-use Spatie\ModelStates\HasStates;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -12,6 +12,7 @@ use FluxErp\Notifications\QueueMonitor\Job\JobStartedNotification;
 use FluxErp\States\QueueMonitor\Failed;
 use FluxErp\States\QueueMonitor\QueueMonitorState;
 use FluxErp\States\QueueMonitor\Succeeded;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\HasFrontendAttributes;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\MonitorsQueue;
@@ -23,7 +24,6 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Context;
-use Spatie\ModelStates\HasStates;
 use Throwable;
 
 class QueueMonitor extends FluxModel

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -12,6 +12,7 @@ use FluxErp\Contracts\Targetable;
 use FluxErp\Models\Pivots\TaskUser;
 use FluxErp\States\Task\TaskState;
 use FluxErp\Support\Scout\ScoutCustomize;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Categorizable;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Filterable;
@@ -32,7 +33,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media as MediaLibraryMedia;
-use Spatie\ModelStates\HasStates;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
 class Task extends FluxModel implements Calendarable, HasMedia, InteractsWithDataTables, IsSubscribable, Targetable

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -7,6 +7,7 @@ use FluxErp\Casts\Money;
 use FluxErp\Contracts\IsSubscribable;
 use FluxErp\States\Ticket\TicketState;
 use FluxErp\Support\Scout\ScoutCustomize;
+use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Communicatable;
 use FluxErp\Traits\Model\Filterable;
@@ -25,7 +26,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
-use Spatie\ModelStates\HasStates;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
 class Ticket extends FluxModel implements HasMedia, InteractsWithDataTables, IsSubscribable

--- a/src/Traits/HasStates.php
+++ b/src/Traits/HasStates.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FluxErp\Traits;
+
+use Spatie\ModelStates\HasStates as BaseHasStates;
+use Spatie\ModelStates\State;
+
+trait HasStates
+{
+    use BaseHasStates;
+
+    public function initializeHasStates(): void
+    {
+        $this->setStateDefaults();
+
+        foreach ($this->getAttributes() as $key => $value) {
+            if (is_string($value) && is_subclass_of($value, State::class)) {
+                $this->attributes[$key] = $value::getMorphClass();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Bump minimum version of `spatie/laravel-model-states` from `^2.4` to `^2.14`
- v2.14.0 fixes a trait binding order bug on PHP 8.5 when states are cast via the `casts()` method
- Resolves `Undefined array key "FluxErp\States\Address\Open"` errors in CI