### PR TITLE
Fix null attribute_changes crash in Activities component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 reports
 /dist
 /workbench
+.playwright-mcp/

--- a/src/Livewire/Support/Activities.php
+++ b/src/Livewire/Support/Activities.php
@@ -12,6 +12,7 @@ use Livewire\Attributes\Modelable;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Livewire\WithPagination;
+use Spatie\Activitylog\Models\Activity;
 use TeamNiftyGmbH\DataTable\Helpers\Icon;
 
 abstract class Activities extends Component
@@ -59,20 +60,20 @@ abstract class Activities extends Component
         $this->total = $activities->total();
 
         $this->activities = $activities
-            ->map(function ($item) {
+            ->map(function (Activity $item) {
                 $itemArray = $item->toArray();
                 $itemArray['causer']['name'] = $item->causer?->getLabel() ?: __('Unknown');
                 $itemArray['causer']['avatar_url'] = $item->causer?->getAvatarUrl() ?: Icon::make('user')->getUrl();
                 $itemArray['event'] = __($item->event);
                 $changes = auth()->user() instanceof User
-                    ? ($item->attribute_changes->toArray() ?? [])
+                    ? ($item->attribute_changes?->toArray() ?? [])
                     : ['old' => [], 'attributes' => []];
 
                 // Translate attribute names to human-readable labels
                 foreach (['old', 'attributes'] as $changeKey) {
                     if (isset($changes[$changeKey])) {
                         $changes[$changeKey] = collect($changes[$changeKey])
-                            ->mapWithKeys(fn ($value, $key) => [__(Str::headline($key)) => $value])
+                            ->mapWithKeys(fn (mixed $value, string $key) => [__(Str::headline($key)) => $value])
                             ->toArray();
                     }
                 }

--- a/tests/Livewire/Support/ActivitiesTest.php
+++ b/tests/Livewire/Support/ActivitiesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Livewire\Order\Activities;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\User;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+test('activities handle null attribute_changes without error', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    // Create a real activity log entry with null attribute_changes
+    DB::table('activity_log')->insert([
+        'log_name' => 'default',
+        'description' => 'updated',
+        'subject_type' => morph_alias(Order::class),
+        'subject_id' => $order->getKey(),
+        'causer_type' => morph_alias(User::class),
+        'causer_id' => $this->user->getKey(),
+        'event' => 'updated',
+        'attribute_changes' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    Livewire::test(Activities::class, ['modelId' => $order->getKey()])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

- Adds null-safe operator to `attribute_changes` access in `Activities::loadData()` - the column is nullable but `->toArray()` was called without null check
- Adds type hints to closure parameters in the same method

Reported from production (sbm-verlag.de) where an activity log entry had `attribute_changes = NULL`.

## Summary by Sourcery

Handle activities with nullable attribute_changes and strengthen type safety in the Activities component while adding regression coverage.

Bug Fixes:
- Prevent a crash in the Activities Livewire component when an activity log entry has a null attribute_changes column.

Enhancements:
- Add explicit Activity model and closure parameter type hints in the Activities component for better type safety.

Tests:
- Add a Livewire test ensuring Activities handles activity_log entries with null attribute_changes without errors.