### PR TITLE
Fix paragraph margins and table borders in print templates

### DIFF
--- a/resources/views/components/print/order/order-position.blade.php
+++ b/resources/views/components/print/order/order-position.blade.php
@@ -31,9 +31,14 @@
             @endif
 
             <p
-                style="font-style: italic; font-size: 12px"
+                style="
+                    font-style: italic;
+                    font-size: 12px;
+                    margin: 0;
+                    padding: 0;
+                "
             >{{ $position->product_number }}</p>
-            <p style="font-weight: 600">
+            <p style="font-weight: 600; margin: 0; padding: 0">
                 {{ render_editor_blade($position->name, ['position' => $position]) }}
             </p>
             <div style="font-size: 12px; line-height: 16px">

--- a/resources/views/printing/contact/balance-statement.blade.php
+++ b/resources/views/printing/contact/balance-statement.blade.php
@@ -44,7 +44,14 @@
     </div>
     <div style="padding-bottom: 24px">
         @section('positions')
-            <table style="width: 100%; table-layout: auto; font-size: 12px">
+            <table
+                style="
+                    width: 100%;
+                    table-layout: auto;
+                    font-size: 12px;
+                    border-collapse: collapse;
+                "
+            >
                 <thead>
                     @section('positions.header')
                         <tr>
@@ -122,7 +129,7 @@
     </div>
     <div style="padding-bottom: 24px">
         @section('total')
-            <table style="width: 100%">
+            <table style="width: 100%; border-collapse: collapse">
                 <tbody style="break-inside: avoid">
                     <tr>
                         <td

--- a/resources/views/printing/order/delivery-note.blade.php
+++ b/resources/views/printing/order/delivery-note.blade.php
@@ -41,10 +41,19 @@
                         />
                     @endif
 
-                    <p style="font-style: italic; font-size: 12px">
+                    <p
+                        style="
+                            font-style: italic;
+                            font-size: 12px;
+                            margin: 0;
+                            padding: 0;
+                        "
+                    >
                         {{ $position->product_number }}
                     </p>
-                    <p style="font-weight: 600">{{ $position->name }}</p>
+                    <p
+                        style="font-weight: 600; margin: 0; padding: 0"
+                    >{{ $position->name }}</p>
                 </td>
                 <td
                     style="

--- a/resources/views/printing/order/final-invoice.blade.php
+++ b/resources/views/printing/order/final-invoice.blade.php
@@ -25,7 +25,7 @@
 @endsection
 
 @section('total')
-    <table style="width: 100%; padding-bottom: 64px; font-size: 12px; break-inside: avoid; page-break-inside: avoid;">
+    <table style="width: 100%; padding-bottom: 64px; font-size: 12px; border-collapse: collapse; break-inside: avoid; page-break-inside: avoid;">
         <tbody style="page-break-inside: avoid;">
         <tr>
             <td colspan="2" style="border-bottom: 2px solid black; font-weight: 600;">

--- a/resources/views/printing/order/order.blade.php
+++ b/resources/views/printing/order/order.blade.php
@@ -134,7 +134,14 @@
     @show
     <div style="padding-bottom: 24px">
         @section('positions')
-            <table style="width: 100%; table-layout: auto; font-size: 12px">
+            <table
+                style="
+                    width: 100%;
+                    table-layout: auto;
+                    font-size: 12px;
+                    border-collapse: collapse;
+                "
+            >
                 <thead>
                     @section('positions.header')
                         <tr style="padding-top: 8px; padding-bottom: 8px">
@@ -205,7 +212,13 @@
     @if($summary)
         @section('summary')
             <div style="padding-bottom: 24px">
-                <table style="width: 100%; font-size: 12px">
+                <table
+                    style="
+                        width: 100%;
+                        font-size: 12px;
+                        border-collapse: collapse;
+                    "
+                >
                     <tbody style="break-inside: avoid">
                         <tr>
                             <td
@@ -239,6 +252,7 @@
         <table
             style="
                 width: 100%;
+                border-collapse: collapse;
                 break-inside: avoid;
                 padding-bottom: 64px;
                 font-size: 12px;


### PR DESCRIPTION
## Summary
- Add `margin: 0; padding: 0` to `<p>` tags in order-position and delivery-note templates
- Add `border-collapse: collapse` to all print tables to remove white cell borders in dompdf

## Summary by Sourcery

Normalize print template styling for order-related documents to improve layout consistency in generated PDFs.

Bug Fixes:
- Remove default paragraph margins and padding in order position and delivery note print views to prevent unintended spacing in PDFs.
- Apply border-collapse to print tables across order, balance statement, and invoice templates to eliminate white gaps between table cells in PDF output.