### PR TITLE
Fix DataTable rows disappearing when opening edit modals

### DIFF
--- a/resources/views/livewire/accounting/payment-run/include-before.blade.php
+++ b/resources/views/livewire/accounting/payment-run/include-before.blade.php
@@ -41,7 +41,10 @@
                                     $wire
                                         .removeOrder(order.id)
                                         .then((closeModal) => {
-                                            if (closeModal) $tsui.close.modal('execute-payment-run');
+                                            if (closeModal)
+                                                $tsui.close.modal(
+                                                    'execute-payment-run',
+                                                );
                                         })
                                 "
                                 wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Payment position')]) }}"

--- a/resources/views/livewire/accounting/payment-run/include-before.blade.php
+++ b/resources/views/livewire/accounting/payment-run/include-before.blade.php
@@ -41,7 +41,7 @@
                                     $wire
                                         .removeOrder(order.id)
                                         .then((closeModal) => {
-                                            if (closeModal) close();
+                                            if (closeModal) $tsui.close.modal('execute-payment-run');
                                         })
                                 "
                                 wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Payment position')]) }}"

--- a/src/Livewire/Contact/Accounting/BankConnections.php
+++ b/src/Livewire/Contact/Accounting/BankConnections.php
@@ -12,6 +12,7 @@ use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Modelable;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -74,6 +75,7 @@ class BankConnections extends BaseContactBankConnectionList
         $this->loadData();
     }
 
+    #[Renderless]
     public function edit(?ContactBankConnection $contactBankConnection = null): void
     {
         $this->contactBankConnection->reset();
@@ -81,9 +83,7 @@ class BankConnections extends BaseContactBankConnectionList
             $this->contactBankConnection->fill($contactBankConnection);
         }
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-contact-bank-connection');
-        JS);
+        $this->modalOpen('edit-contact-bank-connection');
     }
 
     public function save(): bool

--- a/src/Livewire/Contact/Accounting/SepaMandates.php
+++ b/src/Livewire/Contact/Accounting/SepaMandates.php
@@ -119,6 +119,7 @@ class SepaMandates extends SepaMandateList
         $this->loadData();
     }
 
+    #[Renderless]
     public function edit(?SepaMandate $sepaMandate = null): void
     {
         $this->sepaMandate->reset();
@@ -126,9 +127,7 @@ class SepaMandates extends SepaMandateList
             $this->sepaMandate->fill($sepaMandate);
         }
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-sepa-mandate-modal');
-        JS);
+        $this->modalOpen('edit-sepa-mandate-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/DataTables/PaymentRunList.php
+++ b/src/Livewire/DataTables/PaymentRunList.php
@@ -2,7 +2,7 @@
 
 namespace FluxErp\Livewire\DataTables;
 
-use FluxErp\Actions\Order\UpdateOrder;
+use FluxErp\Actions\Order\UpdateLockedOrder;
 use FluxErp\Livewire\Forms\PaymentRunForm;
 use FluxErp\Models\BankConnection;
 use FluxErp\Models\Order;
@@ -107,7 +107,7 @@ class PaymentRunList extends BaseDataTable
 
         if ($order?->payment_state->canTransitionTo(Open::class)) {
             try {
-                UpdateOrder::make([
+                UpdateLockedOrder::make([
                     'id' => $order->getKey(),
                     'payment_state' => Open::$name,
                 ])

--- a/src/Livewire/DataTables/PaymentRunList.php
+++ b/src/Livewire/DataTables/PaymentRunList.php
@@ -106,12 +106,16 @@ class PaymentRunList extends BaseDataTable
         $paymentRun->orders()->detach($id);
 
         if ($order?->payment_state->canTransitionTo(Open::class)) {
-            UpdateOrder::make([
-                'id' => $order->getKey(),
-                'payment_state' => Open::$name,
-            ])
-                ->validate()
-                ->execute();
+            try {
+                UpdateOrder::make([
+                    'id' => $order->getKey(),
+                    'payment_state' => Open::$name,
+                ])
+                    ->validate()
+                    ->execute();
+            } catch (ValidationException|UnauthorizedException $e) {
+                exception_to_notifications($e, $this);
+            }
         }
 
         $paymentRun = resolve_static(PaymentRun::class, 'query')
@@ -125,7 +129,6 @@ class PaymentRunList extends BaseDataTable
         }
 
         $this->loadPaymentRun($paymentRun);
-        $this->loadData();
 
         return false;
     }

--- a/src/Livewire/DataTables/PaymentRunList.php
+++ b/src/Livewire/DataTables/PaymentRunList.php
@@ -8,6 +8,7 @@ use FluxErp\Models\BankConnection;
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentRun;
 use FluxErp\States\Order\PaymentState\Open;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -92,8 +93,10 @@ class PaymentRunList extends BaseDataTable
 
     public function removeOrder(int $id): bool
     {
+        $paymentRunId = $this->paymentRunForm->id;
+
         $paymentRun = resolve_static(PaymentRun::class, 'query')
-            ->whereKey($this->paymentRunForm->id)
+            ->whereKey($paymentRunId)
             ->first();
         $order = resolve_static(Order::class, 'query')
             ->select(['id', 'payment_state'])
@@ -111,13 +114,18 @@ class PaymentRunList extends BaseDataTable
                 ->execute();
         }
 
-        $this->loadPaymentRun($paymentRun);
+        $paymentRun = resolve_static(PaymentRun::class, 'query')
+            ->whereKey($paymentRunId)
+            ->first();
 
-        if (! $this->paymentRunForm->orders) {
+        if ($paymentRun->orders()->doesntExist()) {
             $this->delete();
 
             return true;
         }
+
+        $this->loadPaymentRun($paymentRun);
+        $this->loadData();
 
         return false;
     }
@@ -125,8 +133,8 @@ class PaymentRunList extends BaseDataTable
     protected function loadPaymentRun(PaymentRun $paymentRun): void
     {
         $paymentRun
-            ->loadMissing([
-                'orders' => fn ($query) => $query
+            ->load([
+                'orders' => fn (Builder $query) => $query
                     ->select([
                         'orders.id',
                         'orders.invoice_number',
@@ -140,5 +148,6 @@ class PaymentRunList extends BaseDataTable
             ->loadSum('orders AS total_amount', 'order_payment_run.amount');
 
         $this->paymentRunForm->fill($paymentRun);
+        $this->paymentRunForm->orders = $paymentRun->orders->toArray();
     }
 }

--- a/src/Livewire/DataTables/PaymentRunList.php
+++ b/src/Livewire/DataTables/PaymentRunList.php
@@ -8,7 +8,7 @@ use FluxErp\Models\BankConnection;
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentRun;
 use FluxErp\States\Order\PaymentState\Open;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -134,7 +134,7 @@ class PaymentRunList extends BaseDataTable
     {
         $paymentRun
             ->load([
-                'orders' => fn (Builder $query) => $query
+                'orders' => fn (BelongsToMany $query) => $query
                     ->select([
                         'orders.id',
                         'orders.invoice_number',

--- a/src/Livewire/Product/BundleList.php
+++ b/src/Livewire/Product/BundleList.php
@@ -12,6 +12,7 @@ use FluxErp\Models\Pivots\BundleProductProduct;
 use FluxErp\Models\Product;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Modelable;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -108,14 +109,13 @@ class BundleList extends ProductBundleProductList
         }
     }
 
+    #[Renderless]
     public function edit(BundleProductProduct $productBundleProduct): void
     {
         $this->productBundleProductForm->reset();
         $this->productBundleProductForm->fill($productBundleProduct);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-bundle-product-modal');
-        JS);
+        $this->modalOpen('edit-bundle-product-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Product/SerialNumber/SerialNumberList.php
+++ b/src/Livewire/Product/SerialNumber/SerialNumberList.php
@@ -7,6 +7,7 @@ use FluxErp\Livewire\DataTables\SerialNumberList as BaseSerialNumberList;
 use FluxErp\Livewire\Forms\StockPostingForm;
 use FluxErp\Models\Warehouse;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -38,6 +39,7 @@ class SerialNumberList extends BaseSerialNumberList
         ];
     }
 
+    #[Renderless]
     public function edit(): void
     {
         $this->stockPosting->reset();
@@ -46,9 +48,7 @@ class SerialNumberList extends BaseSerialNumberList
             'quantity' => 1,
         ];
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('create-serial-number-modal');
-        JS);
+        $this->modalOpen('create-serial-number-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Product/StockPostingList.php
+++ b/src/Livewire/Product/StockPostingList.php
@@ -68,15 +68,14 @@ class StockPostingList extends BaseStockPostingList
         ];
     }
 
+    #[Renderless]
     public function create(): void
     {
         $this->stockPosting->reset();
         $this->stockPosting->warehouse_id =
             $this->warehouseId ?? resolve_static(Warehouse::class, 'default')->getKey();
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('create-stock-posting-modal');
-        JS);
+        $this->modalOpen('create-stock-posting-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/ActivityLogs.php
+++ b/src/Livewire/Settings/ActivityLogs.php
@@ -4,6 +4,7 @@ namespace FluxErp\Livewire\Settings;
 
 use FluxErp\Livewire\DataTables\ActivityLogList;
 use FluxErp\Models\Activity;
+use Livewire\Attributes\Renderless;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class ActivityLogs extends ActivityLogList
@@ -23,13 +24,12 @@ class ActivityLogs extends ActivityLogList
         ];
     }
 
+    #[Renderless]
     public function edit(Activity $activity): void
     {
         $this->activity = $activity->toArray();
         $this->activity['causer'] = $activity->causer?->name;
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('activity-log-detail');
-        JS);
+        $this->modalOpen('activity-log-detail');
     }
 }

--- a/src/Livewire/Settings/AddressTypes.php
+++ b/src/Livewire/Settings/AddressTypes.php
@@ -11,6 +11,7 @@ use FluxErp\Models\AddressType;
 use FluxErp\Models\Tenant;
 use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -73,14 +74,13 @@ class AddressTypes extends AddressTypeList
         return true;
     }
 
+    #[Renderless]
     public function edit(AddressType $addressType): void
     {
         $this->addressType->reset();
         $this->addressType->fill($addressType);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-address-type-modal');
-        JS);
+        $this->modalOpen('edit-address-type-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/Countries.php
+++ b/src/Livewire/Settings/Countries.php
@@ -12,6 +12,7 @@ use FluxErp\Models\Currency;
 use FluxErp\Models\Language;
 use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -74,14 +75,13 @@ class Countries extends CountryList
         return true;
     }
 
+    #[Renderless]
     public function edit(Country $country): void
     {
         $this->country->reset();
         $this->country->fill($country);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-country-modal');
-        JS);
+        $this->modalOpen('edit-country-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/Industries.php
+++ b/src/Livewire/Settings/Industries.php
@@ -11,6 +11,7 @@ use FluxErp\Models\Industry;
 use FluxErp\Traits\Livewire\DataTable\AllowRecordMerging;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -75,14 +76,13 @@ class Industries extends IndustryList
         return true;
     }
 
+    #[Renderless]
     public function edit(Industry $industry): void
     {
         $this->industryForm->reset();
         $this->industryForm->fill($industry);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-industry-modal');
-        JS);
+        $this->modalOpen('edit-industry-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/LedgerAccounts.php
+++ b/src/Livewire/Settings/LedgerAccounts.php
@@ -11,6 +11,7 @@ use FluxErp\Livewire\Forms\LedgerAccountForm;
 use FluxErp\Models\LedgerAccount;
 use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -73,14 +74,13 @@ class LedgerAccounts extends LedgerAccountList
         return true;
     }
 
+    #[Renderless]
     public function edit(LedgerAccount $ledgerAccount): void
     {
         $this->ledgerAccount->reset();
         $this->ledgerAccount->fill($ledgerAccount);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-ledger-account-modal');
-        JS);
+        $this->modalOpen('edit-ledger-account-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/MailAccounts.php
+++ b/src/Livewire/Settings/MailAccounts.php
@@ -25,7 +25,6 @@ use Webklex\PHPIMAP\Exceptions\ImapServerErrorException;
 use Webklex\PHPIMAP\Exceptions\ResponseException;
 use Webklex\PHPIMAP\Exceptions\RuntimeException;
 
-#[Renderless]
 class MailAccounts extends MailAccountList
 {
     public array $folders = [];
@@ -99,16 +98,16 @@ class MailAccounts extends MailAccountList
         return true;
     }
 
+    #[Renderless]
     public function edit(MailAccount $mailAccount): void
     {
         $this->mailAccount->reset();
         $this->mailAccount->fill($mailAccount);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-mail-account');
-        JS);
+        $this->modalOpen('edit-mail-account');
     }
 
+    #[Renderless]
     public function editFolders(MailAccount $mailAccount): void
     {
         $this->mailAccount->reset();
@@ -116,11 +115,10 @@ class MailAccounts extends MailAccountList
 
         $this->loadFolders();
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-mail-folders');
-        JS);
+        $this->modalOpen('edit-mail-folders');
     }
 
+    #[Renderless]
     public function editMailFolder(MailFolder $mailFolder): void
     {
         $this->mailFolder->reset();

--- a/src/Livewire/Settings/PaymentReminderTexts.php
+++ b/src/Livewire/Settings/PaymentReminderTexts.php
@@ -11,6 +11,7 @@ use FluxErp\Models\PaymentReminderText;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -78,14 +79,13 @@ class PaymentReminderTexts extends PaymentReminderTextList
         return true;
     }
 
+    #[Renderless]
     public function edit(PaymentReminderText $paymentReminderText): void
     {
         $this->paymentReminderTextForm->reset();
         $this->paymentReminderTextForm->fill($paymentReminderText);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-payment-reminder-text-modal');
-        JS);
+        $this->modalOpen('edit-payment-reminder-text-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/PaymentTypes.php
+++ b/src/Livewire/Settings/PaymentTypes.php
@@ -12,6 +12,7 @@ use FluxErp\Models\Tenant;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -78,14 +79,13 @@ class PaymentTypes extends PaymentTypeList
         return true;
     }
 
+    #[Renderless]
     public function edit(PaymentType $paymentType): void
     {
         $this->paymentType->reset();
         $this->paymentType->fill($paymentType);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-payment-type-modal');
-        JS);
+        $this->modalOpen('edit-payment-type-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/Printers.php
+++ b/src/Livewire/Settings/Printers.php
@@ -56,6 +56,7 @@ class Printers extends PrinterList
         ];
     }
 
+    #[Renderless]
     public function edit(Printer $printer): void
     {
         $this->printerForm->reset();

--- a/src/Livewire/Settings/ProductOptionGroups.php
+++ b/src/Livewire/Settings/ProductOptionGroups.php
@@ -11,6 +11,7 @@ use FluxErp\Models\ProductOptionGroup;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -77,6 +78,7 @@ class ProductOptionGroups extends ProductOptionGroupList
         $this->loadData();
     }
 
+    #[Renderless]
     public function edit(?ProductOptionGroup $productOptionGroup = null): void
     {
         $this->productOptionGroupForm->reset();
@@ -85,9 +87,7 @@ class ProductOptionGroups extends ProductOptionGroupList
             $this->productOptionGroupForm->fill($productOptionGroup);
         }
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-product-option-group-modal');
-        JS);
+        $this->modalOpen('edit-product-option-group-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/SerialNumberRanges.php
+++ b/src/Livewire/Settings/SerialNumberRanges.php
@@ -12,6 +12,7 @@ use FluxErp\Models\Tenant;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Model\HasSerialNumberRange;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -78,14 +79,13 @@ class SerialNumberRanges extends SerialNumberRangeList
         return true;
     }
 
+    #[Renderless]
     public function edit(SerialNumberRange $serialNumberRange): void
     {
         $this->serialNumberRange->reset();
         $this->serialNumberRange->fill($serialNumberRange);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-serial-number-range-modal');
-        JS);
+        $this->modalOpen('edit-serial-number-range-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/Units.php
+++ b/src/Livewire/Settings/Units.php
@@ -10,6 +10,7 @@ use FluxErp\Livewire\Forms\UnitForm;
 use FluxErp\Models\Unit;
 use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -72,14 +73,13 @@ class Units extends UnitList
         return true;
     }
 
+    #[Renderless]
     public function edit(Unit $unit): void
     {
         $this->unit->reset();
         $this->unit->fill($unit);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-unit-modal');
-        JS);
+        $this->modalOpen('edit-unit-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/VatRates.php
+++ b/src/Livewire/Settings/VatRates.php
@@ -11,6 +11,7 @@ use FluxErp\Models\VatRate;
 use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -77,14 +78,13 @@ class VatRates extends VatRateList
         return true;
     }
 
+    #[Renderless]
     public function edit(VatRate $vatRate): void
     {
         $this->vatRate->reset();
         $this->vatRate->fill($vatRate);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-vat-rate-modal');
-        JS);
+        $this->modalOpen('edit-vat-rate-modal');
     }
 
     public function save(): bool

--- a/src/Livewire/Settings/Warehouses.php
+++ b/src/Livewire/Settings/Warehouses.php
@@ -10,6 +10,7 @@ use FluxErp\Livewire\Forms\WarehouseForm;
 use FluxErp\Models\Warehouse;
 use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
@@ -73,14 +74,13 @@ class Warehouses extends WarehouseList
         return true;
     }
 
+    #[Renderless]
     public function edit(Warehouse $warehouse): void
     {
         $this->warehouse->reset();
         $this->warehouse->fill($warehouse);
 
-        $this->js(<<<'JS'
-            $tsui.open.modal('edit-warehouse-modal');
-        JS);
+        $this->modalOpen('edit-warehouse-modal');
     }
 
     public function save(): bool


### PR DESCRIPTION
## Summary

When clicking edit on a row in any DataTable-based Livewire component, the table would empty out (showing "No data found") while the modal opened. The Livewire islands `mode=skip` markers were not preserved by the morph in this scenario, causing the rendered empty state to overwrite existing rows.

## Fix

Action methods that just open a modal now use `#[Renderless]` so no re-render happens — the table DOM is untouched, modal opens client-side via `$tsui.open.modal()`, and form properties sync via the Livewire snapshot. Affected components (22):

- Settings: Printers, PaymentReminderTexts, Warehouses, Industries, MailAccounts (edit, editFolders, editMailFolder), ActivityLogs, SerialNumberRanges, Units, VatRates, PaymentTypes, ProductOptionGroups, AddressTypes, Countries, LedgerAccounts
- Product: BundleList, StockPostingList, SerialNumberList
- Contact/Accounting: SepaMandates, BankConnections

Also converted the `$this->js(<<<JS $tsui.open.modal(...) JS)` pattern to `$this->modalOpen(...)` for consistency.

## PaymentRunList.removeOrder

`#[Renderless]` could not be used here because `Locked` form properties don't sync to the snapshot when render is skipped. Instead the method now refetches the payment run with `load()` (forcing relation refresh after detach), explicitly assigns `$paymentRunForm->orders` to `toArray()` of the relation, switches `count() === 0` to `doesntExist()` for an indexable EXISTS query, and calls `loadData()` to keep the table populated.

## MailAccounts cleanup

Class-level `#[Renderless]` had no effect (`SupportAttributes::call()` filters on `AttributeLevel::METHOD` only) and was removed; method-level Renderless was added to `edit`, `editFolders`, and `editMailFolder`.

## Summary by Sourcery

Prevent DataTable rows from disappearing when opening edit-related modals by making modal-opening Livewire actions renderless and ensuring table state is explicitly refreshed where needed.

Bug Fixes:
- Ensure removing an order from a payment run keeps the payment run table populated and deletes the run only when no related orders exist.

Enhancements:
- Mark multiple edit/create actions across DataTable-based Livewire components as renderless and trigger modals via a shared modalOpen helper instead of inline JavaScript.
- Refine PaymentRunList loading logic to eagerly reload payment run relations and assign form state explicitly after modifications.
- Limit the Renderless attribute on MailAccounts to the specific modal-opening methods and remove ineffective class-level usage.