### PR TITLE
Fix TallStackUI v3 config keys and z-index hierarchy

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -40,9 +40,9 @@
     @show
     @persist('notifications')
         @if(auth()->check() && auth()->id())
-            <x-toast z-index="z-50" />
+            <x-toast />
         @endif
-        <x-dialog z-index="z-40" blur="md" align="center" />
+        <x-dialog />
     @endpersist
 
     @auth('web')

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -2,7 +2,7 @@
     class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8"
     x-data
 >
-    <x-toast z-index="z-50"></x-toast>
+    <x-toast />
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
         <x-flux::logo fill="#0690FA" class="h-24" />
     </div>

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -227,14 +227,14 @@ class FluxServiceProvider extends ServiceProvider
 
     protected function registerConfig(): void
     {
-        $tsComponents = config('ts-ui.components');
-        data_set($tsComponents, 'toast.1.z-index', 'z-50');
-        data_set($tsComponents, 'toast.1.timeout', 5);
-        data_set($tsComponents, 'dialog.1.z-index', 'z-40');
-        data_set($tsComponents, 'dialog.1.blur', 'md');
-        data_set($tsComponents, 'modal.1.z-index', 'z-30');
-        data_set($tsComponents, 'slide.1.z-index', 'z-30');
-        config(['ts-ui.components' => $tsComponents]);
+        config([
+            'ts-ui.components.toast.1.z-index' => 'z-50',
+            'ts-ui.components.toast.1.timeout' => 5,
+            'ts-ui.components.dialog.1.z-index' => 'z-40',
+            'ts-ui.components.dialog.1.blur' => 'md',
+            'ts-ui.components.modal.1.z-index' => 'z-30',
+            'ts-ui.components.slide.1.z-index' => 'z-30',
+        ]);
 
         $this->booted(function (): void {
             config(['permission.models.role' => resolve_static(Role::class, 'class')]);

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -227,14 +227,16 @@ class FluxServiceProvider extends ServiceProvider
 
     protected function registerConfig(): void
     {
+        $tsComponents = config('ts-ui.components');
+        data_set($tsComponents, 'toast.1.z-index', 'z-50');
+        data_set($tsComponents, 'toast.1.timeout', 5);
+        data_set($tsComponents, 'dialog.1.z-index', 'z-40');
+        data_set($tsComponents, 'dialog.1.blur', 'md');
+        data_set($tsComponents, 'modal.1.z-index', 'z-30');
+        data_set($tsComponents, 'slide.1.z-index', 'z-30');
+        config(['ts-ui.components' => $tsComponents]);
+
         $this->booted(function (): void {
-            config([
-                'tallstackui.settings.toast.z-index' => 'z-50',
-                'tallstackui.settings.toast.timeout' => 5,
-                'tallstackui.settings.dialog.z-index' => 'z-40',
-                'tallstackui.settings.modal.z-index' => 'z-30',
-                'tallstackui.settings.slide.z-index' => 'z-30',
-            ]);
             config(['permission.models.role' => resolve_static(Role::class, 'class')]);
             config(['permission.models.permission' => resolve_static(Permission::class, 'class')]);
             config(['permission.display_permission_in_exception' => true]);


### PR DESCRIPTION
## Summary
- Update TallStackUI config overrides from deprecated `tallstackui.settings.*` to `ts-ui.components.*` (v3 format)
- Move config overrides from `booted()` to `registerConfig()` so they run before TallStackUI's static cache is built in `boot()`
- Remove dead `z-index`, `blur`, `align` attributes from `<x-toast>` and `<x-dialog>` (no longer constructor params in v3)
- Add dialog `blur` setting to config overrides

## Summary by Sourcery

Update TallStackUI v3 component configuration usage and clean up deprecated view attributes.

Enhancements:
- Switch TallStackUI configuration overrides to the new ts-ui.components structure and apply them during registerConfig so they take effect before static caching.
- Remove now-unused z-index, blur, and align attributes from toast and dialog Blade components in favor of centralized configuration.