### PR TITLE
adjust ReplicateOrder validation to prevent unwanted creation of chil…

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2702,6 +2702,8 @@
     "Type to search for products…": "Produkte suchen…",
     "Unable to clear email while 'can_login' = 'true'": "Die E-Mail kann nicht gelöscht werden, solange 'can_login' = 'true' ist.",
     "Unable to clear password while 'can_login' = 'true'": "Das Passwort kann nicht gelöscht werden, solange 'can_login' = 'true' ist.",
+    "Unable to create a retoure or refund on given parent order.": "Erstellen einer Retoure oder Gutschrift zum gegebenen Auftrag nicht möglich.",
+    "Unable to create split-order on given parent order.": "Erstellen eines Teilauftrags zum gegebenen Auftrag nicht möglich.",
     "Unassigned Contacts": "Nicht zugewiesene Kontakte",
     "Unassigned Leads": "Nicht zugeordnete Leads",
     "Unassigned payments": "Nicht zugeordnete Zahlungen",

--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -242,9 +242,10 @@ class ReplicateOrder extends FluxAction
         parent::validateData();
 
         $errors = [];
-        $tenantId = resolve_static(Order::class, 'query')
+        $order = resolve_static(Order::class, 'query')
             ->whereKey($this->getData('id'))
-            ->value('tenant_id');
+            ->first(['id', 'contact_id', 'tenant_id']);
+        $tenantId = $order->tenant_id;
         $hasTenants = [
             'contact_id' => Contact::class,
             'address_invoice_id' => Address::class,
@@ -277,7 +278,20 @@ class ReplicateOrder extends FluxAction
             }
         }
 
-        if ($parentId = $this->getData('parent_id')) {
+        $parentId = $this->getData('parent_id');
+        $orderTypeEnum = resolve_static(OrderType::class, 'query')
+            ->whereKey($this->getData('order_type_id'))
+            ->value('order_type_enum');
+
+        if (
+            ! $parentId
+            && $order->contact_id === ($this->getData('contact_id') ?? $order->contact_id)
+            && in_array($orderTypeEnum, [OrderTypeEnum::SplitOrder, OrderTypeEnum::Retoure])
+        ) {
+            $parentId = $order->getKey();
+        }
+
+        if ($parentId) {
             $parentOrder = resolve_static(Order::class, 'query')
                 ->whereKey($parentId)
                 ->with([
@@ -291,12 +305,8 @@ class ReplicateOrder extends FluxAction
                 ];
             }
 
-            $orderType = resolve_static(OrderType::class, 'query')
-                ->whereKey($this->getData('order_type_id'))
-                ->first(['id', 'order_type_enum']);
-
             // Disallow creation of split-orders if order has an invoice_number
-            if ($orderType->order_type_enum === OrderTypeEnum::SplitOrder
+            if ($orderTypeEnum === OrderTypeEnum::SplitOrder
                 && (
                     $parentOrder->orderType->order_type_enum !== OrderTypeEnum::Order
                     || $parentOrder->invoice_number
@@ -308,7 +318,7 @@ class ReplicateOrder extends FluxAction
             }
 
             // Disallow creation of retoures/refunds if order doesn't have an invoice number
-            if (in_array($orderType->order_type_enum, [OrderTypeEnum::Retoure, OrderTypeEnum::Refund])
+            if (in_array($orderTypeEnum, [OrderTypeEnum::Retoure, OrderTypeEnum::Refund])
                 && (
                     ! in_array(
                         $parentOrder->orderType->order_type_enum,

--- a/src/Actions/Order/ReplicateOrder.php
+++ b/src/Actions/Order/ReplicateOrder.php
@@ -278,12 +278,47 @@ class ReplicateOrder extends FluxAction
         }
 
         if ($parentId = $this->getData('parent_id')) {
-            if (resolve_static(Order::class, 'query')
+            $parentOrder = resolve_static(Order::class, 'query')
                 ->whereKey($parentId)
-                ->value('tenant_id') !== $tenantId
-            ) {
+                ->with([
+                    'orderType:id,order_type_enum',
+                ])
+                ->first(['id', 'order_type_id', 'parent_id', 'tenant_id', 'invoice_number']);
+
+            if ($parentOrder->tenant_id !== $tenantId) {
                 $errors += [
                     'parent_id' => ['Parent order not found on given tenant.'],
+                ];
+            }
+
+            $orderType = resolve_static(OrderType::class, 'query')
+                ->whereKey($this->getData('order_type_id'))
+                ->first(['id', 'order_type_enum']);
+
+            // Disallow creation of split-orders if order has an invoice_number
+            if ($orderType->order_type_enum === OrderTypeEnum::SplitOrder
+                && (
+                    $parentOrder->orderType->order_type_enum !== OrderTypeEnum::Order
+                    || $parentOrder->invoice_number
+                )
+            ) {
+                $errors += [
+                    'order_type_id' => ['Unable to create split-order on given parent order.'],
+                ];
+            }
+
+            // Disallow creation of retoures/refunds if order doesn't have an invoice number
+            if (in_array($orderType->order_type_enum, [OrderTypeEnum::Retoure, OrderTypeEnum::Refund])
+                && (
+                    ! in_array(
+                        $parentOrder->orderType->order_type_enum,
+                        [OrderTypeEnum::Order, OrderTypeEnum::SplitOrder]
+                    )
+                    || ! $parentOrder->invoice_number
+                )
+            ) {
+                $errors += [
+                    'order_type_id' => ['Unable to create a retoure or refund on given parent order.'],
                 ];
             }
         }

--- a/tests/Feature/Actions/Order/ReplicateOrderTest.php
+++ b/tests/Feature/Actions/Order/ReplicateOrderTest.php
@@ -719,7 +719,9 @@ test('returned split order makes amount available again for original', function 
         ->execute();
 
     $splitOrder->refresh();
-    $splitOrder->update(['invoice_number' => $splitOrder->getSerialNumber('invoice_number')]);
+    $splitOrder
+        ->getSerialNumber('invoice_number')
+        ->save();
     $splitPosition = $splitOrder->orderPositions->first();
 
     // Verify split order has correct origin_position_id and amounts
@@ -890,7 +892,9 @@ test('partially returned split order reduces available amount proportionally', f
         ->execute();
 
     $splitOrder->refresh();
-    $splitOrder->update(['invoice_number' => $this->getSerialNumber('invoice_number')]);
+    $splitOrder
+        ->getSerialNumber('invoice_number')
+        ->save();
     $splitPosition = $splitOrder->orderPositions->first();
 
     // Step 3: Create partial retoure of the split order (return only 3 items)

--- a/tests/Feature/Actions/Order/ReplicateOrderTest.php
+++ b/tests/Feature/Actions/Order/ReplicateOrderTest.php
@@ -15,6 +15,7 @@ use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
 use FluxErp\Models\VatRate;
 use FluxErp\Models\Warehouse;
+use Illuminate\Support\Str;
 
 test('copies position discounts when creating retoure', function (): void {
     // Arrange: Create an order with a position that has a discount
@@ -51,6 +52,7 @@ test('copies position discounts when creating retoure', function (): void {
         'payment_type_id' => $paymentType->getKey(),
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -125,6 +127,7 @@ test('copies order-level discounts when creating retoure', function (): void {
         'payment_type_id' => $paymentType->getKey(),
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -210,6 +213,7 @@ test('preserves implicit discounts when position has zero total but no discount_
         'payment_type_id' => $paymentType->getKey(),
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -299,6 +303,7 @@ test('retoure total equals negative of original total', function (): void {
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -395,6 +400,7 @@ test('handles vat rate mix correctly when creating retoure', function (): void {
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -512,6 +518,7 @@ test('preserves discounts when creating split order', function (): void {
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => null,
         'is_locked' => true,
     ]);
 
@@ -671,6 +678,7 @@ test('returned split order makes amount available again for original', function 
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => null,
         'is_locked' => true,
     ]);
 
@@ -711,6 +719,7 @@ test('returned split order makes amount available again for original', function 
         ->execute();
 
     $splitOrder->refresh();
+    $splitOrder->update(['invoice_number' => $splitOrder->getSerialNumber('invoice_number')]);
     $splitPosition = $splitOrder->orderPositions->first();
 
     // Verify split order has correct origin_position_id and amounts
@@ -840,6 +849,7 @@ test('partially returned split order reduces available amount proportionally', f
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => null,
         'is_locked' => true,
     ]);
 
@@ -880,6 +890,7 @@ test('partially returned split order reduces available amount proportionally', f
         ->execute();
 
     $splitOrder->refresh();
+    $splitOrder->update(['invoice_number' => $this->getSerialNumber('invoice_number')]);
     $splitPosition = $splitOrder->orderPositions->first();
 
     // Step 3: Create partial retoure of the split order (return only 3 items)
@@ -999,6 +1010,7 @@ test('direct retoure still reduces available amount to zero', function (): void 
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
         'shipping_costs_net_price' => 0,
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 
@@ -1194,6 +1206,7 @@ test('does not set parent_id when creating refund', function (): void {
         'payment_type_id' => $paymentType->getKey(),
         'price_list_id' => $priceList->getKey(),
         'tenant_id' => $this->dbTenant->getKey(),
+        'invoice_number' => Str::random(),
         'is_locked' => true,
     ]);
 

--- a/tests/Livewire/Order/CreateChildOrderTest.php
+++ b/tests/Livewire/Order/CreateChildOrderTest.php
@@ -15,6 +15,7 @@ use FluxErp\Models\Product;
 use FluxErp\Models\Unit;
 use FluxErp\Models\VatRate;
 use FluxErp\Models\Warehouse;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -119,7 +120,7 @@ test('can render retoure creation', function (): void {
 
 test('can render split order creation', function (): void {
     // Split orders can only be created from non-invoiced orders
-    $this->parentOrder->update(['invoice_date' => null]);
+    $this->parentOrder->update(['invoice_number' => null]);
 
     $component = Livewire::test(CreateChildOrder::class, [
         'orderId' => $this->parentOrder->id,
@@ -135,6 +136,7 @@ test('can render split order creation', function (): void {
 });
 
 test('can save retoure', function (): void {
+    $this->parentOrder->update(['invoice_number' => Str::random()]);
     $orderPosition = $this->parentOrder->orderPositions()->first();
 
     $component = Livewire::test(CreateChildOrder::class, [
@@ -159,7 +161,7 @@ test('can save retoure', function (): void {
 
 test('can save split order', function (): void {
     // Split orders can only be created from non-invoiced orders
-    $this->parentOrder->update(['invoice_date' => null]);
+    $this->parentOrder->update(['invoice_number' => null]);
 
     $orderPosition = $this->parentOrder->orderPositions()->first();
 


### PR DESCRIPTION
…d orders

## Summary by Sourcery

Tighten child order creation validation to restrict split orders and retour/refund orders based on the parent order’s type and invoicing state.

Bug Fixes:
- Prevent creation of split orders from invoiced or non-standard parent orders.
- Prevent creation of retoure and refund orders from parent orders without an invoice or with an incompatible order type.

Enhancements:
- Load parent order and order type details during replication validation to support more robust business rules around child order creation.

Tests:
- Adjust child order creation tests to use invoice_number and cover the new validation rules for split, retoure, and refund orders.