### PR TITLE
allow full retoures on final invoices

### DIFF
--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -105,6 +105,7 @@
                             :order-id="$orderId"
                             :already-taken-positions="array_column($replicateOrder->order_positions, 'id')"
                             :type="$type"
+                            :count-only="$countOnly"
                             wire:model="selectedPositions"
                             lazy
                         />

--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -288,7 +288,7 @@ class ReplicateOrder extends FluxAction
                 ];
             }
 
-            // Disallow creation of split-orders if parent order has an invoice_number
+            // Disallow creation of split-orders if order has an invoice_number
             if ($parentOrder->invoice_number
                 && resolve_static(OrderType::class, 'query')
                     ->whereKey($this->getData('order_type_id'))

--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -278,12 +278,40 @@ class ReplicateOrder extends FluxAction
         }
 
         if ($parentId = $this->getData('parent_id')) {
-            if (resolve_static(Order::class, 'query')
+            $parentOrder = resolve_static(Order::class, 'query')
                 ->whereKey($parentId)
-                ->value('tenant_id') !== $tenantId
-            ) {
+                ->first(['id', 'order_type_id', 'parent_id', 'tenant_id', 'invoice_number']);
+
+            if ($parentOrder->tenant_id !== $tenantId) {
                 $errors += [
                     'parent_id' => ['Parent order not found on given tenant.'],
+                ];
+            }
+
+            // Disallow creation of split-orders if parent order has an invoice_number
+            if ($parentOrder->invoice_number
+                && resolve_static(OrderType::class, 'query')
+                    ->whereKey($this->getData('order_type_id'))
+                    ->where('order_type_enum', OrderTypeEnum::SplitOrder->value)
+                    ->exists()
+            ) {
+                $errors += [
+                    'order_type_id' => ['Unable to create split-order, order has an invoice number.'],
+                ];
+            }
+
+            // Disallow creation of retoures on split-orders if parent order has an invoice_number
+            if ($parentOrder->orderType->order_type_enum === OrderTypeEnum::SplitOrder
+                && $parentOrder->parent->invoice_number
+                && resolve_static(OrderType::class, 'query')
+                    ->whereKey($this->getData('order_type_id'))
+                    ->where('order_type_enum', OrderTypeEnum::Retoure->value)
+                    ->exists()
+            ) {
+                $errors += [
+                    'order_type_id' => [
+                        'Unable to create a retoure on given split-order, parent order has an invoice number.',
+                    ],
                 ];
             }
         }

--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -300,9 +300,14 @@ class ReplicateOrder extends FluxAction
                 ];
             }
 
-            // Disallow creation of retoures on split-orders if parent order has an invoice_number
-            if ($parentOrder->orderType->order_type_enum === OrderTypeEnum::SplitOrder
-                && $parentOrder->parent->invoice_number
+            // Disallow creation of retoures if order doesn't have an invoice number
+            // or on split-orders if parent order has an invoice_number
+            if (
+                (
+                    ! $parentOrder->invoice_number
+                    || $parentOrder->orderType->order_type_enum === OrderTypeEnum::SplitOrder
+                    && $parentOrder->parent->invoice_number
+                )
                 && resolve_static(OrderType::class, 'query')
                     ->whereKey($this->getData('order_type_id'))
                     ->where('order_type_enum', OrderTypeEnum::Retoure->value)
@@ -310,7 +315,7 @@ class ReplicateOrder extends FluxAction
             ) {
                 $errors += [
                     'order_type_id' => [
-                        'Unable to create a retoure on given split-order, parent order has an invoice number.',
+                        'Unable to create a retoure on given order.',
                     ],
                 ];
             }

--- a/src/Actions/OrderPosition/CreateOrderPosition.php
+++ b/src/Actions/OrderPosition/CreateOrderPosition.php
@@ -216,23 +216,40 @@ class CreateOrderPosition extends FluxAction
                         'origin_position_id' => ['Order position does not exists in parent order.'],
                     ];
                 } else {
+                    $only = [];
+                    if ($order->orderType->order_type_enum === OrderTypeEnum::Retoure
+                        && $order->parent->invoice_number
+                        && $order->parent->orderType->order_type_enum === OrderTypeEnum::Order
+                    ) {
+                        $only = array_merge(
+                            [$order->getKey()],
+                            resolve_static(Order::class, 'query')
+                                ->join('order_types AS ot', 'ot.id', '=', 'orders.order_type_id')
+                                ->where('orders.parent_id', $order->getKey())
+                                ->where('ot.order_type_enum', OrderTypeEnum::Retoure->value)
+                                ->pluck('orders.id')
+                                ->toArray()
+                        );
+                    }
+
                     $maxAmount = data_get(
                         array_find(
                             $this->calculateMaxAmounts(
                                 DB::select(
                                     'WITH RECURSIVE siblings AS (
-                                    SELECT id, origin_position_id, signed_amount
-                                    FROM order_positions
-                                    WHERE id = ' . $originPositionId
-                                    . ' AND order_id = ' . $order->parent_id
-                                    . ' AND deleted_at IS NULL'
-                                    . ' UNION ALL
-                                    SELECT op.id, op.origin_position_id, op.signed_amount
-                                    FROM order_positions op
-                                    INNER JOIN siblings s ON s.id = op.origin_position_id
-                                    WHERE op.deleted_at IS NULL
-                                )
-                                SELECT * FROM siblings'
+                                        SELECT id, origin_position_id, signed_amount
+                                        FROM order_positions
+                                        WHERE id = ' . $originPositionId
+                                        . ' AND order_id = ' . $order->parent_id
+                                        . ' AND deleted_at IS NULL'
+                                        . ' UNION ALL
+                                        SELECT op.id, op.origin_position_id, op.signed_amount
+                                        FROM order_positions op
+                                        INNER JOIN siblings s ON s.id = op.origin_position_id
+                                        WHERE op.deleted_at IS NULL'
+                                    . ($only ? ' AND op.order_id IN (' . implode(',', $only) . ')' : '')
+                                    . ')
+                                    SELECT * FROM siblings'
                                 )
                             ),
                             fn (array $value) => $value['id'] === $originPositionId

--- a/src/Livewire/Order/CreateChildOrder.php
+++ b/src/Livewire/Order/CreateChildOrder.php
@@ -41,6 +41,9 @@ class CreateChildOrder extends Component
     #[Url]
     public ?string $type = null;
 
+    #[Locked]
+    public array $countOnly = [];
+
     public function mount(): void
     {
         $parentOrder = resolve_static(Order::class, 'query')
@@ -87,6 +90,21 @@ class CreateChildOrder extends Component
 
         if (count($this->availableOrderTypes) === 1) {
             $this->replicateOrder->order_type_id = data_get($this->availableOrderTypes, '0.id');
+        }
+
+        if (
+            $parentOrder->orderType->order_type_enum === OrderTypeEnum::Order
+            && $parentOrder->invoice_number
+        ) {
+            $this->countOnly = array_merge(
+                [$this->orderId],
+                resolve_static(Order::class, 'query')
+                    ->join('order_types AS ot', 'ot.id', '=', 'orders.order_type_id')
+                    ->where('orders.parent_id', $this->orderId)
+                    ->where('ot.order_type_enum', OrderTypeEnum::Retoure->value)
+                    ->pluck('orders.id')
+                    ->toArray()
+            );
         }
     }
 
@@ -214,8 +232,9 @@ class CreateChildOrder extends Component
                     SELECT op.id, op.origin_position_id, op.signed_amount
                     FROM order_positions op
                     INNER JOIN siblings s ON s.id = op.origin_position_id
-                    WHERE op.deleted_at IS NULL
-                )
+                    WHERE op.deleted_at IS NULL'
+                . ($this->countOnly ? ' AND op.order_id IN (' . implode(',', $this->countOnly) . ')' : '')
+                . ')
                 SELECT * FROM siblings'
             )
         );

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -469,7 +469,14 @@ class Order extends Component
                             ->where('order_type_enum', OrderTypeEnum::Retoure->value)
                             ->where('is_active', true)
                             ->whereHasTenant($this->order->tenant_id)
-                            ->exists();
+                            ->exists()
+                        && (
+                            ! $this->order->parent_id
+                            || resolve_static(OrderModel::class, 'query')
+                                ->whereKey($this->order->parent_id)
+                                ->whereNull('invoice_number')
+                                ->exists()
+                        );
                 })
                 ->attributes([
                     'class' => 'w-full',

--- a/src/Livewire/Order/ReplicateOrderPositionList.php
+++ b/src/Livewire/Order/ReplicateOrderPositionList.php
@@ -48,6 +48,9 @@ class ReplicateOrderPositionList extends OrderPositionList
 
     public bool $orderAsc = true;
 
+    #[Locked]
+    public array $countOnly = [];
+
     protected function getSelectedActions(): array
     {
         return [];
@@ -118,8 +121,9 @@ class ReplicateOrderPositionList extends OrderPositionList
                         SELECT op.id, op.origin_position_id, op.signed_amount
                         FROM order_positions op
                         INNER JOIN siblings s ON s.id = op.origin_position_id
-                        WHERE op.deleted_at IS NULL
-                    )
+                        WHERE op.deleted_at IS NULL'
+                    . ($this->countOnly ? ' AND op.order_id IN (' . implode(',', $this->countOnly) . ')' : '')
+                    . ')
                     SELECT * FROM siblings'
                 )
             )
@@ -137,7 +141,10 @@ class ReplicateOrderPositionList extends OrderPositionList
             // Real positions also checked by signed_amount
             if (! data_get($item, 'is_free_text') && ! data_get($item, 'is_bundle_position')) {
                 $totalAmount = data_get(
-                    array_find($maxAmounts, fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')),
+                    array_find(
+                        $maxAmounts,
+                        fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')
+                    ),
                     'signed_amount'
                 );
 
@@ -187,7 +194,10 @@ class ReplicateOrderPositionList extends OrderPositionList
 
             if (! data_get($item, 'is_free_text') && ! data_get($item, 'is_bundle_position')) {
                 $totalAmount = data_get(
-                    array_find($maxAmounts, fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')),
+                    array_find(
+                        $maxAmounts,
+                        fn (array $value): bool => data_get($value, 'id') === data_get($item, 'id')
+                    ),
                     'signed_amount'
                 );
             }


### PR DESCRIPTION
## Summary by Sourcery

Allow full retoures on fully invoiced orders while tightening validation and UI constraints around split orders and retoure creation.

New Features:
- Support counting retoure quantities across the original order and existing retoures when validating and selecting order positions for new retoures.

Bug Fixes:
- Prevent creation of split orders from invoiced parent orders.
- Prevent creation of retoures on split orders whose parent order is already invoiced.
- Restrict availability of the retoure action on child orders whose parent has an invoice.