### PR TITLE
Fix tabs Livewire hook leak after wire:navigate

### DIFF
--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -16,14 +16,17 @@
             this.tabSelected = this.tab = tabButton.dataset.tabName
         },
         init() {
-            Livewire.hook('commit', ({ succeed }) => {
+            this._unhookCommit = Livewire.hook('commit', ({ succeed }) => {
                 succeed(() => {
                     this.$refs.tabButtons
-                        .querySelectorAll('.animate-pulse')
+                        ?.querySelectorAll('.animate-pulse')
                         .forEach(btn => btn.classList.remove('animate-pulse'))
                     this.loadingTab = null
                 })
             })
+        },
+        destroy() {
+            this._unhookCommit?.()
         },
     }"
     wire:ignore


### PR DESCRIPTION
## Summary
- Clean up `Livewire.hook('commit')` registered in the tabs component by storing the unhook function and calling it in `destroy()`
- The global hook persisted after `wire:navigate` destroyed the component, causing `Cannot read properties of undefined (reading 'querySelectorAll')` errors when the succeed callback fired for other components' commits

## Summary by Sourcery

Bug Fixes:
- Ensure the tabs component unregisters its Livewire commit hook on destroy to avoid accessing DOM references after the component is removed.