### PR TITLE
Add window.fluxEditorExtensions hook for custom TipTap extensions

### DIFF
--- a/resources/js/components/tiptap.js
+++ b/resources/js/components/tiptap.js
@@ -123,6 +123,10 @@ export default function (
                     parent.setIsClickListenerSet(false);
                 };
 
+                const customExtensions = Array.isArray(window.fluxEditorExtensions)
+                    ? window.fluxEditorExtensions
+                    : [];
+
                 _editor = new Editor({
                     element: element,
                     extensions: [
@@ -144,6 +148,7 @@ export default function (
                         Table,
                         MentionConfig(searchModel, element),
                         BladeVariableConfig(),
+                        ...customExtensions,
                     ],
                     timeout: null,
                     content: this.content,

--- a/resources/js/components/tiptap.js
+++ b/resources/js/components/tiptap.js
@@ -123,7 +123,9 @@ export default function (
                     parent.setIsClickListenerSet(false);
                 };
 
-                const customExtensions = Array.isArray(window.fluxEditorExtensions)
+                const customExtensions = Array.isArray(
+                    window.fluxEditorExtensions,
+                )
                     ? window.fluxEditorExtensions
                     : [];
 


### PR DESCRIPTION
## Summary
- Customer projects can now register additional TipTap extensions by pushing them to `window.fluxEditorExtensions` before the editor initializes
- Extensions are spread into the editor's extensions array after the default extensions
- Enables project-specific editor features (e.g. borderless tables, custom marks) without modifying the core package

## Summary by Sourcery

New Features:
- Support loading custom TipTap extensions from window.fluxEditorExtensions and appending them after the default extensions.