### PR TITLE
Move promptValue to $nuxbe namespace for Livewire v4

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -138,7 +138,7 @@ Livewire.directive('flux-confirm', ({ el, directive, component }) => {
     };
 });
 
-window.$promptValue = (id) => {
+window.$nuxbe.promptValue = (id) => {
     const el = document.getElementById(id ? id : 'prompt-value');
 
     if (el.type === 'checkbox') {

--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -137,13 +137,3 @@ Livewire.directive('flux-confirm', ({ el, directive, component }) => {
             .send();
     };
 });
-
-window.$nuxbe.promptValue = (id) => {
-    const el = document.getElementById(id ? id : 'prompt-value');
-
-    if (el.type === 'checkbox') {
-        return el.checked;
-    }
-
-    return el.value;
-};

--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -1,7 +1,17 @@
 import * as format from './nuxbe/format.js';
 import { parseNumber, openDetailModal } from './nuxbe/utils.js';
 
-const nuxbe = { format, parseNumber, openDetailModal };
+function promptValue(id) {
+    const el = document.getElementById(id ? id : 'prompt-value');
+
+    if (el.type === 'checkbox') {
+        return el.checked;
+    }
+
+    return el.value;
+}
+
+const nuxbe = { format, parseNumber, openDetailModal, promptValue };
 
 window.$nuxbe = nuxbe;
 

--- a/resources/views/components/address/address.blade.php
+++ b/resources/views/components/address/address.blade.php
@@ -388,7 +388,7 @@
                                         sm
                                         icon="plus"
                                         color="emerald"
-                                        wire:click="addTag($promptValue())"
+                                        wire:click="addTag($nuxbe.promptValue())"
                                         wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                                     />
                                 @endcanAction

--- a/resources/views/components/product/general.blade.php
+++ b/resources/views/components/product/general.blade.php
@@ -222,7 +222,7 @@
                             sm
                             icon="plus"
                             color="emerald"
-                            wire:click="addTag($promptValue())"
+                            wire:click="addTag($nuxbe.promptValue())"
                             wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                         />
                     @endcanAction

--- a/resources/views/components/task/general.blade.php
+++ b/resources/views/components/task/general.blade.php
@@ -265,7 +265,7 @@
                                     sm
                                     icon="plus"
                                     color="emerald"
-                                    wire:click="addTag($promptValue())"
+                                    wire:click="addTag($nuxbe.promptValue())"
                                     wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                                 />
                             @endcanAction

--- a/resources/views/livewire/features/communications/communication.blade.php
+++ b/resources/views/livewire/features/communications/communication.blade.php
@@ -376,7 +376,7 @@
                                 sm
                                 icon="plus"
                                 color="emerald"
-                                wire:click="addTag($promptValue())"
+                                wire:click="addTag($nuxbe.promptValue())"
                                 wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                             />
                         @endcanAction

--- a/resources/views/livewire/lead/general.blade.php
+++ b/resources/views/livewire/lead/general.blade.php
@@ -286,7 +286,7 @@
                                     sm
                                     icon="plus"
                                     color="emerald"
-                                    wire:click="addTag($promptValue())"
+                                    wire:click="addTag($nuxbe.promptValue())"
                                     wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                                 />
                             @endcanAction

--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -253,7 +253,7 @@
                                 class="w-full"
                                 icon="plus"
                                 :text="__('Add')"
-                                wire:click="addFavorite(window.location.pathname + window.location.search, $promptValue())"
+                                wire:click="addFavorite(window.location.pathname + window.location.search, $nuxbe.promptValue())"
                                 wire:flux-confirm.prompt="{{  __('New Favorite') }}||{{  __('Cancel') }}|{{  __('Save') }}"
                             />
                         </div>

--- a/resources/views/livewire/settings/mail-accounts.blade.php
+++ b/resources/views/livewire/settings/mail-accounts.blade.php
@@ -194,7 +194,7 @@
                     spinner
                     :text="__('Send test mail')"
                     wire:flux-confirm.prompt="{{  __('Send test mail to') }}||{{  __('Cancel') }}|{{  __('Send') }}"
-                    wire:click="sendTestMail($promptValue())"
+                    wire:click="sendTestMail($nuxbe.promptValue())"
                 />
             </x-slot>
         </x-card>

--- a/resources/views/livewire/settings/plugins.blade.php
+++ b/resources/views/livewire/settings/plugins.blade.php
@@ -336,7 +336,7 @@
                                 <x-button
                                     color="emerald"
                                     :text="__('Install')"
-                                    wire:click="install(key, $promptValue('delete-data'))"
+                                    wire:click="install(key, $nuxbe.promptValue('delete-data'))"
                                 />
                             </div>
                         @endif
@@ -346,7 +346,7 @@
                                 <x-button
                                     color="red"
                                     :text="__('Uninstall')"
-                                    wire:click="uninstall(key, $promptValue('delete-data'))"
+                                    wire:click="uninstall(key, $nuxbe.promptValue('delete-data'))"
                                     wire:flux-confirm.type.error.id.uninstall="{{ __('wire:confirm.uninstall-plugin') }}"
                                 />
                             </div>

--- a/resources/views/livewire/task/task.blade.php
+++ b/resources/views/livewire/task/task.blade.php
@@ -192,7 +192,7 @@
                                     sm
                                     icon="plus"
                                     color="emerald"
-                                    wire:click="addTag($promptValue())"
+                                    wire:click="addTag($nuxbe.promptValue())"
                                     wire:flux-confirm.prompt="{{ __('New Tag') }}||{{ __('Cancel') }}|{{ __('Save') }}"
                                 />
                             @endcanAction


### PR DESCRIPTION
## Summary
- Move `window.$promptValue()` to `$nuxbe.promptValue()` for Livewire v4 compatibility
- In Livewire v4, `$`-prefixed variables in `wire:click` expressions are resolved as Alpine/Livewire magics, not window globals — causing "Converting circular structure to JSON" errors
- `$nuxbe` is already registered as an Alpine magic, so `$nuxbe.promptValue()` works in both Alpine and Livewire expression contexts
- Updated all 10 occurrences across 9 blade files

## Summary by Sourcery

Update prompt value handling to use the $nuxbe namespace for Livewire v4 compatibility and consistent Alpine/Livewire expression support.

Bug Fixes:
- Prevent Livewire v4 expression resolution errors by avoiding use of $promptValue as a window-global in wire:click bindings.

Enhancements:
- Expose promptValue via the existing $nuxbe Alpine magic to unify prompt access across Livewire and Alpine contexts.