### PR TITLE
Remove unused autoprefixer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
                 "@wireui/alpinejs-hold-directive": "^1.0.1",
                 "alpinejs": "^3.13.2",
                 "apexcharts": "^5.10.6",
-                "autoprefixer": "^10.4.16",
                 "axios": "^1.15.1",
                 "dayjs": "^1.11.11",
                 "filepond": "^4.31.3",
@@ -1494,43 +1493,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/autoprefixer": {
-            "version": "10.4.27",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-            "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "browserslist": "^4.28.1",
-                "caniuse-lite": "^1.0.30001774",
-                "fraction.js": "^5.3.4",
-                "picocolors": "^1.1.1",
-                "postcss-value-parser": "^4.2.0"
-            },
-            "bin": {
-                "autoprefixer": "bin/autoprefixer"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            },
-            "peerDependencies": {
-                "postcss": "^8.1.0"
-            }
-        },
         "node_modules/axios": {
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
@@ -1541,53 +1503,6 @@
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
-            }
-        },
-        "node_modules/baseline-browser-mapping": {
-            "version": "2.10.14",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
-            "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "baseline-browser-mapping": "dist/cli.cjs"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -1620,27 +1535,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001785",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
-            "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -1728,13 +1622,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.331",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-            "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/engine.io-client": {
             "version": "6.6.4",
@@ -1825,16 +1712,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/escalade": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1906,20 +1783,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/fraction.js": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/rawify"
             }
         },
         "node_modules/fsevents": {
@@ -2511,13 +2374,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/node-releases": {
-            "version": "2.0.37",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2632,13 +2488,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/postcss-value-parser": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/preact": {
             "version": "10.12.1",
@@ -3176,37 +3025,6 @@
             "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
             "dev": true,
             "license": "Unlicense"
-        },
-        "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
-            }
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
         "@wireui/alpinejs-hold-directive": "^1.0.1",
         "alpinejs": "^3.13.2",
         "apexcharts": "^5.10.6",
-        "autoprefixer": "^10.4.16",
         "axios": "^1.15.1",
         "dayjs": "^1.11.11",
         "filepond": "^4.31.3",


### PR DESCRIPTION
## Summary

`autoprefixer` is listed in `devDependencies` but not used anywhere — no `postcss.config.*` exists, `vite.config.js` configures only `@tailwindcss/vite`, and Tailwind 4 ships its own vendor-prefixing via Lightning CSS.

Removing it drops 182 lines from the lockfile, eliminates the direct postcss path (it remains as a transitive dep of Vite, which is fine), and makes the related dependabot PR for postcss obsolete since the only entry point is now Vite's own pinning.

`npm run build` succeeds unchanged.

## Summary by Sourcery

Build:
- Remove the unused `autoprefixer` entry from `devDependencies` in `package.json` and clean up the corresponding entries from `package-lock.json`.