### PR TITLE
Add @stack extension points across blade templates

### DIFF
--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -743,6 +743,7 @@
                                     )
                                 "
                             />
+                            @stack('purchase-invoice-edit-modal-footer-actions')
                             <x-button
                                 color="indigo"
                                 x-cloak
@@ -778,7 +779,6 @@
                                     "
                                 />
                             @endcanAction
-                            @stack('purchase-invoice-edit-modal-footer-actions')
                         @show
                     </div>
                 </div>

--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -778,7 +778,7 @@
                                     "
                                 />
                             @endcanAction
-
+                            @stack('purchase-invoice-edit-modal-footer-actions')
                         @show
                     </div>
                 </div>
@@ -1170,6 +1170,7 @@
                 :text="__('Close')"
                 x-on:click="$tsui.close.modal('bulk-pdf-upload-modal')"
             />
+            @stack('purchase-invoice-bulk-pdf-upload-modal-footer')
         </x-slot:footer>
     </x-modal>
 

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -49,6 +49,7 @@
                         $tsui.close.modal('transaction-assign-orders-modal')
                     "
                 />
+                @stack('transaction-assign-orders-modal-footer')
                 <x-button :text="__('Assign')" wire:click="assignOrders" />
             </x-slot:footer>
         </x-modal>
@@ -99,6 +100,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('transaction-comments-modal')"
                 />
+                @stack('transaction-comments-modal-footer')
             </x-slot:footer>
         </x-modal>
     @endteleport
@@ -153,6 +155,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('order-transaction-modal')"
                 />
+                @stack('order-transaction-modal-footer')
                 <x-button
                     :text="__('Save')"
                     x-on:click="$wire.saveOrderTransaction()"

--- a/resources/views/livewire/contact/contact-list.blade.php
+++ b/resources/views/livewire/contact/contact-list.blade.php
@@ -30,6 +30,7 @@
                         :text="__('Cancel') "
                         x-on:click="$tsui.close.modal('assign-agent-modal')"
                     />
+                    @stack('contact-list-assign-agent-modal-footer')
                     <x-button
                         color="indigo"
                         :text="__('Assign')"
@@ -47,6 +48,6 @@
             </x-modal>
         @endcanAction
         {!! $createContactForm->autoRender($__data) !!}
-
+        @stack('contact-list-modals')
     @show
 </div>

--- a/resources/views/livewire/contact/contact.blade.php
+++ b/resources/views/livewire/contact/contact.blade.php
@@ -71,10 +71,11 @@
                             wire:click="delete()"
                         />
                     @endcanAction
-
+                    @stack('contact-detail-header-actions')
                 @show
             </div>
         </div>
         <x-flux::tabs wire:model.live="tab" :$tabs wire:ignore />
+        @stack('contact-detail-after-tabs')
     </main>
 </div>

--- a/resources/views/livewire/create-documents-modal.blade.php
+++ b/resources/views/livewire/create-documents-modal.blade.php
@@ -26,6 +26,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('preview-{{ strtolower($this->getId()) }}')"
                 />
+                @stack('create-documents-preview-modal-footer')
                 <x-button
                     loading
                     color="indigo"
@@ -260,6 +261,7 @@
             :text="__('Cancel')"
             x-on:click="$tsui.close.modal('create-documents-{{ strtolower($this->getId()) }}')"
         />
+        @stack('create-documents-modal-footer')
         <x-button
             color="indigo"
             :text="__('Continue')"

--- a/resources/views/livewire/edit-mail.blade.php
+++ b/resources/views/livewire/edit-mail.blade.php
@@ -257,6 +257,7 @@
                 class="ml-auto"
                 :text="__('Continue')"
             />
+            @stack('edit-mail-modal-footer')
             <x-button
                 x-cloak
                 x-show="! isMultiGroup || isLastGroup"
@@ -266,7 +267,6 @@
                 class="ml-auto"
                 :text="__('Send')"
             />
-            @stack('edit-mail-modal-footer')
         </x-slot>
     </x-modal>
 </div>

--- a/resources/views/livewire/edit-mail.blade.php
+++ b/resources/views/livewire/edit-mail.blade.php
@@ -266,6 +266,7 @@
                 class="ml-auto"
                 :text="__('Send')"
             />
+            @stack('edit-mail-modal-footer')
         </x-slot>
     </x-modal>
 </div>

--- a/resources/views/livewire/features/create-task-modal.blade.php
+++ b/resources/views/livewire/features/create-task-modal.blade.php
@@ -129,6 +129,7 @@
                 :text="__('Cancel')"
                 x-on:click="$tsui.close.modal('create-task-modal')"
             />
+            @stack('create-task-modal-footer')
             <x-button
                 color="indigo"
                 :text="__('Save')"

--- a/resources/views/livewire/human-resources/employee.blade.php
+++ b/resources/views/livewire/human-resources/employee.blade.php
@@ -50,11 +50,6 @@
                 @show
             @show
         </div>
-        <div
-            class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-y-0 sm:space-x-3 sm:space-x-reverse md:mt-0 md:flex-row md:space-x-3"
-        >
-            @stack('employee-detail-header-actions')
-        </div>
     </div>
     <x-flux::tabs wire:model.live="tab" :$tabs />
     @stack('employee-detail-after-tabs')

--- a/resources/views/livewire/human-resources/employee.blade.php
+++ b/resources/views/livewire/human-resources/employee.blade.php
@@ -50,6 +50,12 @@
                 @show
             @show
         </div>
+        <div
+            class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-y-0 sm:space-x-3 sm:space-x-reverse md:mt-0 md:flex-row md:space-x-3"
+        >
+            @stack('employee-detail-header-actions')
+        </div>
     </div>
     <x-flux::tabs wire:model.live="tab" :$tabs />
+    @stack('employee-detail-after-tabs')
 </div>

--- a/resources/views/livewire/lead/lead-list.blade.php
+++ b/resources/views/livewire/lead/lead-list.blade.php
@@ -118,6 +118,7 @@
                 light
                 x-on:click="$tsui.close.modal('{{ $leadForm->modalName() }}')"
             />
+            @stack('lead-edit-modal-footer')
             <x-button
                 :text="__('Save')"
                 color="indigo"

--- a/resources/views/livewire/lead/lead.blade.php
+++ b/resources/views/livewire/lead/lead.blade.php
@@ -93,7 +93,9 @@
                     $wire.resetForm();
                 "
             />
+            @stack('lead-detail-header-actions')
         </div>
     </div>
     <x-flux::tabs wire:model.live="tab" :$tabs />
+    @stack('lead-detail-after-tabs')
 </div>

--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -47,6 +47,7 @@
                 :text="__('Cancel')"
                 x-on:click="$tsui.close.modal('edit-position-discount')"
             />
+            @stack('order-edit-position-discount-modal-footer')
             <x-button
                 color="indigo"
                 :text="__('Save')"
@@ -555,6 +556,7 @@
                         :text="__('Cancel')"
                         x-on:click="$tsui.close.modal('edit-order-position')"
                     />
+                    @stack('order-edit-position-modal-footer')
                     <x-button
                         color="indigo"
                         x-on:click="

--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -201,6 +201,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('replicate-order')"
                 />
+                @stack('order-replicate-modal-footer')
                 <x-button
                     loading="saveReplicate"
                     color="indigo"
@@ -256,6 +257,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('edit-discount')"
                 />
+                @stack('order-edit-discount-modal-footer')
                 <x-button
                     color="indigo"
                     :text="__('Save')"
@@ -401,6 +403,7 @@
                     :text="__('Save')"
                 />
             @endif
+            @stack('order-detail-header-actions')
         </div>
     </div>
     <x-flux::tabs
@@ -1480,4 +1483,5 @@
             @show
         </x-slot:append>
     </x-flux::tabs>
+    @stack('order-detail-after-tabs')
 </div>

--- a/resources/views/livewire/product/product-list.blade.php
+++ b/resources/views/livewire/product/product-list.blade.php
@@ -54,6 +54,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('create-product-modal')"
                 />
+                @stack('product-create-modal-footer')
                 <x-button
                     loading="save"
                     color="indigo"
@@ -169,6 +170,7 @@
                     :text="__('Cancel')"
                     x-on:click="$tsui.close.modal('update-prices-modal')"
                 />
+                @stack('product-update-prices-modal-footer')
                 <x-button
                     loading="updatePrices"
                     color="indigo"

--- a/resources/views/livewire/product/product.blade.php
+++ b/resources/views/livewire/product/product.blade.php
@@ -94,7 +94,9 @@
                     :text="__('Cancel')"
                 />
             @endcanAction
+            @stack('product-detail-header-actions')
         </div>
     </div>
     <x-flux::tabs wire:model.live="tab" wire:loading="tab" :$tabs wire:ignore />
+    @stack('product-detail-after-tabs')
 </div>

--- a/resources/views/livewire/project/project.blade.php
+++ b/resources/views/livewire/project/project.blade.php
@@ -116,7 +116,9 @@
                     $wire.resetForm();
                 "
             />
+            @stack('project-detail-header-actions')
         </div>
     </div>
     <x-flux::tabs wire:model.live="tab" :$tabs />
+    @stack('project-detail-after-tabs')
 </div>

--- a/resources/views/livewire/task/task-list.blade.php
+++ b/resources/views/livewire/task/task-list.blade.php
@@ -133,6 +133,7 @@
                 :text="__('Cancel')"
                 x-on:click="$tsui.close.modal('new-task-modal')"
             />
+            @stack('task-new-modal-footer')
             <x-button
                 color="indigo"
                 :text="__('Save')"

--- a/resources/views/livewire/task/task.blade.php
+++ b/resources/views/livewire/task/task.blade.php
@@ -219,6 +219,7 @@
                 x-on:click="$tsui.close.modal('replicate-task-modal')"
                 :text="__('Cancel')"
             />
+            @stack('task-replicate-modal-footer')
             <x-button
                 color="primary"
                 wire:click="replicate()"
@@ -315,6 +316,7 @@
                     :text="__('Cancel')"
                 />
             @endcanAction
+            @stack('task-detail-header-actions')
         </div>
     </div>
     <x-flux::tabs
@@ -323,4 +325,5 @@
         wire:loading="taskTab"
         card
     />
+    @stack('task-detail-after-tabs')
 </div>

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -66,6 +66,7 @@
                 />
             @endcanAction
             <x-button color="indigo" :text="__('Save')" wire:click="save()" />
+            @stack('ticket-detail-header-actions')
         @show
     </div>
     <div class="w-full pt-6 lg:col-start-1 xl:col-span-2 xl:flex xl:space-x-6">
@@ -121,6 +122,7 @@
                                     wire:ignore
                                 />
                             </x-card>
+                            @stack('ticket-detail-content-after')
                         </div>
                     </div>
                 </div>
@@ -271,6 +273,7 @@
                         </div>
                     </x-card>
                 @show
+                @stack('ticket-detail-sidebar')
             </div>
         </section>
     </div>

--- a/resources/views/livewire/ticket/tickets.blade.php
+++ b/resources/views/livewire/ticket/tickets.blade.php
@@ -56,6 +56,7 @@
             :text="__('Cancel')"
             x-on:click="$tsui.close.modal('new-ticket-modal')"
         />
+        @stack('ticket-new-modal-footer')
         <x-button color="indigo" :text="__('Save')" wire:click="save()" />
     </x-slot:footer>
 </x-modal>


### PR DESCRIPTION
## Summary
- Adds ~37 new \`@stack(...)\` directives to high-traffic blade templates so downstream packages and customer projects can extend the UI via \`@push(...)\` instead of overriding entire blade files.
- All stack names follow the \`{bereich}-{komponente}-{zweck}\` pattern to avoid collisions across packages.
- Purely additive — existing rendering is unchanged because empty stacks produce no output.

## Coverage

**Detail pages** (header actions, after-tabs content, sidebar):
| File | Stacks |
|---|---|
| contact/contact | header-actions, after-tabs |
| lead/lead | header-actions, after-tabs |
| product/product | header-actions, after-tabs |
| project/project | header-actions, after-tabs |
| task/task | header-actions, after-tabs, replicate-modal-footer |
| ticket/ticket | header-actions, content-after, sidebar |
| order/order | header-actions, after-tabs, replicate-modal-footer, edit-discount-modal-footer |
| human-resources/employee | header-actions, after-tabs |

**Modals** (footer button injection points):
| File | Stacks |
|---|---|
| order/order-list-header | edit-position-discount-modal-footer, edit-position-modal-footer |
| ticket/tickets | new-modal-footer |
| product/product-list | create-modal-footer, update-prices-modal-footer |
| task/task-list | new-modal-footer |
| lead/lead-list | edit-modal-footer |
| contact/contact-list | assign-agent-modal-footer, modals |
| features/create-task-modal | footer |
| create-documents-modal | preview-modal-footer, create-modal-footer |
| edit-mail | modal-footer |
| accounting/transaction-assignments | assign-orders, comments, order-transaction modal footers |
| accounting/purchase-invoice-list | edit-modal-footer-actions, bulk-pdf-upload-modal-footer |

## Naming convention
Stack names mandatorily follow \`{bereich}-{komponente}-{zweck}\` to prevent global namespace collisions when multiple packages register stacks. Generic names like \`actions\`, \`footer-buttons\`, or \`scripts\` are forbidden.

## Non-breaking
Empty stacks render nothing. Downstream consumers that don't push to the new stacks see no behavior difference. Existing \`@section\`/\`@show\` extension points are untouched.

## Summary by Sourcery

Add Blade stack extension points across detail views and modals to allow downstream projects to extend UI regions without overriding core templates.

Enhancements:
- Introduce named @stack regions for header actions and post-tab content on contact, lead, product, project, task, ticket, order, and employee detail pages.
- Add @stack-based footer injection points to numerous modals, including order replication/discount, transaction assignment/comments/order-transaction, contact assignment, lead/task/ticket/product create/edit flows, document creation/preview, mail editing, and purchase invoice actions and bulk PDF upload.