### PR TITLE
Fix flux-confirm showing undefined when no description given

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -116,9 +116,7 @@ Livewire.directive('flux-confirm', ({ el, directive, component }) => {
     let message = directive.expression.replaceAll('\\n', '\n').split('|');
     let title = message.shift();
     let description =
-        '<div>' +
-        message[0] +
-        '</div>' +
+        (message[0] ? '<div>' + message[0] + '</div>' : '') +
         (promptAppend ? '<div>' + promptAppend + '</div>' : '');
     let cancelLabel = message[1] ?? 'Cancel';
     let confirmLabel = message[2] ?? 'Confirm';


### PR DESCRIPTION
## Summary
- Fix `wire:flux-confirm` rendering the literal string "undefined" as description when no pipe separator is used in the expression
- `message[0]` is `undefined` after shifting the title from a single-segment string, now only wraps in `<div>` if a description actually exists

## Summary by Sourcery

Bug Fixes:
- Avoid renderering the literal string "undefined" as the confirmation description when the directive expression omits a description segment.