### PR TITLE
Fix alternating row backgrounds in print templates

### DIFF
--- a/resources/views/components/print/first-page-header.blade.php
+++ b/resources/views/components/print/first-page-header.blade.php
@@ -1,38 +1,61 @@
-<div class="cover-page z-10 h-auto overflow-auto bg-white">
+<div
+    class="cover-page"
+    style="z-index: 10; height: auto; overflow: auto; background: white"
+>
     @section('first-page-logo')
-        <div class="grid h-32 content-center">
-            <div class="m-auto max-h-72 text-center">
+        <div style="display: grid; height: 128px; align-content: center">
+            <div style="margin: auto; max-height: 288px; text-align: center">
                 @if($tenant->logo)
-                    <img class="logo m-auto" src="{{ $tenant->logo }}" />
+                    <img
+                        class="logo"
+                        style="margin: auto"
+                        src="{{ $tenant->logo }}"
+                    />
                 @else
-                    <div class="text-5xl font-semibold">
+                    <div
+                        style="
+                            font-size: 48px;
+                            line-height: 1;
+                            font-weight: 600;
+                        "
+                    >
                         {{ $tenant->name }}
                     </div>
                 @endif
             </div>
         </div>
     @show
-    <table class="w-full">
+    <table style="width: 100%">
         <tr>
-            <td colspan="2" class="text-2xs w-full pt-6 pb-1">
+            <td
+                colspan="2"
+                style="
+                    font-size: 10px;
+                    width: 100%;
+                    padding-top: 24px;
+                    padding-bottom: 4px;
+                "
+            >
                 @section('tenant-address')
                     <div>{{ $tenant->postal_address_one_line }}</div>
                     <div class="black-bar"></div>
                 @show
             </td>
         </tr>
-        <tr class="h-4">
+        <tr style="height: 16px">
             <td colspan="2"></td>
         </tr>
         @section('recipient-address')
             <tr>
-                <td class="w-1/2 align-top">
+                <td style="width: 50%; vertical-align: top">
                     @section('recipient-address.left-block')
                         @if($slot->isNotEmpty())
                             {!! $slot !!}
                         @else
-                            <address class="text-xs not-italic">
-                                <div class="font-semibold">
+                            <address
+                                style="font-size: 12px; font-style: normal"
+                            >
+                                <div style="font-weight: 600">
                                     {{ $address->company ?? '' }}
                                 </div>
                                 <div>
@@ -50,10 +73,15 @@
                         @endif
                     @show
                 </td>
-                <td class="w-1/2 align-top">
+                <td style="width: 50%; vertical-align: top">
                     @section('recipient-address.right-block')
                         <div
-                            class="float-right inline-block max-w-full text-xs"
+                            style="
+                                float: right;
+                                display: inline-block;
+                                max-width: 100%;
+                                font-size: 12px;
+                            "
                         >
                             {{ $rightBlock ?? '' }}
                         </div>
@@ -63,6 +91,15 @@
         @show
     </table>
     @section('first-page-subject')
-        <h1 class="pt-20 text-xl font-semibold">{{ $subject ?? '' }}</h1>
+        <h1
+            style="
+                padding-top: 80px;
+                font-size: 20px;
+                line-height: 28px;
+                font-weight: 600;
+            "
+        >
+            {{ $subject ?? '' }}
+        </h1>
     @show
 </div>

--- a/resources/views/components/print/footer.blade.php
+++ b/resources/views/components/print/footer.blade.php
@@ -1,18 +1,43 @@
-<footer class="fixed h-auto w-full bg-white text-center">
-    <div class="footer-content text-2xs leading-3">
+<footer
+    style="
+        position: fixed;
+        height: auto;
+        width: 100%;
+        background: white;
+        text-align: center;
+    "
+>
+    <div class="footer-content" style="font-size: 10px; line-height: 12px">
         @section('footer.logo')
-            <div class="absolute right-0 left-0 m-auto max-h-32 px-6">
+            <div
+                style="
+                    position: absolute;
+                    right: 0;
+                    left: 0;
+                    margin: auto;
+                    max-height: 128px;
+                    padding-left: 24px;
+                    padding-right: 24px;
+                "
+            >
                 <img
-                    class="logo-small footer-logo m-auto"
+                    class="logo-small footer-logo"
+                    style="margin: auto"
                     src="{{ $tenant->logo_small }}"
                 />
             </div>
         @show
-        <div class="w-full">
-            <div class="border-semi-black border-t">
+        <div style="width: 100%">
+            <div style="border-top: 1px solid #6b7280">
                 @section('footer.tenant-address')
-                    <address class="float-left text-left not-italic">
-                        <div class="font-semibold">
+                    <address
+                        style="
+                            float: left;
+                            text-align: left;
+                            font-style: normal;
+                        "
+                    >
+                        <div style="font-weight: 600">
                             {{ $tenant->name ?? '' }}
                         </div>
                         <div>{{ $tenant->ceo ?? '' }}</div>
@@ -28,8 +53,14 @@
                 @show
                 @section('footer.bank-connections')
                     @foreach($tenant->bankConnections as $bankConnection)
-                        <div class="float-right pl-3 text-left">
-                            <div class="font-semibold">
+                        <div
+                            style="
+                                float: right;
+                                padding-left: 12px;
+                                text-align: left;
+                            "
+                        >
+                            <div style="font-weight: 600">
                                 {{ $bankConnection->bank_name ?? '' }}
                             </div>
                             <div>{{ $bankConnection->iban ?? '' }}</div>
@@ -41,7 +72,7 @@
                     @endforeach
 
                 @show
-                <div class="clear-both"></div>
+                <div style="clear: both"></div>
             </div>
         </div>
     </div>

--- a/resources/views/components/print/header.blade.php
+++ b/resources/views/components/print/header.blade.php
@@ -1,14 +1,41 @@
-<header class="fixed h-auto w-full bg-white text-center font-light">
+<header
+    style="
+        position: fixed;
+        height: auto;
+        width: 100%;
+        background: white;
+        text-align: center;
+        font-weight: 300;
+    "
+>
     <div class="header-content">
         <div>
             @section('subject')
-                <div class="float-left inline-block text-left">
-                    <h2 class="text-xl font-semibold">{{ $subject ?? '' }}</h2>
-                    <div class="page-count text-xs"></div>
+                <div
+                    style="float: left; display: inline-block; text-align: left"
+                >
+                    <h2
+                        style="
+                            font-size: 20px;
+                            line-height: 28px;
+                            font-weight: 600;
+                        "
+                    >
+                        {{ $subject ?? '' }}
+                    </h2>
+                    <div class="page-count" style="font-size: 12px"></div>
                 </div>
             @show
             @section('logo')
-                <div class="float-right inline-block max-h-72 w-44 text-right">
+                <div
+                    style="
+                        float: right;
+                        display: inline-block;
+                        max-height: 288px;
+                        width: 176px;
+                        text-align: right;
+                    "
+                >
                     <img
                         class="logo-small"
                         src="{{ $tenant->logo_small }}"
@@ -16,7 +43,7 @@
                     />
                 </div>
             @show
-            <div class="clear-both"></div>
+            <div style="clear: both"></div>
         </div>
     </div>
 </header>

--- a/resources/views/components/print/order/order-position.blade.php
+++ b/resources/views/components/print/order/order-position.blade.php
@@ -1,9 +1,11 @@
 @use(Illuminate\Support\Facades\Blade; use Illuminate\Support\Number)
 <tbody>
     <tr
-        @if($loop ?? false) @if($loop->odd) style="
-            background: #f2f4f7;
-        " @endif @endif
+        @if($loop ?? false)
+            @if($loop->odd)
+                style="background: #f2f4f7"
+            @endif
+        @endif
     >
         <td
             class="pos"
@@ -28,10 +30,9 @@
                 />
             @endif
 
-            <p style="
-                    font-style: italic;
-                    font-size: 12px;
-                ">{{ $position->product_number }}</p>
+            <p
+                style="font-style: italic; font-size: 12px"
+            >{{ $position->product_number }}</p>
             <p style="font-weight: 600">
                 {{ render_editor_blade($position->name, ['position' => $position]) }}
             </p>

--- a/resources/views/components/print/order/order-position.blade.php
+++ b/resources/views/components/print/order/order-position.blade.php
@@ -1,40 +1,69 @@
 @use(Illuminate\Support\Facades\Blade; use Illuminate\Support\Number)
-<tbody class="bg-uneven">
-    <tr>
-        <td class="pos py-2 pr-8 align-top">
+<tbody>
+    <tr
+        @if($loop ?? false) @if($loop->odd) style="
+            background: #f2f4f7;
+        " @endif @endif
+    >
+        <td
+            class="pos"
+            style="
+                padding-top: 8px;
+                padding-bottom: 8px;
+                padding-right: 32px;
+                vertical-align: top;
+            "
+        >
             {{ $position->total_net_price ? $position->slug_position : '' }}
         </td>
         <td
-            class="py-2 pr-8 align-top"
-            style="padding-left: {{ $position->depth * 15 }}px"
+            style="padding-top: 8px; padding-bottom: 8px; padding-right: 32px; vertical-align: top; padding-left: {{ $position->depth * 15 }}px;"
         >
             @if($position->is_alternative)
                 <x-badge
                     color="amber"
-                    class="mb-2"
+                    style="margin-bottom: 8px"
                     :text="__('Alternative')"
                     position="right"
                 />
             @endif
 
-            <p class="font-italic text-xs">{{ $position->product_number }}</p>
-            <p class="font-semibold">
+            <p style="
+                    font-style: italic;
+                    font-size: 12px;
+                ">{{ $position->product_number }}</p>
+            <p style="font-weight: 600">
                 {{ render_editor_blade($position->name, ['position' => $position]) }}
             </p>
-            <div class="prose-xs">
+            <div style="font-size: 12px; line-height: 16px">
                 {{ render_editor_blade($position->description, ['position' => $position]) }}
             </div>
         </td>
-        <td class="py-2 pr-8 text-center align-top">
+        <td
+            style="
+                padding-top: 8px;
+                padding-bottom: 8px;
+                padding-right: 32px;
+                text-align: center;
+                vertical-align: top;
+            "
+        >
             @if(! $position->is_free_text && ! $position->is_bundle_position)
                 {{ Number::format($position->amount) }}
                 {{ data_get($position, 'product.unit.abbreviation') }}
             @endif
         </td>
-        <td class="py-2 text-right align-top">
+        <td
+            style="
+                padding-top: 8px;
+                padding-bottom: 8px;
+                text-align: right;
+                vertical-align: top;
+            "
+        >
             @if(bccomp($position->total_base_net_price ?? 0, $position->total_net_price ?? 0, 2) === 1)
-                <div class="text-xs whitespace-nowrap">
-                    <div class="line-through">
+                <div style="font-size: 12px; white-space: nowrap">
+                    <div style="text-decoration: line-through">
                         {{ Number::currency($isNet ? $position->total_base_net_price : $position->total_base_gross_price) }}
                     </div>
                     <div>

--- a/resources/views/components/print/order/order.blade.php
+++ b/resources/views/components/print/order/order.blade.php
@@ -1,6 +1,10 @@
 @use(Illuminate\Support\Number)
-<tbody class="bg-uneven">
-    <tr>
+<tbody>
+    <tr
+        @if($loop ?? false) @if($loop->odd) style="
+            background: #f2f4f7;
+        " @endif @endif
+    >
         <td
             class="pos"
             style="padding-top: 16px; padding-bottom: 16px; vertical-align: top"

--- a/resources/views/components/print/order/order.blade.php
+++ b/resources/views/components/print/order/order.blade.php
@@ -1,18 +1,51 @@
 @use(Illuminate\Support\Number)
 <tbody class="bg-uneven">
     <tr>
-        <td class="pos py-4 align-top">{{ $order->order_number }}</td>
-        <td class="py-4 align-top">
+        <td
+            class="pos"
+            style="padding-top: 16px; padding-bottom: 16px; vertical-align: top"
+        >
+            {{ $order->order_number }}
+        </td>
+        <td
+            style="padding-top: 16px; padding-bottom: 16px; vertical-align: top"
+        >
             {{ $order->invoice_date->locale(app()->getLocale())->isoFormat('L') }}
         </td>
-        <td class="pos py-4 align-top">{{ $order->invoice_number }}</td>
-        <td class="py-4 text-right align-top">
+        <td
+            class="pos"
+            style="padding-top: 16px; padding-bottom: 16px; vertical-align: top"
+        >
+            {{ $order->invoice_number }}
+        </td>
+        <td
+            style="
+                padding-top: 16px;
+                padding-bottom: 16px;
+                text-align: right;
+                vertical-align: top;
+            "
+        >
             {{ Number::currency($order->total_gross_price) }}
         </td>
-        <td class="py-4 text-right align-top">
+        <td
+            style="
+                padding-top: 16px;
+                padding-bottom: 16px;
+                text-align: right;
+                vertical-align: top;
+            "
+        >
             {{ Number::currency($order->totalPaid()) }}
         </td>
-        <td class="py-4 text-right align-top">
+        <td
+            style="
+                padding-top: 16px;
+                padding-bottom: 16px;
+                text-align: right;
+                vertical-align: top;
+            "
+        >
             {{ Number::currency($order->balance) }}
         </td>
     </tr>

--- a/resources/views/printing/address/address-label.blade.php
+++ b/resources/views/printing/address/address-label.blade.php
@@ -1,5 +1,5 @@
-<table class="text-2xs w-full" style="page-break-inside: avoid">
-    <tr colspan="100%" class="text-3xs">
+<table style="font-size: 10px; width: 100%; page-break-inside: avoid">
+    <tr colspan="100%" style="font-size: 8px">
         <td>
             @section('tenant_address')
                 {{ $tenant->postal_address_one_line }}
@@ -16,7 +16,14 @@
         </td>
         <td style="text-align: right; vertical-align: top">
             @section('logo')
-                <div class="float-right inline-block max-h-72 text-right">
+                <div
+                    style="
+                        float: right;
+                        display: inline-block;
+                        max-height: 288px;
+                        text-align: right;
+                    "
+                >
                     <img
                         class="logo-small"
                         src="{{ $tenant->logo_small }}"

--- a/resources/views/printing/communication/communication.blade.php
+++ b/resources/views/printing/communication/communication.blade.php
@@ -1,15 +1,15 @@
 <x-flux::print.first-page-header>
     {!! nl2br(implode('<br>', $model->to)) !!}
     <x-slot:right-block>
-        <div class="inline-block">
+        <div style="display: inline-block">
             @section('first-page-right-block')
-                <div class="text-xs">
+                <div style="font-size: 12px">
                     {{ ($model->date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
                 </div>
             @show
         </div>
     </x-slot:right-block>
 </x-flux::print.first-page-header>
-<main class="pt-8">
+<main style="padding-top: 32px">
     <div>{!! $model->html_body ?? $model->text_body !!}</div>
 </main>

--- a/resources/views/printing/contact/balance-statement.blade.php
+++ b/resources/views/printing/contact/balance-statement.blade.php
@@ -3,17 +3,23 @@
     :address="$model->invoiceAddress ?? $model->mainAddress"
 >
     <x-slot:right-block>
-        <div class="inline-block">
+        <div style="display: inline-block">
             @section('first-page-right-block')
-                <div class="inline-block">
+                <div style="display: inline-block">
                     @section('first-page-right-block.labels')
-                        <div class="font-semibold">
+                        <div style="font-weight: 600">
                             {{ __('Customer no.') }}:
                         </div>
-                        <div class="font-semibold">{{ __('Date') }}:</div>
+                        <div style="font-weight: 600">{{ __('Date') }}:</div>
                     @show
                 </div>
-                <div class="inline-block pl-6 text-right">
+                <div
+                    style="
+                        display: inline-block;
+                        padding-left: 24px;
+                        text-align: right;
+                    "
+                >
                     @section('first-page-right-block.values')
                         <div>{{ $model->customer_number }}</div>
                         <div>
@@ -26,29 +32,77 @@
     </x-slot:right-block>
 </x-flux::print.first-page-header>
 <main>
-    <div class="prose-xs pt-10 pb-4">{!! $model->header !!}</div>
-    <div class="pb-6">
+    <div
+        style="
+            font-size: 12px;
+            line-height: 16px;
+            padding-top: 40px;
+            padding-bottom: 16px;
+        "
+    >
+        {!! $model->header !!}
+    </div>
+    <div style="padding-bottom: 24px">
         @section('positions')
-            <table class="w-full table-auto text-xs">
-                <thead class="border-b-2 border-black">
+            <table style="width: 100%; table-layout: auto; font-size: 12px">
+                <thead>
                     @section('positions.header')
                         <tr>
-                            <th class="text-left font-normal">
+                            <th
+                                style="
+                                    text-align: left;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Order no.') }}
                             </th>
-                            <th class="text-left font-normal">
+                            <th
+                                style="
+                                    text-align: left;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Date') }}
                             </th>
-                            <th class="text-left font-normal">
+                            <th
+                                style="
+                                    text-align: left;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Invoice no.') }}
                             </th>
-                            <th class="text-right font-normal uppercase">
+                            <th
+                                style="
+                                    text-align: right;
+                                    font-weight: 400;
+                                    text-transform: uppercase;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Total Gross') }}
                             </th>
-                            <th class="text-right font-normal uppercase">
+                            <th
+                                style="
+                                    text-align: right;
+                                    font-weight: 400;
+                                    text-transform: uppercase;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Payments') }}
                             </th>
-                            <th class="text-right font-semibold uppercase">
+                            <th
+                                style="
+                                    text-align: right;
+                                    font-weight: 600;
+                                    text-transform: uppercase;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Balance') }}
                             </th>
                         </tr>
@@ -63,19 +117,27 @@
             </table>
         @show
     </div>
-    <div class="pb-6">
+    <div style="padding-bottom: 24px">
         @section('total')
-            <table class="w-full">
-                <tbody class="break-inside-avoid">
+            <table style="width: 100%">
+                <tbody style="break-inside: avoid">
                     <tr>
                         <td
                             colspan="3"
-                            class="border-b border-black font-semibold"
+                            style="
+                                border-bottom: 1px solid black;
+                                font-weight: 600;
+                            "
                         >
                             {{ __('Total') }}
                         </td>
                         <td
-                            class="float-right border-b border-black text-right font-semibold"
+                            style="
+                                float: right;
+                                border-bottom: 1px solid black;
+                                text-align: right;
+                                font-weight: 600;
+                            "
                         >
                             {{ Number::currency($model->orders()->unpaid()->sum('balance'),) }}
                         </td>

--- a/resources/views/printing/contact/balance-statement.blade.php
+++ b/resources/views/printing/contact/balance-statement.blade.php
@@ -110,7 +110,10 @@
                 </thead>
                 @section('positions.body')
                     @foreach($model->orders()->unpaid()->get(['id', 'order_number', 'invoice_date', 'invoice_number', 'total_gross_price', 'balance']) as $order)
-                        <x-flux::print.order.order :order="$order" />
+                        <x-flux::print.order.order
+                            :order="$order"
+                            :loop="$loop"
+                        />
                     @endforeach
 
                 @show

--- a/resources/views/printing/order/cancellation-confirmation.blade.php
+++ b/resources/views/printing/order/cancellation-confirmation.blade.php
@@ -6,27 +6,74 @@
     :$model
 >
     <x-slot:right-block>
-        <table class="border-separate border-spacing-x-2">
-            <tbody class="align-text-top text-xs leading-none">
-                <tr class="leading-none">
-                    <td class="py-0 text-left font-semibold">
+        <table style="border-collapse: separate; border-spacing: 8px 0">
+            <tbody
+                style="
+                    vertical-align: text-top;
+                    font-size: 12px;
+                    line-height: 1;
+                "
+            >
+                <tr style="line-height: 1">
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: left;
+                            font-weight: 600;
+                        "
+                    >
                         {{ __('Order no.') }}
                     </td>
-                    <td class="py-0 text-right">{{ $model->order_number }}</td>
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: right;
+                        "
+                    >
+                        {{ $model->order_number }}
+                    </td>
                 </tr>
-                <tr class="leading-none">
-                    <td class="py-0 text-left font-semibold">
+                <tr style="line-height: 1">
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: left;
+                            font-weight: 600;
+                        "
+                    >
                         {{ __('Customer no.') }}
                     </td>
-                    <td class="py-0 text-right">
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: right;
+                        "
+                    >
                         {{ $model->contact()->withTrashed()->value('customer_number') }}
                     </td>
                 </tr>
-                <tr class="leading-none">
-                    <td class="py-0 text-left font-semibold">
+                <tr style="line-height: 1">
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: left;
+                            font-weight: 600;
+                        "
+                    >
                         {{ __('Date') }}
                     </td>
-                    <td class="py-0 text-right">
+                    <td
+                        style="
+                            padding-top: 0;
+                            padding-bottom: 0;
+                            text-align: right;
+                        "
+                    >
                         {{ now()->locale(app()->getLocale())->isoFormat('L') }}
                     </td>
                 </tr>
@@ -34,8 +81,8 @@
         </table>
     </x-slot:right-block>
 </x-flux::print.first-page-header>
-<main class="pt-6">
-    <div class="prose-sm">
+<main style="padding-top: 24px">
+    <div style="font-size: 14px; line-height: 20px">
         {{ render_editor_blade(app(SubscriptionSettings::class)->cancellation_text, ['order' => $model]) }}
     </div>
 </main>

--- a/resources/views/printing/order/delivery-note.blade.php
+++ b/resources/views/printing/order/delivery-note.blade.php
@@ -16,8 +16,8 @@
 
 @section('positions.positions')
     @foreach($model->orderPositions as $position)
-        <tbody class="bg-uneven">
-            <tr>
+        <tbody>
+            <tr @if($loop->odd) style="background: #f2f4f7" @endif>
                 <td
                     class="pos"
                     style="

--- a/resources/views/printing/order/delivery-note.blade.php
+++ b/resources/views/printing/order/delivery-note.blade.php
@@ -2,9 +2,15 @@
 
 @section('positions.header')
     <tr>
-        <th class="pr-8 text-left font-normal">{{ __('Pos.') }}</th>
-        <th class="pr-8 text-left font-normal">{{ __('Name') }}</th>
-        <th class="pr-8 text-center font-normal">{{ __('Amount') }}</th>
+        <th style="padding-right: 32px; text-align: left; font-weight: 400">
+            {{ __('Pos.') }}
+        </th>
+        <th style="padding-right: 32px; text-align: left; font-weight: 400">
+            {{ __('Name') }}
+        </th>
+        <th style="padding-right: 32px; text-align: center; font-weight: 400">
+            {{ __('Amount') }}
+        </th>
     </tr>
 @endsection
 
@@ -12,28 +18,43 @@
     @foreach($model->orderPositions as $position)
         <tbody class="bg-uneven">
             <tr>
-                <td class="pos py-4 pr-8 align-top">
+                <td
+                    class="pos"
+                    style="
+                        padding-top: 16px;
+                        padding-bottom: 16px;
+                        padding-right: 32px;
+                        vertical-align: top;
+                    "
+                >
                     {{ $position->total_net_price ? $position->slug_position : '' }}
                 </td>
                 <td
-                    class="py-4 pr-8 align-top"
-                    style="padding-left: {{ $position->depth * 15 }}px"
+                    style="padding-top: 16px; padding-bottom: 16px; padding-right: 32px; vertical-align: top; padding-left: {{ $position->depth * 15 }}px"
                 >
                     @if($position->is_alternative)
                         <x-badge
                             color="amber"
-                            class="mb-2"
+                            style="margin-bottom: 8px"
                             :text="__('Alternative')"
                             position="right"
                         />
                     @endif
 
-                    <p class="font-italic text-xs">
+                    <p style="font-style: italic; font-size: 12px">
                         {{ $position->product_number }}
                     </p>
-                    <p class="font-semibold">{{ $position->name }}</p>
+                    <p style="font-weight: 600">{{ $position->name }}</p>
                 </td>
-                <td class="py-4 pr-8 text-center align-top">
+                <td
+                    style="
+                        padding-top: 16px;
+                        padding-bottom: 16px;
+                        padding-right: 32px;
+                        text-align: center;
+                        vertical-align: top;
+                    "
+                >
                     {{ Number::format($position->amount) }} {{ data_get($position, 'product.unit.abbreviation') }}
                 </td>
             </tr>

--- a/resources/views/printing/order/final-invoice.blade.php
+++ b/resources/views/printing/order/final-invoice.blade.php
@@ -3,16 +3,16 @@
 @section('first-page-right-block.rows')
     @parent
     <tr>
-        <td class="py-0 text-left font-semibold">{{ __('Invoice Date') }}:</td>
-        <td class="p-0 text-right">
+        <td style="padding-top: 0; padding-bottom: 0; text-align: left; font-weight: 600;">{{ __('Invoice Date') }}:</td>
+        <td style="padding: 0; text-align: right;">
             {{ ($model->invoice_date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
         </td>
     </tr>
     <tr>
-        <td class="py-0 text-left font-semibold">
+        <td style="padding-top: 0; padding-bottom: 0; text-align: left; font-weight: 600;">
             {{ __('Performance Date') }}:
         </td>
-        <td class="p-0 text-right">
+        <td style="padding: 0; text-align: right;">
             @if ($model->system_delivery_date_end && $model->system_delivery_date_end->format('Y-m-d') !== $model->system_delivery_date->format('Y-m-d'))
                 {{ ($model->system_delivery_date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
                 -
@@ -25,19 +25,19 @@
 @endsection
 
 @section('total')
-    <table class="w-full pb-16 text-xs break-inside-avoid" style="page-break-inside: avoid;">
+    <table style="width: 100%; padding-bottom: 64px; font-size: 12px; break-inside: avoid; page-break-inside: avoid;">
         <tbody style="page-break-inside: avoid;">
         <tr>
-            <td colspan="2" class="border-b-2 border-black font-semibold">
+            <td colspan="2" style="border-bottom: 2px solid black; font-weight: 600;">
                 {{ __('Total') }}
             </td>
         </tr>
         @section('total.subtotal')
             <tr>
-                <td class="text-right">
+                <td style="text-align: right;">
                     {{ __('Subtotal net') }}
                 </td>
-                <td class="w-0 whitespace-nowrap pl-12 text-right">
+                <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                     {{ Number::currency($model->subtotal_net_price) }}
                 </td>
             </tr>
@@ -45,7 +45,7 @@
         @section('total.subtotal.vats')
             @foreach ($model->subtotal_vats ?? [] as $subTotalVat)
                 <tr>
-                    <td class="text-right">
+                    <td style="text-align: right;">
                         {{
                             __('Plus :percentage VAT from :total_net', [
                                 'percentage' => Number::percentage(bcmul($subTotalVat['vat_rate_percentage'], 100)),
@@ -53,27 +53,27 @@
                             ])
                         }}
                     </td>
-                    <td class="w-0 whitespace-nowrap pl-12 text-right">
+                    <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                         {{ Number::currency($subTotalVat['total_vat_price']) }}
                     </td>
                 </tr>
-                <tr class="border-b"></tr>
+                <tr><td colspan="2" style="border-bottom: 1px solid black;"></td></tr>
             @endforeach
         @show
         @section('total.children')
             @if ($model->children->isNotEmpty())
                 @foreach ($model->children as $child)
                     <tr>
-                        <td class="text-right font-semibold">
+                        <td style="text-align: right; font-weight: 600;">
                             {{ $child->getLabel() }}
                         </td>
-                        <td class="w-0 whitespace-nowrap pl-12 text-right">
+                        <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                             {{ Number::currency(bcmul($child->total_net_price, '-1')) }}
                         </td>
                     </tr>
                     @foreach ($child->total_vats ?? [] as $childVat)
                         <tr>
-                            <td class="text-right">
+                            <td style="text-align: right;">
                                 {{
                                     __('Plus :percentage VAT from :total_net', [
                                         'percentage' => Number::percentage(bcmul($childVat['vat_rate_percentage'], 100)),
@@ -81,22 +81,22 @@
                                     ])
                                 }}
                             </td>
-                            <td class="w-0 whitespace-nowrap pl-12 text-right">
+                            <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                                 {{ Number::currency(bcmul($childVat['total_vat_price'], '-1')) }}
                             </td>
                         </tr>
                     @endforeach
                 @endforeach
 
-                <tr class="border-b"></tr>
+                <tr><td colspan="2" style="border-bottom: 1px solid black;"></td></tr>
             @endif
         @show
         @section('total.net')
             <tr>
-                <td class="text-right">
+                <td style="text-align: right;">
                     {{ __('Sum net') }}
                 </td>
-                <td class="w-0 whitespace-nowrap pl-12 text-right">
+                <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                     {{ Number::currency($model->total_net_price) }}
                 </td>
             </tr>
@@ -104,7 +104,7 @@
         @section('total.net.vats')
             @foreach ($model->total_vats ?? [] as $totalVat)
                 <tr>
-                    <td class="text-right">
+                    <td style="text-align: right;">
                         {{
                             __('Plus :percentage VAT from :total_net', [
                                 'percentage' => Number::percentage(bcmul($totalVat['vat_rate_percentage'], 100)),
@@ -112,20 +112,20 @@
                             ])
                         }}
                     </td>
-                    <td class="w-0 whitespace-nowrap pl-12 text-right">
+                    <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                         {{ Number::currency($totalVat['total_vat_price']) }}
                     </td>
                 </tr>
             @endforeach
 
-            <tr class="border-b"></tr>
+            <tr><td colspan="2" style="border-bottom: 1px solid black;"></td></tr>
         @show
         @section('total.gross')
-            <tr class="font-bold">
-                <td class="text-right">
+            <tr style="font-weight: 700;">
+                <td style="text-align: right;">
                     {{ __('Total Gross') }}
                 </td>
-                <td class="w-0 whitespace-nowrap pl-12 text-right">
+                <td style="width: 0; white-space: nowrap; padding-left: 48px; text-align: right;">
                     {{ Number::currency($model->total_gross_price) }}
                 </td>
             </tr>

--- a/resources/views/printing/order/invoice.blade.php
+++ b/resources/views/printing/order/invoice.blade.php
@@ -3,16 +3,32 @@
 @section('first-page-right-block.rows')
     @parent
     <tr>
-        <td class="py-0 text-left font-semibold">{{ __('Invoice Date') }}:</td>
-        <td class="p-0 text-right">
+        <td
+            style="
+                padding-top: 0;
+                padding-bottom: 0;
+                text-align: left;
+                font-weight: 600;
+            "
+        >
+            {{ __('Invoice Date') }}:
+        </td>
+        <td style="padding: 0; text-align: right">
             {{ ($model->invoice_date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
         </td>
     </tr>
     <tr>
-        <td class="py-0 text-left font-semibold">
+        <td
+            style="
+                padding-top: 0;
+                padding-bottom: 0;
+                text-align: left;
+                font-weight: 600;
+            "
+        >
             {{ __('Performance Date') }}:
         </td>
-        <td class="p-0 text-right">
+        <td style="padding: 0; text-align: right">
             @if($model->system_delivery_date_end && $model->system_delivery_date_end->format('Y-m-d') !== $model->system_delivery_date->format('Y-m-d'))
                 {{ ($model->system_delivery_date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
                 -

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -194,6 +194,7 @@
                         <x-flux::print.order.order-position
                             :position="$position"
                             :is-net="$isNet"
+                            :loop="$loop"
                         />
                     @endforeach
 

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -13,39 +13,97 @@
     >
         <x-slot:right-block>
             @section('first-page-right-block')
-                <table class="border-separate border-spacing-x-2">
-                    <tbody class="align-text-top text-xs leading-none">
+                <table style="border-collapse: separate; border-spacing: 8px 0">
+                    <tbody
+                        style="
+                            vertical-align: text-top;
+                            font-size: 12px;
+                            line-height: 1;
+                        "
+                    >
                         @section('first-page-right-block.rows')
-                            <tr class="leading-none">
-                                <td class="py-0 text-left font-semibold">
+                            <tr style="line-height: 1">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: left;
+                                        font-weight: 600;
+                                    "
+                                >
                                     {{ __('Order no.') }}
                                 </td>
-                                <td class="py-0 text-right">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: right;
+                                    "
+                                >
                                     {{ $model->order_number }}
                                 </td>
                             </tr>
-                            <tr class="leading-none">
-                                <td class="py-0 text-left font-semibold">
+                            <tr style="line-height: 1">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: left;
+                                        font-weight: 600;
+                                    "
+                                >
                                     {{ __('Customer no.') }}
                                 </td>
-                                <td class="py-0 text-right">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: right;
+                                    "
+                                >
                                     {{ $model->contact()->withTrashed()->value('customer_number') }}
                                 </td>
                             </tr>
-                            <tr class="leading-none">
-                                <td class="py-0 text-left font-semibold">
+                            <tr style="line-height: 1">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: left;
+                                        font-weight: 600;
+                                    "
+                                >
                                     {{ __('Order Date') }}
                                 </td>
-                                <td class="py-0 text-right">
+                                <td
+                                    style="
+                                        padding-top: 0;
+                                        padding-bottom: 0;
+                                        text-align: right;
+                                    "
+                                >
                                     {{ $model->order_date->locale(app()->getLocale())->isoFormat('L') }}
                                 </td>
                             </tr>
                             @if($model->commission)
-                                <tr class="leading-none">
-                                    <td class="py-0 text-left font-semibold">
+                                <tr style="line-height: 1">
+                                    <td
+                                        style="
+                                            padding-top: 0;
+                                            padding-bottom: 0;
+                                            text-align: left;
+                                            font-weight: 600;
+                                        "
+                                    >
                                         {{ __('Commission') }}
                                     </td>
-                                    <td class="py-0 text-right">
+                                    <td
+                                        style="
+                                            padding-top: 0;
+                                            padding-bottom: 0;
+                                            text-align: right;
+                                        "
+                                    >
                                         {{ $model->commission }}
                                     </td>
                                 </tr>
@@ -60,29 +118,72 @@
 @show
 <main>
     @section('header')
-        <div class="prose-xs pt-10 pb-4">
+        <div
+            style="
+                font-size: 12px;
+                line-height: 16px;
+                padding-top: 40px;
+                padding-bottom: 16px;
+            "
+        >
             {{ render_editor_blade($model->header, ['order' => $model]) }}
             @if($model->orderType?->document_header)
                 {{ render_editor_blade($model->orderType->document_header, ['order' => $model]) }}
             @endif
         </div>
     @show
-    <div class="pb-6">
+    <div style="padding-bottom: 24px">
         @section('positions')
-            <table class="w-full table-auto text-xs">
-                <thead class="border-b-2 border-black">
+            <table style="width: 100%; table-layout: auto; font-size: 12px">
+                <thead>
                     @section('positions.header')
-                        <tr class="py-2">
-                            <th class="py-2 pr-8 text-left font-normal">
+                        <tr style="padding-top: 8px; padding-bottom: 8px">
+                            <th
+                                style="
+                                    padding-top: 8px;
+                                    padding-bottom: 8px;
+                                    padding-right: 32px;
+                                    text-align: left;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Pos.') }}
                             </th>
-                            <th class="py-2 pr-8 text-left font-normal">
+                            <th
+                                style="
+                                    padding-top: 8px;
+                                    padding-bottom: 8px;
+                                    padding-right: 32px;
+                                    text-align: left;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Name') }}
                             </th>
-                            <th class="py-2 pr-8 text-center font-normal">
+                            <th
+                                style="
+                                    padding-top: 8px;
+                                    padding-bottom: 8px;
+                                    padding-right: 32px;
+                                    text-align: center;
+                                    font-weight: 400;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Amount') }}
                             </th>
-                            <th class="py-2 text-right font-normal uppercase">
+                            <th
+                                style="
+                                    padding-top: 8px;
+                                    padding-bottom: 8px;
+                                    text-align: right;
+                                    font-weight: 400;
+                                    text-transform: uppercase;
+                                    border-bottom: 2px solid black;
+                                "
+                            >
                                 {{ __('Sum') }}
                             </th>
                         </tr>
@@ -102,13 +203,16 @@
     </div>
     @if($summary)
         @section('summary')
-            <div class="pb-6">
-                <table class="w-full text-xs">
-                    <tbody class="break-inside-avoid">
+            <div style="padding-bottom: 24px">
+                <table style="width: 100%; font-size: 12px">
+                    <tbody style="break-inside: avoid">
                         <tr>
                             <td
                                 colspan="3"
-                                class="border-b border-black font-semibold"
+                                style="
+                                    border-bottom: 1px solid black;
+                                    font-weight: 600;
+                                "
                             >
                                 {{ __('Summary') }}
                             </td>
@@ -116,10 +220,10 @@
                         @foreach($summary as $summaryItem)
                             <tr>
                                 <td>{{ $summaryItem->slug_position }}</td>
-                                <td class="whitespace-nowrap">
+                                <td style="white-space: nowrap">
                                     {{ $summaryItem->name }}
                                 </td>
-                                <td class="float-right text-right">
+                                <td style="float: right; text-align: right">
                                     {{ Number::currency($summaryItem->total_net_price ?? 0) }}
                                 </td>
                             </tr>
@@ -132,14 +236,19 @@
 
     @section('total')
         <table
-            class="w-full break-inside-avoid pb-16 text-xs"
-            style="page-break-inside: avoid"
+            style="
+                width: 100%;
+                break-inside: avoid;
+                padding-bottom: 64px;
+                font-size: 12px;
+                page-break-inside: avoid;
+            "
         >
             <tbody style="page-break-inside: avoid">
                 <tr>
                     <td
                         colspan="2"
-                        class="border-b-2 border-black font-semibold"
+                        style="border-bottom: 2px solid black; font-weight: 600"
                     >
                         {{ __('Total') }}
                     </td>
@@ -147,34 +256,51 @@
                 @section('total.discounts')
                     @if(bccomp($model->total_base_net_price ?? 0, $model->total_net_price ?? 0) !== 0)
                         <tr>
-                            <td class="text-right">
+                            <td style="text-align: right">
                                 {{ __('Sum net without discount') }}
                             </td>
-                            <td class="w-0 pl-12 text-right whitespace-nowrap">
+                            <td
+                                style="
+                                    width: 0;
+                                    padding-left: 48px;
+                                    text-align: right;
+                                    white-space: nowrap;
+                                "
+                            >
                                 {{ Number::currency($model->total_base_net_price) }}
                             </td>
                         </tr>
                         @if(bccomp($model->total_position_discount_percentage ?? 0, 0) !== 0)
                             <tr>
-                                <td class="text-right">
+                                <td style="text-align: right">
                                     <span>{{ __('Position discounts') }}</span>
                                     <span>
                                         {{ Number::percentage(bcmul($model->total_position_discount_percentage ?? 0, 100), maxPrecision: 2) }}
                                     </span>
                                 </td>
                                 <td
-                                    class="w-0 pl-12 text-right whitespace-nowrap"
+                                    style="
+                                        width: 0;
+                                        padding-left: 48px;
+                                        text-align: right;
+                                        white-space: nowrap;
+                                    "
                                 >
                                     {{ Number::currency(bcmul($model->total_position_discount_flat ?? 0, -1)) }}
                                 </td>
                             </tr>
                             @if($model->discounts->isNotEmpty())
                                 <tr>
-                                    <td class="text-right">
+                                    <td style="text-align: right">
                                         {{ __('Sum net discounted') }}
                                     </td>
                                     <td
-                                        class="w-0 pl-12 text-right whitespace-nowrap"
+                                        style="
+                                            width: 0;
+                                            padding-left: 48px;
+                                            text-align: right;
+                                            white-space: nowrap;
+                                        "
                                     >
                                         {{ Number::currency($model->total_base_discounted_net_price ?? 0) }}
                                     </td>
@@ -183,7 +309,7 @@
                         @endif
                         @foreach($model->discounts as $discount)
                             <tr>
-                                <td class="text-right">
+                                <td style="text-align: right">
                                     <span>
                                         {{ data_get($discount, 'name', __('Head discount')) }}
                                     </span>
@@ -192,20 +318,37 @@
                                     </span>
                                 </td>
                                 <td
-                                    class="w-0 pl-12 text-right whitespace-nowrap"
+                                    style="
+                                        width: 0;
+                                        padding-left: 48px;
+                                        text-align: right;
+                                        white-space: nowrap;
+                                    "
                                 >
                                     {{ Number::currency(bcmul(data_get($discount, 'discount_flat', 0), -1)) }}
                                 </td>
                             </tr>
                         @endforeach
-                        <tr class="border-b"></tr>
+                        <tr>
+                            <td
+                                colspan="2"
+                                style="border-bottom: 1px solid black"
+                            ></td>
+                        </tr>
                     @endif
 
                 @show
                 @section('total.net')
                     <tr>
-                        <td class="text-right">{{ __('Sum net') }}</td>
-                        <td class="w-0 pl-12 text-right whitespace-nowrap">
+                        <td style="text-align: right">{{ __('Sum net') }}</td>
+                        <td
+                            style="
+                                width: 0;
+                                padding-left: 48px;
+                                text-align: right;
+                                white-space: nowrap;
+                            "
+                        >
                             {{ Number::currency($model->total_net_price) }}
                         </td>
                     </tr>
@@ -213,7 +356,7 @@
                 @section('total.vats')
                     @foreach($model->total_vats ?? [] as $vat)
                         <tr>
-                            <td class="text-right">
+                            <td style="text-align: right">
                                 {{
                             __('Plus :percentage VAT from :total_net', [
                                 'percentage' => Number::percentage(bcmul($vat['vat_rate_percentage'], 100), maxPrecision: 2),
@@ -221,7 +364,14 @@
                             ])
                         }}
                             </td>
-                            <td class="w-0 pl-12 text-right whitespace-nowrap">
+                            <td
+                                style="
+                                    width: 0;
+                                    padding-left: 48px;
+                                    text-align: right;
+                                    white-space: nowrap;
+                                "
+                            >
                                 {{ Number::currency($vat['total_vat_price']) }}
                             </td>
                         </tr>
@@ -229,9 +379,18 @@
 
                 @show
                 @section('total.gross')
-                    <tr class="font-bold">
-                        <td class="text-right">{{ __('Total Gross') }}</td>
-                        <td class="w-0 pl-12 text-right whitespace-nowrap">
+                    <tr style="font-weight: 700">
+                        <td style="text-align: right">
+                            {{ __('Total Gross') }}
+                        </td>
+                        <td
+                            style="
+                                width: 0;
+                                padding-left: 48px;
+                                text-align: right;
+                                white-space: nowrap;
+                            "
+                        >
                             {{ Number::currency($model->total_gross_price) }}
                         </td>
                     </tr>
@@ -240,7 +399,7 @@
         </table>
     @show
     @section('footer')
-        <div class="prose-xs break-inside-avoid">
+        <div style="font-size: 12px; line-height: 16px; break-inside: avoid">
             {{ render_editor_blade($model->footer, ['order' => $model]) }}
             @if($model->orderType?->document_footer)
                 {{ render_editor_blade($model->orderType->document_footer, ['order' => $model]) }}

--- a/resources/views/printing/order/refund.blade.php
+++ b/resources/views/printing/order/refund.blade.php
@@ -2,16 +2,34 @@
 @section('first-page-right-block.rows')
     @parent
     <tr>
-        <td class="py-0 text-left font-semibold">{{ __('Refund Date') }}:</td>
-        <td class="py-0 text-right">
+        <td
+            style="
+                padding-top: 0;
+                padding-bottom: 0;
+                text-align: left;
+                font-weight: 600;
+            "
+        >
+            {{ __('Refund Date') }}:
+        </td>
+        <td style="padding-top: 0; padding-bottom: 0; text-align: right">
             {{ ($model->invoice_date ?: now())->locale(app()->getLocale())->isoFormat('L') }}
         </td>
     </tr>
     <tr>
-        <td class="py-0 text-left font-semibold">
+        <td
+            style="
+                padding-top: 0;
+                padding-bottom: 0;
+                text-align: left;
+                font-weight: 600;
+            "
+        >
             {{ __('Related Invoice Number') }}:
         </td>
-        <td class="py-0 text-right">{{ $model->parent?->invoice_number }}</td>
+        <td style="padding-top: 0; padding-bottom: 0; text-align: right">
+            {{ $model->parent?->invoice_number }}
+        </td>
     </tr>
 @endsection
 

--- a/resources/views/printing/sepa-mandate/sepa-mandate.blade.php
+++ b/resources/views/printing/sepa-mandate/sepa-mandate.blade.php
@@ -1,50 +1,50 @@
 <x-flux::print.first-page-header :address="$model->contact->mainAddress" />
-<main class="pt-6">
+<main style="padding-top: 24px">
     <div>
         {{ __('Creditor Identifier') }}
-        <span class="font-semibold">
+        <span style="font-weight: 600">
             {{ $model->tenant->creditor_identifier }}
         </span>
     </div>
     <div>
         {{ __('Mandate Reference Number') }}
-        <span class="font-semibold">
+        <span style="font-weight: 600">
             {{ $model->mandate_reference_number }}
         </span>
     </div>
-    <div class="py-4">
+    <div style="padding-top: 16px; padding-bottom: 16px">
         {!! $model->sepa_mandate_type_enum === \FluxErp\Enums\SepaMandateTypeEnum::BASIC ? $tenant->sepa_text_basic : $tenant->sepa_text_b2b !!}
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('Account Holder') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('Account Holder') }}:</span>
         <span>{{ $model->contactBankConnection?->account_holder }}</span>
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('Street') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('Street') }}:</span>
         <span>{{ $model->contact->mainAddress->street }}</span>
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('Zip / City') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('Zip / City') }}:</span>
         <span>
             {{ $model->contact->mainAddress->zip . ' ' . $model->contact->mainAddress->city }}
         </span>
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('Bank Name') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('Bank Name') }}:</span>
         <span>{{ $model->contactBankConnection?->bank_name }}</span>
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('BIC') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('BIC') }}:</span>
         <span>{{ $model->contactBankConnection?->bic }}</span>
     </div>
-    <div class="pt-4">
-        <span class="font-semibold">{{ __('IBAN') }}:</span>
+    <div style="padding-top: 16px">
+        <span style="font-weight: 600">{{ __('IBAN') }}:</span>
         <span>{{ $model->contactBankConnection?->iban }}</span>
     </div>
-    <div class="pt-4 font-semibold">
+    <div style="padding-top: 16px; font-weight: 600">
         {{ __('Date, Location and Signature') }}
     </div>
-    <div class="mt-8 max-w-sm">
-        <hr class="border-black" />
+    <div style="margin-top: 32px; max-width: 384px">
+        <hr style="border: 0; border-top: 1px solid black" />
     </div>
 </main>


### PR DESCRIPTION
## Summary
- Pass `$loop` variable to print components for odd/even row detection
- Replace `bg-uneven` CSS class with inline `background: #f2f4f7` style
- Fixes missing alternating row backgrounds in dompdf output

## Summary by Sourcery

Ensure print templates render consistently in DOMPDF and restore alternating row backgrounds for tabular data.

Bug Fixes:
- Restore alternating row striping in order position and balance statement tables by using the Blade loop state instead of the removed CSS class.

Enhancements:
- Replace Tailwind and utility classes with inline styles across print headers, footers, order documents, and SEPA templates to improve PDF rendering consistency and compatibility.
- Standardize typography, spacing, and table layout in print views for orders, invoices, delivery notes, balance statements, address labels, and communications.