### PR TITLE
Log activity when data export is started

### DIFF
--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -26,6 +26,18 @@ class ExportDataTableJob implements ShouldQueue
 
     public function handle(): void
     {
+        $user = morph_to($this->userMorph);
+
+        activity()
+            ->causedBy($user)
+            ->withProperties([
+                'model' => $this->modelClass,
+                'columns' => $this->columns,
+            ])
+            ->useLog('export')
+            ->event('export_started')
+            ->log(morph_alias($this->modelClass) . ' export started');
+
         $query = invade(unserialize($this->component))->buildSearch();
 
         $fileName = morph_alias($this->modelClass) . '_' . now()->toDateTimeLocalString('minute') . '.xlsx';
@@ -43,7 +55,6 @@ class ExportDataTableJob implements ShouldQueue
             $filePath
         );
 
-        $user = morph_to($this->userMorph);
         $user->notify(ExportReady::make($filePath, morph_alias($this->modelClass)));
     }
 }

--- a/tests/Unit/Livewire/DataTable/ExportTest.php
+++ b/tests/Unit/Livewire/DataTable/ExportTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use FluxErp\Jobs\ExportDataTableJob;
+use FluxErp\Models\Tenant;
 use FluxErp\Notifications\ExportReady;
 use FluxErp\Tests\Unit\Livewire\DataTable\ExportTestDataTable;
 use Illuminate\Support\Facades\Notification;
@@ -50,7 +51,7 @@ test('export logs activity', function (): void {
 
     $job = new ExportDataTableJob(
         serialize(Livewire::test(ExportTestDataTable::class)->instance()),
-        \FluxErp\Models\Tenant::class,
+        Tenant::class,
         [],
         $this->user->getMorphClass() . ':' . $this->user->getKey()
     );
@@ -64,7 +65,7 @@ test('export logs activity', function (): void {
         ->causer_id->toBe($this->user->getKey())
         ->log_name->toBe('export')
         ->and($activity->properties->toArray())->toMatchArray([
-            'model' => \FluxErp\Models\Tenant::class,
+            'model' => Tenant::class,
             'columns' => [],
         ]);
 });

--- a/tests/Unit/Livewire/DataTable/ExportTest.php
+++ b/tests/Unit/Livewire/DataTable/ExportTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
+use Spatie\Activitylog\Models\Activity;
 use function Livewire\invade;
 
 test('can export data', function (): void {
@@ -42,4 +43,28 @@ test('can export data', function (): void {
             return true;
         }
     );
+});
+
+test('export logs activity', function (): void {
+    Storage::fake(config('filesystems.default'));
+
+    $job = new ExportDataTableJob(
+        serialize(Livewire::test(ExportTestDataTable::class)->instance()),
+        \FluxErp\Models\Tenant::class,
+        [],
+        $this->user->getMorphClass() . ':' . $this->user->getKey()
+    );
+
+    $job->handle();
+
+    $activity = Activity::query()->where('event', 'export_started')->latest()->first();
+
+    expect($activity)
+        ->not->toBeNull()
+        ->causer_id->toBe($this->user->getKey())
+        ->log_name->toBe('export')
+        ->and($activity->properties->toArray())->toMatchArray([
+            'model' => \FluxErp\Models\Tenant::class,
+            'columns' => [],
+        ]);
 });


### PR DESCRIPTION
## Summary
- Add activity logging to `ExportDataTableJob` tracking user, exported model, and selected columns
- Log entry created at export start with log name `export` and event `export_started`
- Add test verifying activity is logged with correct causer, log name, and properties

## Summary by Sourcery

Log export start activity when running data table exports and verify it via tests.

New Features:
- Record an activity entry when a data table export job starts, including user, model, and selected columns.

Tests:
- Add a unit test ensuring an export_started activity is logged with the correct causer, log name, and properties.