### PR TITLE
Use DataTableExport::store() instead of Excel::store

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "spatie/laravel-tags": "^4.3",
         "spatie/pdf-to-image": "^3.0",
         "tallstackui/tallstackui": "^3.0.6",
-        "team-nifty-gmbh/tall-datatables": "^2.4.0",
+        "team-nifty-gmbh/tall-datatables": "^2.4.10",
         "webklex/laravel-imap": "^6.1"
     },
     "require-dev": {

--- a/src/Actions/Record/MergeRecords.php
+++ b/src/Actions/Record/MergeRecords.php
@@ -218,7 +218,15 @@ class MergeRecords extends FluxAction
                             );
                         break;
                 }
-            } catch (ReflectionException|QueryException) {
+            } catch (ReflectionException) {
+                continue;
+            } catch (QueryException $e) {
+                logger()->warning('MergeRecords: skipping relation due to query exception', [
+                    'relation' => $relationItem->name,
+                    'model' => $mainRecord::class,
+                    'message' => $e->getMessage(),
+                ]);
+
                 continue;
             }
         }

--- a/src/Actions/Record/MergeRecords.php
+++ b/src/Actions/Record/MergeRecords.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -116,109 +117,109 @@ class MergeRecords extends FluxAction
             try {
                 $method = new ReflectionMethod($mainRecord, $relationItem->name);
                 $relation = $method->invoke($mainRecord);
-            } catch (ReflectionException) {
-                continue;
-            }
 
-            // On MorphOne and HasOne relations if it is not from the main record,
-            // it must be updated accordingly, and the related record from the main record must be deleted.
-            // For now, related records from these relations are not replaced to avoid data loss.
-            // Update each related model separately to trigger the model events.
-            switch (true) {
-                case $relation instanceof HasOne:
-                case $relation instanceof HasMany:
-                case $relation instanceof MorphOne:
-                case $relation instanceof MorphMany:
-                    $relation->getRelated()
-                        ->newQuery()
-                        ->when(
-                            $relation instanceof MorphOne || $relation instanceof MorphMany,
-                            fn ($query) => $query->where(
-                                $relation->getQualifiedMorphType(),
-                                $mainRecord->getMorphClass()
+                // On MorphOne and HasOne relations if it is not from the main record,
+                // it must be updated accordingly, and the related record from the main record must be deleted.
+                // For now, related records from these relations are not replaced to avoid data loss.
+                // Update each related model separately to trigger the model events.
+                switch (true) {
+                    case $relation instanceof HasOne:
+                    case $relation instanceof HasMany:
+                    case $relation instanceof MorphOne:
+                    case $relation instanceof MorphMany:
+                        $relation->getRelated()
+                            ->newQuery()
+                            ->when(
+                                $relation instanceof MorphOne || $relation instanceof MorphMany,
+                                fn ($query) => $query->where(
+                                    $relation->getQualifiedMorphType(),
+                                    $mainRecord->getMorphClass()
+                                )
                             )
-                        )
-                        ->whereIn($relation->getQualifiedForeignKeyName(), $this->getData('merge_records.*.id'))
-                        ->get()
-                        ->each(fn (Model $model) => $model
-                            ->fill([
-                                $relation->getForeignKeyName() => $mainRecord->getKey(),
-                            ])
-                            ->save()
-                        );
-                    break;
-                case $relation instanceof BelongsToMany:
-                    if ($relation->getParentKeyName() !== $mainRecord->getKeyName()) {
+                            ->whereIn($relation->getQualifiedForeignKeyName(), $this->getData('merge_records.*.id'))
+                            ->get()
+                            ->each(fn (Model $model) => $model
+                                ->fill([
+                                    $relation->getForeignKeyName() => $mainRecord->getKey(),
+                                ])
+                                ->save()
+                            );
                         break;
-                    }
+                    case $relation instanceof BelongsToMany:
+                        if ($relation->getParentKeyName() !== $mainRecord->getKeyName()) {
+                            break;
+                        }
 
-                    // If the relation has pivot columns, we assume that duplicate entries are allowed
-                    $pivotColumns = $relation->getPivotColumns();
-                    $columns = array_merge(
-                        [
-                            $relation->getForeignPivotKeyName(),
-                            $relation->getRelatedPivotKeyName(),
-                        ],
-                        $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
-                        $pivotColumns
-                    );
-                    $wheres = array_filter(
-                        $relation->toBase()->wheres,
-                        fn (array $where) => str_starts_with(
-                            data_get($where, 'column') ?? '',
-                            $relation->getTable() . '.'
-                        )
-                            && data_get($where, 'column') !== $relation->getQualifiedForeignPivotKeyName()
-                    );
-
-                    $existingRelatedIds = $relation->newPivotStatement()
-                        ->where($relation->getQualifiedForeignPivotKeyName(), $mainRecord->getKey())
-                        ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
-                        ->when(
-                            $relation instanceof MorphToMany && $relation->getInverse() === false,
-                            fn (Builder $query) => $query->where(
-                                $relation->getQualifiedMorphTypeName(),
-                                $mainRecord->getMorphClass()
-                            )
-                        )
-                        ->pluck($relation->getQualifiedRelatedPivotKeyName())
-                        ->unique()
-                        ->toArray();
-
-                    $relation->newPivotStatement()
-                        ->insertUsing(
-                            $columns,
-                            $relation->newPivotStatement()
-                                ->select(array_merge(
-                                    [DB::raw($mainRecord->getKey())],
-                                    array_diff($columns, [$relation->getForeignPivotKeyName()])
-                                ))
-                                ->when(
-                                    $relation instanceof MorphToMany && $relation->getInverse() === false,
-                                    fn ($query) => $query->where(
-                                        $relation->getQualifiedMorphTypeName(),
-                                        $mainRecord->getMorphClass()
-                                    )
-                                )
-                                ->whereIn(
-                                    $relation->getQualifiedForeignPivotKeyName(),
-                                    $this->getData('merge_records.*.id')
-                                )
-                                ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
-                                ->when(
-                                    ! $pivotColumns,
-                                    fn (Builder $query) => $query
-                                        ->whereNotIn(
-                                            $relation->getQualifiedRelatedPivotKeyName(),
-                                            $existingRelatedIds
-                                        )
-                                        ->groupBy(array_merge(
-                                            [$relation->getRelatedPivotKeyName()],
-                                            $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
-                                        ))
-                                )
+                        // If the relation has pivot columns, we assume that duplicate entries are allowed
+                        $pivotColumns = $relation->getPivotColumns();
+                        $columns = array_merge(
+                            [
+                                $relation->getForeignPivotKeyName(),
+                                $relation->getRelatedPivotKeyName(),
+                            ],
+                            $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
+                            $pivotColumns
                         );
-                    break;
+                        $wheres = array_filter(
+                            $relation->toBase()->wheres,
+                            fn (array $where) => str_starts_with(
+                                data_get($where, 'column') ?? '',
+                                $relation->getTable() . '.'
+                            )
+                                && data_get($where, 'column') !== $relation->getQualifiedForeignPivotKeyName()
+                        );
+
+                        $existingRelatedIds = $relation->newPivotStatement()
+                            ->where($relation->getQualifiedForeignPivotKeyName(), $mainRecord->getKey())
+                            ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
+                            ->when(
+                                $relation instanceof MorphToMany && $relation->getInverse() === false,
+                                fn (Builder $query) => $query->where(
+                                    $relation->getQualifiedMorphTypeName(),
+                                    $mainRecord->getMorphClass()
+                                )
+                            )
+                            ->pluck($relation->getQualifiedRelatedPivotKeyName())
+                            ->unique()
+                            ->toArray();
+
+                        $relation->newPivotStatement()
+                            ->insertUsing(
+                                $columns,
+                                $relation->newPivotStatement()
+                                    ->select(array_merge(
+                                        [DB::raw($mainRecord->getKey())],
+                                        array_diff($columns, [$relation->getForeignPivotKeyName()])
+                                    ))
+                                    ->when(
+                                        $relation instanceof MorphToMany && $relation->getInverse() === false,
+                                        fn ($query) => $query->where(
+                                            $relation->getQualifiedMorphTypeName(),
+                                            $mainRecord->getMorphClass()
+                                        )
+                                    )
+                                    ->whereIn(
+                                        $relation->getQualifiedForeignPivotKeyName(),
+                                        $this->getData('merge_records.*.id')
+                                    )
+                                    ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
+                                    ->when(
+                                        ! $pivotColumns,
+                                        fn (Builder $query) => $query
+                                            ->whereNotIn(
+                                                $relation->getQualifiedRelatedPivotKeyName(),
+                                                $existingRelatedIds
+                                            )
+                                            ->groupBy(array_merge(
+                                                [$relation->getRelatedPivotKeyName()],
+                                                $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
+                                            ))
+                                    )
+                            );
+                        break;
+                }
+            } catch (ReflectionException|QueryException) {
+                continue;
             }
         }
 

--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -43,12 +43,14 @@ class ExportDataTableJob implements ShouldQueue
         $folder = 'exports/' . str_replace(':', '_', $this->userMorph) . '/';
         $filePath = $folder . str_replace(['<', '>', ':', '"', '/', '\\', '|', '?', '*'], '_', $fileName);
 
-        $export = app(DataTableExport::class, [
-            'builder' => $query,
-            'exportColumns' => $this->columns,
-        ]);
-
-        $export->store($filePath);
+        app(
+            DataTableExport::class,
+            [
+                'builder' => $query,
+                'exportColumns' => $this->columns,
+            ]
+        )
+            ->store($filePath);
 
         $user->notify(ExportReady::make($filePath, morph_alias($this->modelClass)));
     }

--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -7,7 +7,6 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Maatwebsite\Excel\Facades\Excel;
 use TeamNiftyGmbH\DataTable\Exports\DataTableExport;
 use function Livewire\invade;
 
@@ -44,16 +43,13 @@ class ExportDataTableJob implements ShouldQueue
         $folder = 'exports/' . str_replace(':', '_', $this->userMorph) . '/';
         $filePath = $folder . str_replace(['<', '>', ':', '"', '/', '\\', '|', '?', '*'], '_', $fileName);
 
-        Excel::store(
-            app(
-                DataTableExport::class,
-                [
-                    'builder' => $query,
-                    'exportColumns' => $this->columns,
-                ]
-            ),
-            $filePath
-        );
+        app(
+            DataTableExport::class,
+            [
+                'builder' => $query,
+                'exportColumns' => $this->columns,
+            ]
+        )->store($filePath);
 
         $user->notify(ExportReady::make($filePath, morph_alias($this->modelClass)));
     }

--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -43,13 +43,12 @@ class ExportDataTableJob implements ShouldQueue
         $folder = 'exports/' . str_replace(':', '_', $this->userMorph) . '/';
         $filePath = $folder . str_replace(['<', '>', ':', '"', '/', '\\', '|', '?', '*'], '_', $fileName);
 
-        app(
-            DataTableExport::class,
-            [
-                'builder' => $query,
-                'exportColumns' => $this->columns,
-            ]
-        )->store($filePath);
+        $export = app(DataTableExport::class, [
+            'builder' => $query,
+            'exportColumns' => $this->columns,
+        ]);
+
+        $export->store($filePath);
 
         $user->notify(ExportReady::make($filePath, morph_alias($this->modelClass)));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@ use Illuminate\Foundation\Testing\WithCachedRoutes;
 use Illuminate\Support\Facades\File;
 use Laravel\Scout\ScoutServiceProvider;
 use Livewire\LivewireServiceProvider;
-use Maatwebsite\Excel\ExcelServiceProvider;
 use NotificationChannels\WebPush\WebPushServiceProvider;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use Spatie\Activitylog\ActivitylogServiceProvider;
@@ -47,7 +46,6 @@ abstract class TestCase extends BaseTestCase
             FluxServiceProvider::class,
             WebPushServiceProvider::class,
             ServiceProvider::class,
-            ExcelServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Summary
- `tall-datatables` 2.4.10 drops the `maatwebsite/excel` dependency and exposes its own `store()` method on `DataTableExport`.
- Switches `ExportDataTableJob` to call `$export->store($filePath)` directly instead of going through the Excel facade.
- Bumps the `team-nifty-gmbh/tall-datatables` constraint to `^2.4.10` so the new API is required.
- Removes the `Maatwebsite\Excel\ExcelServiceProvider` registration from `tests/TestCase.php` since the package is no longer transitively available.

## Summary by Sourcery

Switch data table export job to use the DataTableExport store API and align dependencies with the updated tall-datatables package.

Enhancements:
- Update ExportDataTableJob to invoke DataTableExport::store() directly instead of using the Excel facade.
- Remove the Excel service provider registration from the test application bootstrap as the Excel package is no longer required.

Build:
- Bump the team-nifty-gmbh/tall-datatables dependency to ^2.4.10 to require the new export API.