### PR TITLE
Remove HasStates workaround for spatie 2.14.1

### DIFF
--- a/src/Traits/HasStates.php
+++ b/src/Traits/HasStates.php
@@ -3,20 +3,8 @@
 namespace FluxErp\Traits;
 
 use Spatie\ModelStates\HasStates as BaseHasStates;
-use Spatie\ModelStates\State;
 
 trait HasStates
 {
     use BaseHasStates;
-
-    public function initializeHasStates(): void
-    {
-        $this->setStateDefaults();
-
-        foreach ($this->getAttributes() as $key => $value) {
-            if (is_string($value) && is_subclass_of($value, State::class)) {
-                $this->attributes[$key] = $value::getMorphClass();
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Remove the `initializeHasStates` override in `HasStates` trait that worked around a PHP 8.5 regression in spatie/laravel-model-states 2.14.0
- spatie/laravel-model-states 2.14.1 (released today) fixes this upstream: spatie/laravel-model-states#308
- Requires `composer update spatie/laravel-model-states` on deploy

## Summary by Sourcery

Enhancements:
- Rely on the upstream HasStates behavior by dropping the local initializeHasStates override that worked around an earlier framework regression.