### PR TITLE
fix: use duration formatter for millisecond columns

### DIFF
--- a/src/Livewire/DataTables/CommunicationList.php
+++ b/src/Livewire/DataTables/CommunicationList.php
@@ -18,7 +18,7 @@ class CommunicationList extends BaseDataTable
     ];
 
     public array $formatters = [
-        'total_time_ms' => 'time',
+        'total_time_ms' => 'duration',
         'started_at' => 'datetime',
         'ended_at' => 'datetime',
     ];

--- a/src/Livewire/DataTables/WorkTimeList.php
+++ b/src/Livewire/DataTables/WorkTimeList.php
@@ -19,8 +19,8 @@ class WorkTimeList extends BaseDataTable
     ];
 
     public array $formatters = [
-        'total_time_ms' => 'time',
-        'paused_time_ms' => 'time',
+        'total_time_ms' => 'duration',
+        'paused_time_ms' => 'duration',
         'started_at' => 'datetime',
         'ended_at' => 'datetime',
     ];


### PR DESCRIPTION
## Summary
- Replace `'time'` with `'duration'` formatter for `total_time_ms` and `paused_time_ms` in WorkTimeList and CommunicationList
- The `'time'` formatter treated millisecond duration values as Unix timestamps, producing nonsensical time displays
- Requires tall-datatables >= 2.4.8 which adds the `DurationFormatter`

## Summary by Sourcery

Bug Fixes:
- Correct display of total and paused millisecond durations in work time and communication lists by formatting them as durations rather than Unix timestamps.