### PR TITLE
Use address language for email salutation translation

### DIFF
--- a/src/Enums/SalutationEnum.php
+++ b/src/Enums/SalutationEnum.php
@@ -37,21 +37,23 @@ class SalutationEnum extends FluxEnum
             'company' => data_get($address, 'company'),
         ];
 
+        $locale = data_get($address, 'language.language_code');
+
         if (data_get($address, 'has_formal_salutation')) {
             return match ($case) {
-                SalutationEnum::Mrs => __('salutation.formal.mrs', $parameter),
-                SalutationEnum::Mr => __('salutation.formal.mr', $parameter),
-                SalutationEnum::Company => __('salutation.formal.company', $parameter),
-                SalutationEnum::Family => __('salutation.formal.family', $parameter),
-                default => __('salutation.formal.no_salutation', $parameter),
+                SalutationEnum::Mrs => __('salutation.formal.mrs', $parameter, $locale),
+                SalutationEnum::Mr => __('salutation.formal.mr', $parameter, $locale),
+                SalutationEnum::Company => __('salutation.formal.company', $parameter, $locale),
+                SalutationEnum::Family => __('salutation.formal.family', $parameter, $locale),
+                default => __('salutation.formal.no_salutation', $parameter, $locale),
             };
         } else {
             return match ($case) {
-                SalutationEnum::Mrs => __('salutation.informal.mrs', $parameter),
-                SalutationEnum::Mr => __('salutation.informal.mr', $parameter),
-                SalutationEnum::Company => __('salutation.informal.company', $parameter),
-                SalutationEnum::Family => __('salutation.informal.family', $parameter),
-                default => __('salutation.informal.no_salutation', $parameter),
+                SalutationEnum::Mrs => __('salutation.informal.mrs', $parameter, $locale),
+                SalutationEnum::Mr => __('salutation.informal.mr', $parameter, $locale),
+                SalutationEnum::Company => __('salutation.informal.company', $parameter, $locale),
+                SalutationEnum::Family => __('salutation.informal.family', $parameter, $locale),
+                default => __('salutation.informal.no_salutation', $parameter, $locale),
             };
         }
     }

--- a/src/Enums/SalutationEnum.php
+++ b/src/Enums/SalutationEnum.php
@@ -46,7 +46,7 @@ class SalutationEnum extends FluxEnum
             default => 'no_salutation',
         };
 
-        return __("salutation.{$form}.{$suffix}", $parameter, $locale);
+        return __('salutation.' . $form . '.' . $suffix, $parameter, $locale);
     }
 
     public function get(Model $model, string $key, mixed $value, array $attributes): ?object

--- a/src/Enums/SalutationEnum.php
+++ b/src/Enums/SalutationEnum.php
@@ -29,7 +29,7 @@ class SalutationEnum extends FluxEnum
         };
     }
 
-    public static function salutation(string $case, object|array $address): string
+    public static function salutation(string $case, object|array $address, ?string $locale = null): string
     {
         $parameter = [
             'firstname' => data_get($address, 'firstname'),
@@ -37,25 +37,16 @@ class SalutationEnum extends FluxEnum
             'company' => data_get($address, 'company'),
         ];
 
-        $locale = data_get($address, 'language.language_code');
+        $form = data_get($address, 'has_formal_salutation') ? 'formal' : 'informal';
+        $suffix = match ($case) {
+            SalutationEnum::Mrs => 'mrs',
+            SalutationEnum::Mr => 'mr',
+            SalutationEnum::Company => 'company',
+            SalutationEnum::Family => 'family',
+            default => 'no_salutation',
+        };
 
-        if (data_get($address, 'has_formal_salutation')) {
-            return match ($case) {
-                SalutationEnum::Mrs => __('salutation.formal.mrs', $parameter, $locale),
-                SalutationEnum::Mr => __('salutation.formal.mr', $parameter, $locale),
-                SalutationEnum::Company => __('salutation.formal.company', $parameter, $locale),
-                SalutationEnum::Family => __('salutation.formal.family', $parameter, $locale),
-                default => __('salutation.formal.no_salutation', $parameter, $locale),
-            };
-        } else {
-            return match ($case) {
-                SalutationEnum::Mrs => __('salutation.informal.mrs', $parameter, $locale),
-                SalutationEnum::Mr => __('salutation.informal.mr', $parameter, $locale),
-                SalutationEnum::Company => __('salutation.informal.company', $parameter, $locale),
-                SalutationEnum::Family => __('salutation.informal.family', $parameter, $locale),
-                default => __('salutation.informal.no_salutation', $parameter, $locale),
-            };
-        }
+        return __("salutation.{$form}.{$suffix}", $parameter, $locale);
     }
 
     public function get(Model $model, string $key, mixed $value, array $attributes): ?object

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -538,12 +538,15 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
 
     public function salutation(): ?string
     {
+        $this->loadMissing('language');
+
         return resolve_static(
             SalutationEnum::class,
             'salutation',
             [
                 'case' => $this->salutation?->value ?? SalutationEnum::NoSalutation,
                 'address' => $this,
+                'locale' => $this->preferredLocale(),
             ]
         );
     }

--- a/tests/Unit/Enums/SalutationEnumTest.php
+++ b/tests/Unit/Enums/SalutationEnumTest.php
@@ -15,7 +15,7 @@ test('values include mr and mrs', function (): void {
     expect(SalutationEnum::values())->toContain('mr', 'mrs');
 });
 
-test('salutation uses the address language', function (): void {
+test('salutation honours the explicit locale argument', function (): void {
     app()->setLocale('de');
 
     $address = [
@@ -27,8 +27,6 @@ test('salutation uses the address language', function (): void {
     expect(SalutationEnum::salutation(SalutationEnum::Mrs, $address))
         ->toBe('Sehr geehrte Frau Lopez');
 
-    $address['language'] = ['language_code' => 'en'];
-
-    expect(SalutationEnum::salutation(SalutationEnum::Mrs, $address))
+    expect(SalutationEnum::salutation(SalutationEnum::Mrs, $address, 'en'))
         ->toBe('Dear Mrs. Lopez');
 });

--- a/tests/Unit/Enums/SalutationEnumTest.php
+++ b/tests/Unit/Enums/SalutationEnumTest.php
@@ -14,3 +14,21 @@ test('toArray returns all values', function (): void {
 test('values include mr and mrs', function (): void {
     expect(SalutationEnum::values())->toContain('mr', 'mrs');
 });
+
+test('salutation uses the address language', function (): void {
+    app()->setLocale('de');
+
+    $address = [
+        'firstname' => 'Cristina',
+        'lastname' => 'Lopez',
+        'has_formal_salutation' => true,
+    ];
+
+    expect(SalutationEnum::salutation(SalutationEnum::Mrs, $address))
+        ->toBe('Sehr geehrte Frau Lopez');
+
+    $address['language'] = ['language_code' => 'en'];
+
+    expect(SalutationEnum::salutation(SalutationEnum::Mrs, $address))
+        ->toBe('Dear Mrs. Lopez');
+});

--- a/tests/Unit/Models/AddressSalutationTest.php
+++ b/tests/Unit/Models/AddressSalutationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use FluxErp\Enums\SalutationEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Language;
+use FluxErp\Models\Tenant;
+
+it('uses the address language for the salutation translation', function (): void {
+    app()->setLocale('de');
+
+    $english = Language::query()->firstOrCreate(
+        ['language_code' => 'en'],
+        ['name' => 'English', 'iso_name' => 'en']
+    );
+
+    $tenant = Tenant::factory()->create();
+    $contact = Contact::factory()
+        ->hasAttached($tenant, relationship: 'tenants')
+        ->create();
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'language_id' => $english->getKey(),
+        'salutation' => SalutationEnum::Mrs,
+        'lastname' => 'Lopez',
+        'has_formal_salutation' => true,
+    ]);
+
+    expect($address->salutation())->toBe('Dear Mrs. Lopez');
+});
+
+it('falls back to the current locale when address has no language', function (): void {
+    app()->setLocale('de');
+
+    $tenant = Tenant::factory()->create();
+    $contact = Contact::factory()
+        ->hasAttached($tenant, relationship: 'tenants')
+        ->create();
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'language_id' => null,
+        'salutation' => SalutationEnum::Mrs,
+        'lastname' => 'Lopez',
+        'has_formal_salutation' => true,
+    ]);
+
+    expect($address->salutation())->toBe('Sehr geehrte Frau Lopez');
+});

--- a/tests/Unit/Models/AddressSalutationTest.php
+++ b/tests/Unit/Models/AddressSalutationTest.php
@@ -9,10 +9,11 @@ use FluxErp\Models\Tenant;
 it('uses the address language for the salutation translation', function (): void {
     app()->setLocale('de');
 
-    $english = Language::query()->firstOrCreate(
-        ['language_code' => 'en'],
-        ['name' => 'English', 'iso_name' => 'en']
-    );
+    $english = Language::factory()->create([
+        'language_code' => 'en',
+        'iso_name' => 'en',
+        'name' => 'English',
+    ]);
 
     $tenant = Tenant::factory()->create();
     $contact = Contact::factory()


### PR DESCRIPTION
## Summary

Email salutation was rendered using the current application locale instead of the recipient address's language. A contact with English language received "Sehr geehrte Frau Lopez" while the rest of the template body was in English.

## Fix

`SalutationEnum::salutation()` now accepts an optional `?string $locale` argument and forwards it to `__()`. `Address::salutation()` reads `preferredLocale()` (existing helper that returns `language?->language_code`) and passes it in, calling `loadMissing('language')` first so the relation is available even with `Model::preventLazyLoading()`.

## Tests

- `SalutationEnumTest`: covers the explicit locale argument.
- `AddressSalutationTest`: integration test creating an `Address` with an English `Language` relation and asserting `Dear Mrs. Lopez` is returned even when the app locale is `de`. Also asserts the German fallback when no language is set.

## Summary by Sourcery

Use the address’s preferred language when generating email salutations instead of always using the current application locale.

Bug Fixes:
- Ensure email salutations are translated using the address language when available, preventing mismatched-language greetings in emails.

Enhancements:
- Allow salutation generation to accept an explicit locale parameter and streamline salutation translation key selection logic in the enum.
- Make the Address model load its language relation and pass the preferred locale through to salutation generation.

Tests:
- Add unit test confirming SalutationEnum::salutation respects an explicitly provided locale over the app default.
- Add integration tests verifying Address::salutation uses the address language for translations and falls back to the current locale when no language is set.