### PR TITLE
Fix alternating row backgrounds in print templates

### DIFF
--- a/resources/views/components/print/order/order.blade.php
+++ b/resources/views/components/print/order/order.blade.php
@@ -1,6 +1,12 @@
 @use(Illuminate\Support\Number)
-<tbody class="bg-uneven">
-    <tr>
+<tbody>
+    <tr
+        @if($loop ?? false)
+            @if($loop->odd)
+                style="background: #f2f4f7"
+            @endif
+        @endif
+    >
         <td
             class="pos"
             style="padding-top: 16px; padding-bottom: 16px; vertical-align: top"

--- a/resources/views/printing/contact/balance-statement.blade.php
+++ b/resources/views/printing/contact/balance-statement.blade.php
@@ -110,7 +110,10 @@
                 </thead>
                 @section('positions.body')
                     @foreach($model->orders()->unpaid()->get(['id', 'order_number', 'invoice_date', 'invoice_number', 'total_gross_price', 'balance']) as $order)
-                        <x-flux::print.order.order :order="$order" />
+                        <x-flux::print.order.order
+                            :order="$order"
+                            :loop="$loop"
+                        />
                     @endforeach
 
                 @show

--- a/resources/views/printing/order/delivery-note.blade.php
+++ b/resources/views/printing/order/delivery-note.blade.php
@@ -16,8 +16,8 @@
 
 @section('positions.positions')
     @foreach($model->orderPositions as $position)
-        <tbody class="bg-uneven">
-            <tr>
+        <tbody>
+            <tr @if($loop->odd) style="background: #f2f4f7" @endif>
                 <td
                     class="pos"
                     style="

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -194,6 +194,7 @@
                         <x-flux::print.order.order-position
                             :position="$position"
                             :is-net="$isNet"
+                            :loop="$loop"
                         />
                     @endforeach
 


### PR DESCRIPTION
## Summary
- Pass `$loop` variable to print components for odd/even row detection
- Replace `bg-uneven` CSS class with inline `background: #f2f4f7` style
- Fixes missing alternating row backgrounds in dompdf output

## Summary by Sourcery

Fix alternating row background styling in print order templates to restore odd/even striping in printed and dompdf outputs.

Bug Fixes:
- Restore alternating row backgrounds for order rows in dompdf and printed outputs by basing styling on the Blade loop index instead of the removed bg-uneven class.

Enhancements:
- Pass the Blade loop context into reusable print order components so they can apply odd/even row-specific styling inline.