### PR TITLE
Fix currency display in order positions

### DIFF
--- a/resources/js/nuxbe/format.js
+++ b/resources/js/nuxbe/format.js
@@ -36,10 +36,10 @@ function getLocale() {
 
 function getCurrencyCode() {
     return (
+        document.body?.dataset?.currencyCode ||
         document
             .querySelector('meta[name="currency-code"]')
             ?.getAttribute('content') ||
-        document.body?.dataset?.currencyCode ||
         'EUR'
     );
 }

--- a/src/Livewire/Order/OrderPositions.php
+++ b/src/Livewire/Order/OrderPositions.php
@@ -370,7 +370,7 @@ class OrderPositions extends OrderPositionList
 
     public function getBuilder(Builder $builder): Builder
     {
-        return $builder->where('order_id', $this->order->id)->reorder('slug_position');
+        return $builder->where('order_id', $this->order->id)->with('currency')->reorder('slug_position');
     }
 
     public function getFormatters(): array

--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -497,6 +497,22 @@ test('augmentItemArray injects order currency for money formatter', function ():
         ->and($itemArray['currency']['iso'])->toBe('USD');
 });
 
+test('money columns are formatted with order currency not default EUR', function (): void {
+    $usdCurrency = Currency::factory()->create(['iso' => 'USD', 'name' => 'US Dollar']);
+    $this->order->update(['currency_id' => $usdCurrency->getKey()]);
+    $this->order->orderPositions()->update(['unit_net_price' => 10, 'total_net_price' => 10]);
+    $this->orderForm->fill($this->order->fresh(['currency']));
+
+    $component = Livewire::test(OrderPositions::class, ['order' => $this->orderForm]);
+    $data = $component->instance()->getDataForTesting();
+
+    $unitNetPrice = $data['data'][0]['unit_net_price'];
+    $formatted = is_array($unitNetPrice) ? $unitNetPrice['display'] : $unitNetPrice;
+
+    expect($formatted)->not->toContain('€')
+        ->and($formatted)->toContain('$');
+});
+
 test('listeners configuration', function (): void {
     $component = Livewire::test(OrderPositions::class, ['order' => $this->orderForm]);
     $listeners = $component->instance()->getListeners();


### PR DESCRIPTION
## Summary
- Eager-load `currency` relation in `OrderPositions::getBuilder()` so the `MoneyFormatter` receives the correct currency ISO code instead of falling back to EUR
- Fix priority in `getCurrencyCode()` JS helper: page-specific `document.body.dataset.currencyCode` now takes precedence over the global `<meta name="currency-code">` tag

## Summary by Sourcery

Ensure order position monetary values and frontend currency formatting use the correct order-specific currency instead of defaulting to EUR.

Bug Fixes:
- Load the currency relation when building order positions so money fields are formatted with the order’s currency.
- Adjust the JavaScript currency code resolution to prioritize page-specific currency data attributes over the global meta tag.

Tests:
- Add a Livewire order positions test verifying that money columns render with the order currency symbol instead of the EUR default.