### PR TITLE
remove redundant actions trait usage

### DIFF
--- a/src/Livewire/Contact/Accounting/BankConnections.php
+++ b/src/Livewire/Contact/Accounting/BankConnections.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\ContactBankConnection\UpdateContactBankConnection;
 use FluxErp\Livewire\DataTables\ContactBankConnectionList as BaseContactBankConnectionList;
 use FluxErp\Livewire\Forms\ContactBankConnectionForm;
 use FluxErp\Models\ContactBankConnection;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Modelable;
@@ -18,8 +17,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class BankConnections extends BaseContactBankConnectionList
 {
-    use Actions;
-
     public ContactBankConnectionForm $contactBankConnection;
 
     #[Modelable]

--- a/src/Livewire/Contact/Accounting/CreditAccounts.php
+++ b/src/Livewire/Contact/Accounting/CreditAccounts.php
@@ -5,7 +5,6 @@ namespace FluxErp\Livewire\Contact\Accounting;
 use FluxErp\Actions\Transaction\CreateTransaction;
 use FluxErp\Livewire\Forms\ContactBankConnectionForm;
 use FluxErp\Livewire\Forms\TransactionForm;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Modelable;
@@ -15,8 +14,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class CreditAccounts extends BankConnections
 {
-    use Actions;
-
     public array $columnLabels = [
         'bank_name' => 'Name',
     ];

--- a/src/Livewire/Contact/Accounting/SepaMandates.php
+++ b/src/Livewire/Contact/Accounting/SepaMandates.php
@@ -13,7 +13,6 @@ use FluxErp\Livewire\Forms\SepaMandateForm;
 use FluxErp\Models\ContactBankConnection;
 use FluxErp\Models\SepaMandate;
 use FluxErp\Models\Tenant;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\CreatesDocuments;
 use FluxErp\Traits\Livewire\WithFileUploads;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,7 +24,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class SepaMandates extends SepaMandateList
 {
-    use Actions, CreatesDocuments, WithFileUploads;
+    use CreatesDocuments, WithFileUploads;
 
     #[Modelable]
     public ContactForm $contact;

--- a/src/Livewire/DataTables/MediaList.php
+++ b/src/Livewire/DataTables/MediaList.php
@@ -5,7 +5,6 @@ namespace FluxErp\Livewire\DataTables;
 use FluxErp\Actions\Media\DeleteMedia;
 use FluxErp\Livewire\Forms\MediaForm;
 use FluxErp\Models\Media;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -17,8 +16,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class MediaList extends BaseDataTable
 {
-    use Actions;
-
     public array $enabledCols = [
         'file_name',
         'collection_name',

--- a/src/Livewire/Features/CommissionRates.php
+++ b/src/Livewire/Features/CommissionRates.php
@@ -5,13 +5,12 @@ namespace FluxErp\Livewire\Features;
 use FluxErp\Livewire\DataTables\CommissionRateList;
 use FluxErp\Livewire\Forms\CommissionRateForm;
 use FluxErp\Support\Livewire\Attributes\DataTableForm;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 use Livewire\Attributes\Locked;
 
 class CommissionRates extends CommissionRateList
 {
-    use Actions, DataTableHasFormEdit {
+    use DataTableHasFormEdit {
         DataTableHasFormEdit::save as parentSave;
     }
 

--- a/src/Livewire/Project/ProjectTaskList.php
+++ b/src/Livewire/Project/ProjectTaskList.php
@@ -9,7 +9,6 @@ use FluxErp\Livewire\Forms\TaskForm;
 use FluxErp\Models\Task;
 use FluxErp\States\Task\TaskState;
 use FluxErp\Support\Livewire\Attributes\DataTableForm;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 use FluxErp\Traits\Livewire\WithTabs;
 use Illuminate\Database\Eloquent\Builder;
@@ -20,7 +19,7 @@ use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class ProjectTaskList extends BaseTaskList
 {
-    use Actions, DataTableHasFormEdit, WithTabs {
+    use DataTableHasFormEdit, WithTabs {
         DataTableHasFormEdit::edit as editForm;
     }
 

--- a/src/Livewire/Settings/AddressTypes.php
+++ b/src/Livewire/Settings/AddressTypes.php
@@ -9,7 +9,6 @@ use FluxErp\Livewire\DataTables\AddressTypeList;
 use FluxErp\Livewire\Forms\AddressTypeForm;
 use FluxErp\Models\AddressType;
 use FluxErp\Models\Tenant;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -17,8 +16,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class AddressTypes extends AddressTypeList
 {
-    use Actions;
-
     public AddressTypeForm $addressType;
 
     protected ?string $includeBefore = 'flux::livewire.settings.address-types';

--- a/src/Livewire/Settings/BankConnections.php
+++ b/src/Livewire/Settings/BankConnections.php
@@ -6,12 +6,11 @@ use FluxErp\Livewire\DataTables\BankConnectionList;
 use FluxErp\Livewire\Forms\BankConnectionForm;
 use FluxErp\Models\Currency;
 use FluxErp\Support\Livewire\Attributes\DataTableForm;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 
 class BankConnections extends BankConnectionList
 {
-    use Actions, DataTableHasFormEdit;
+    use DataTableHasFormEdit;
 
     #[DataTableForm('bank-connection-modal')]
     public BankConnectionForm $bankConnection;

--- a/src/Livewire/Settings/Categories.php
+++ b/src/Livewire/Settings/Categories.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\Category\UpdateCategory;
 use FluxErp\Livewire\DataTables\CategoryList;
 use FluxErp\Livewire\Forms\CategoryForm;
 use FluxErp\Models\Category;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\AllowRecordMerging;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use FluxErp\Traits\Model\Categorizable;
@@ -19,7 +18,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Categories extends CategoryList
 {
-    use Actions, AllowRecordMerging, SupportsLocalization;
+    use AllowRecordMerging, SupportsLocalization;
 
     public CategoryForm $category;
 

--- a/src/Livewire/Settings/Countries.php
+++ b/src/Livewire/Settings/Countries.php
@@ -10,7 +10,6 @@ use FluxErp\Livewire\Forms\CountryForm;
 use FluxErp\Models\Country;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Language;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -18,8 +17,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Countries extends CountryList
 {
-    use Actions;
-
     public CountryForm $country;
 
     protected ?string $includeBefore = 'flux::livewire.settings.countries';

--- a/src/Livewire/Settings/Currencies.php
+++ b/src/Livewire/Settings/Currencies.php
@@ -6,15 +6,12 @@ use FluxErp\Actions\Currency\DeleteCurrency;
 use FluxErp\Livewire\DataTables\CurrencyList;
 use FluxErp\Livewire\Forms\CurrencyForm;
 use FluxErp\Models\Currency;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Currencies extends CurrencyList
 {
-    use Actions;
-
     public bool $editModal = false;
 
     public CurrencyForm $selectedCurrency;

--- a/src/Livewire/Settings/Languages.php
+++ b/src/Livewire/Settings/Languages.php
@@ -6,15 +6,12 @@ use FluxErp\Actions\Language\DeleteLanguage;
 use FluxErp\Livewire\DataTables\LanguageList;
 use FluxErp\Livewire\Forms\LanguageForm;
 use FluxErp\Models\Language;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Languages extends LanguageList
 {
-    use Actions;
-
     public bool $editModal = false;
 
     public LanguageForm $selectedLanguage;

--- a/src/Livewire/Settings/LedgerAccounts.php
+++ b/src/Livewire/Settings/LedgerAccounts.php
@@ -9,7 +9,6 @@ use FluxErp\Enums\LedgerAccountTypeEnum;
 use FluxErp\Livewire\DataTables\LedgerAccountList;
 use FluxErp\Livewire\Forms\LedgerAccountForm;
 use FluxErp\Models\LedgerAccount;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -17,8 +16,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class LedgerAccounts extends LedgerAccountList
 {
-    use Actions;
-
     public LedgerAccountForm $ledgerAccount;
 
     protected ?string $includeBefore = 'flux::livewire.settings.ledger-accounts';

--- a/src/Livewire/Settings/OrderTypes.php
+++ b/src/Livewire/Settings/OrderTypes.php
@@ -8,7 +8,6 @@ use FluxErp\Livewire\Forms\OrderTypeForm;
 use FluxErp\Models\Order;
 use FluxErp\Models\Tenant;
 use FluxErp\Support\Livewire\Attributes\DataTableForm;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\AllowRecordMerging;
 use FluxErp\Traits\Livewire\DataTable\DataTableHasFormEdit;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
@@ -18,7 +17,7 @@ use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class OrderTypes extends OrderTypeList
 {
-    use Actions, AllowRecordMerging, DataTableHasFormEdit, SupportsLocalization;
+    use AllowRecordMerging, DataTableHasFormEdit, SupportsLocalization;
 
     #[DataTableForm]
     public OrderTypeForm $orderType;

--- a/src/Livewire/Settings/PaymentReminderTexts.php
+++ b/src/Livewire/Settings/PaymentReminderTexts.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\PaymentReminderText\UpdatePaymentReminderText;
 use FluxErp\Livewire\DataTables\PaymentReminderTextList;
 use FluxErp\Livewire\Forms\PaymentReminderTextForm;
 use FluxErp\Models\PaymentReminderText;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -17,7 +16,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class PaymentReminderTexts extends PaymentReminderTextList
 {
-    use Actions, SupportsLocalization;
+    use SupportsLocalization;
 
     public PaymentReminderTextForm $paymentReminderTextForm;
 

--- a/src/Livewire/Settings/PaymentTypes.php
+++ b/src/Livewire/Settings/PaymentTypes.php
@@ -9,7 +9,6 @@ use FluxErp\Livewire\DataTables\PaymentTypeList;
 use FluxErp\Livewire\Forms\PaymentTypeForm;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\Tenant;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -18,7 +17,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class PaymentTypes extends PaymentTypeList
 {
-    use Actions, SupportsLocalization;
+    use SupportsLocalization;
 
     public ?string $includeBefore = 'flux::livewire.settings.payment-types';
 

--- a/src/Livewire/Settings/PriceLists.php
+++ b/src/Livewire/Settings/PriceLists.php
@@ -14,7 +14,6 @@ use FluxErp\Livewire\Forms\PriceListForm;
 use FluxErp\Models\Category;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -22,8 +21,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class PriceLists extends PriceListList
 {
-    use Actions;
-
     public array $discountedCategories = [];
 
     public array $newCategoryDiscount = [

--- a/src/Livewire/Settings/Printers.php
+++ b/src/Livewire/Settings/Printers.php
@@ -9,7 +9,6 @@ use FluxErp\Livewire\Forms\PrinterBridgeConfigForm;
 use FluxErp\Livewire\Forms\PrinterForm;
 use FluxErp\Models\Printer;
 use FluxErp\Models\Token;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -17,8 +16,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Printers extends PrinterList
 {
-    use Actions;
-
     public PrinterBridgeConfigForm $configForm;
 
     public PrinterForm $printerForm;

--- a/src/Livewire/Settings/ProductOptionGroups.php
+++ b/src/Livewire/Settings/ProductOptionGroups.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\ProductOptionGroup\UpdateProductOptionGroup;
 use FluxErp\Livewire\DataTables\ProductOptionGroupList;
 use FluxErp\Livewire\Forms\ProductOptionGroupForm;
 use FluxErp\Models\ProductOptionGroup;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -17,7 +16,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class ProductOptionGroups extends ProductOptionGroupList
 {
-    use Actions, SupportsLocalization;
+    use SupportsLocalization;
 
     public ProductOptionGroupForm $productOptionGroupForm;
 

--- a/src/Livewire/Settings/ProductPropertyGroups.php
+++ b/src/Livewire/Settings/ProductPropertyGroups.php
@@ -9,7 +9,6 @@ use FluxErp\Enums\PropertyTypeEnum;
 use FluxErp\Livewire\DataTables\ProductPropertyGroupList;
 use FluxErp\Livewire\Forms\ProductPropertyGroupForm;
 use FluxErp\Models\ProductPropertyGroup;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -19,7 +18,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class ProductPropertyGroups extends ProductPropertyGroupList
 {
-    use Actions, SupportsLocalization;
+    use SupportsLocalization;
 
     public ProductPropertyGroupForm $productPropertyGroup;
 

--- a/src/Livewire/Settings/Scheduling.php
+++ b/src/Livewire/Settings/Scheduling.php
@@ -10,7 +10,6 @@ use FluxErp\Facades\Repeatable;
 use FluxErp\Livewire\DataTables\ScheduleList;
 use FluxErp\Livewire\Forms\ScheduleForm;
 use FluxErp\Models\Schedule;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -20,8 +19,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Scheduling extends ScheduleList
 {
-    use Actions;
-
     public ?string $includeBefore = 'flux::livewire.settings.scheduling';
 
     public array $repeatable;

--- a/src/Livewire/Settings/SerialNumberRanges.php
+++ b/src/Livewire/Settings/SerialNumberRanges.php
@@ -9,7 +9,6 @@ use FluxErp\Livewire\DataTables\SerialNumberRangeList;
 use FluxErp\Livewire\Forms\SerialNumberRangeForm;
 use FluxErp\Models\SerialNumberRange;
 use FluxErp\Models\Tenant;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Model\HasSerialNumberRange;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -18,8 +17,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class SerialNumberRanges extends SerialNumberRangeList
 {
-    use Actions;
-
     public ?string $includeBefore = 'flux::livewire.settings.serial-number-ranges';
 
     public SerialNumberRangeForm $serialNumberRange;

--- a/src/Livewire/Settings/Tenants.php
+++ b/src/Livewire/Settings/Tenants.php
@@ -12,7 +12,6 @@ use FluxErp\Models\BankConnection;
 use FluxErp\Models\Country;
 use FluxErp\Models\Scopes\UserTenantScope;
 use FluxErp\Models\Tenant;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use FluxErp\Traits\Livewire\WithFileUploads;
 use FluxErp\Traits\Livewire\WithTabs;
@@ -24,7 +23,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Tenants extends TenantList
 {
-    use Actions, SupportsLocalization, WithFileUploads, WithTabs;
+    use SupportsLocalization, WithFileUploads, WithTabs;
 
     public TenantForm $tenant;
 

--- a/src/Livewire/Settings/Units.php
+++ b/src/Livewire/Settings/Units.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\Unit\UpdateUnit;
 use FluxErp\Livewire\DataTables\UnitList;
 use FluxErp\Livewire\Forms\UnitForm;
 use FluxErp\Models\Unit;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -16,8 +15,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Units extends UnitList
 {
-    use Actions;
-
     public UnitForm $unit;
 
     protected ?string $includeBefore = 'flux::livewire.settings.units';

--- a/src/Livewire/Settings/VatRates.php
+++ b/src/Livewire/Settings/VatRates.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\VatRate\UpdateVatRate;
 use FluxErp\Livewire\DataTables\VatRateList;
 use FluxErp\Livewire\Forms\VatRateForm;
 use FluxErp\Models\VatRate;
-use FluxErp\Traits\Livewire\Actions;
 use FluxErp\Traits\Livewire\DataTable\SupportsLocalization;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -17,7 +16,7 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class VatRates extends VatRateList
 {
-    use Actions, SupportsLocalization;
+    use SupportsLocalization;
 
     public ?string $includeBefore = 'flux::livewire.settings.vat-rates';
 

--- a/src/Livewire/Settings/Warehouses.php
+++ b/src/Livewire/Settings/Warehouses.php
@@ -8,7 +8,6 @@ use FluxErp\Actions\Warehouse\UpdateWarehouse;
 use FluxErp\Livewire\DataTables\WarehouseList;
 use FluxErp\Livewire\Forms\WarehouseForm;
 use FluxErp\Models\Warehouse;
-use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -16,8 +15,6 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Warehouses extends WarehouseList
 {
-    use Actions;
-
     public ?string $includeBefore = 'flux::livewire.settings.warehouses';
 
     public WarehouseForm $warehouse;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Drop unnecessary FluxErp\Traits\Livewire\Actions imports and trait usage from multiple Livewire settings, accounting, project, and media components where it is no longer required.