### PR TITLE
Use Support CauserResolver via container after Activitylog v5 facade removal

### DIFF
--- a/database/seeders/CommentTableSeeder.php
+++ b/database/seeders/CommentTableSeeder.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Str;
-use Spatie\Activitylog\Facades\CauserResolver;
+use Spatie\Activitylog\Support\CauserResolver;
 
 class CommentTableSeeder extends Seeder
 {
@@ -29,7 +29,7 @@ class CommentTableSeeder extends Seeder
 
             foreach ($records as $record) {
                 for ($i = 0; $i < rand(0, 10); $i++) {
-                    CauserResolver::setCauser($users->random());
+                    app(CauserResolver::class)->setCauser($users->random());
 
                     Comment::factory()->create([
                         'uuid' => Str::uuid(),

--- a/database/seeders/FluxSeeder.php
+++ b/database/seeders/FluxSeeder.php
@@ -6,7 +6,7 @@ use FluxErp\Console\Commands\Init\InitPermissions;
 use FluxErp\Models\Role;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
-use Spatie\Activitylog\Facades\CauserResolver;
+use Spatie\Activitylog\Support\CauserResolver;
 
 class FluxSeeder extends Seeder
 {
@@ -16,7 +16,7 @@ class FluxSeeder extends Seeder
         Artisan::call(InitPermissions::class);
         Role::findOrCreate('Super Admin');
         $this->call(UserTableSeeder::class);
-        CauserResolver::resolveUsing(function () {
+        app(CauserResolver::class)->resolveUsing(function () {
             return \FluxErp\Models\User::query()->inRandomOrder()->first();
         });
 


### PR DESCRIPTION
## Summary

`spatie/laravel-activitylog` v5 removed the `Spatie\Activitylog\Facades\CauserResolver` facade and moved the class to `Spatie\Activitylog\Support\CauserResolver`. The two seeders still imported the old facade, breaking `db:seed` with `Class "Spatie\Activitylog\Facades\CauserResolver" not found`.

## Fix

Switch both seeders to the supported namespace and resolve through the container, matching the pattern already used in `CreateMailExecutedSubscriber`:

```php
use Spatie\Activitylog\Support\CauserResolver;
…
app(CauserResolver::class)->resolveUsing(fn () => …);
app(CauserResolver::class)->setCauser($user);
```

Files: `FluxSeeder.php`, `CommentTableSeeder.php`.

## Summary by Sourcery

Bug Fixes:
- Fix failing database seeders by replacing the removed CauserResolver facade with the supported support class resolved from the container.