### PR TITLE
fix(MergeRecords): skip relations that throw QueryException

### DIFF
--- a/src/Actions/Record/MergeRecords.php
+++ b/src/Actions/Record/MergeRecords.php
@@ -218,7 +218,15 @@ class MergeRecords extends FluxAction
                             );
                         break;
                 }
-            } catch (ReflectionException|QueryException) {
+            } catch (ReflectionException) {
+                continue;
+            } catch (QueryException $e) {
+                logger()->warning('MergeRecords: skipping relation due to query exception', [
+                    'relation' => $relationItem->name,
+                    'model' => $mainRecord::class,
+                    'message' => $e->getMessage(),
+                ]);
+
                 continue;
             }
         }

--- a/src/Actions/Record/MergeRecords.php
+++ b/src/Actions/Record/MergeRecords.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -116,109 +117,109 @@ class MergeRecords extends FluxAction
             try {
                 $method = new ReflectionMethod($mainRecord, $relationItem->name);
                 $relation = $method->invoke($mainRecord);
-            } catch (ReflectionException) {
-                continue;
-            }
 
-            // On MorphOne and HasOne relations if it is not from the main record,
-            // it must be updated accordingly, and the related record from the main record must be deleted.
-            // For now, related records from these relations are not replaced to avoid data loss.
-            // Update each related model separately to trigger the model events.
-            switch (true) {
-                case $relation instanceof HasOne:
-                case $relation instanceof HasMany:
-                case $relation instanceof MorphOne:
-                case $relation instanceof MorphMany:
-                    $relation->getRelated()
-                        ->newQuery()
-                        ->when(
-                            $relation instanceof MorphOne || $relation instanceof MorphMany,
-                            fn ($query) => $query->where(
-                                $relation->getQualifiedMorphType(),
-                                $mainRecord->getMorphClass()
+                // On MorphOne and HasOne relations if it is not from the main record,
+                // it must be updated accordingly, and the related record from the main record must be deleted.
+                // For now, related records from these relations are not replaced to avoid data loss.
+                // Update each related model separately to trigger the model events.
+                switch (true) {
+                    case $relation instanceof HasOne:
+                    case $relation instanceof HasMany:
+                    case $relation instanceof MorphOne:
+                    case $relation instanceof MorphMany:
+                        $relation->getRelated()
+                            ->newQuery()
+                            ->when(
+                                $relation instanceof MorphOne || $relation instanceof MorphMany,
+                                fn ($query) => $query->where(
+                                    $relation->getQualifiedMorphType(),
+                                    $mainRecord->getMorphClass()
+                                )
                             )
-                        )
-                        ->whereIn($relation->getQualifiedForeignKeyName(), $this->getData('merge_records.*.id'))
-                        ->get()
-                        ->each(fn (Model $model) => $model
-                            ->fill([
-                                $relation->getForeignKeyName() => $mainRecord->getKey(),
-                            ])
-                            ->save()
-                        );
-                    break;
-                case $relation instanceof BelongsToMany:
-                    if ($relation->getParentKeyName() !== $mainRecord->getKeyName()) {
+                            ->whereIn($relation->getQualifiedForeignKeyName(), $this->getData('merge_records.*.id'))
+                            ->get()
+                            ->each(fn (Model $model) => $model
+                                ->fill([
+                                    $relation->getForeignKeyName() => $mainRecord->getKey(),
+                                ])
+                                ->save()
+                            );
                         break;
-                    }
+                    case $relation instanceof BelongsToMany:
+                        if ($relation->getParentKeyName() !== $mainRecord->getKeyName()) {
+                            break;
+                        }
 
-                    // If the relation has pivot columns, we assume that duplicate entries are allowed
-                    $pivotColumns = $relation->getPivotColumns();
-                    $columns = array_merge(
-                        [
-                            $relation->getForeignPivotKeyName(),
-                            $relation->getRelatedPivotKeyName(),
-                        ],
-                        $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
-                        $pivotColumns
-                    );
-                    $wheres = array_filter(
-                        $relation->toBase()->wheres,
-                        fn (array $where) => str_starts_with(
-                            data_get($where, 'column') ?? '',
-                            $relation->getTable() . '.'
-                        )
-                            && data_get($where, 'column') !== $relation->getQualifiedForeignPivotKeyName()
-                    );
-
-                    $existingRelatedIds = $relation->newPivotStatement()
-                        ->where($relation->getQualifiedForeignPivotKeyName(), $mainRecord->getKey())
-                        ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
-                        ->when(
-                            $relation instanceof MorphToMany && $relation->getInverse() === false,
-                            fn (Builder $query) => $query->where(
-                                $relation->getQualifiedMorphTypeName(),
-                                $mainRecord->getMorphClass()
-                            )
-                        )
-                        ->pluck($relation->getQualifiedRelatedPivotKeyName())
-                        ->unique()
-                        ->toArray();
-
-                    $relation->newPivotStatement()
-                        ->insertUsing(
-                            $columns,
-                            $relation->newPivotStatement()
-                                ->select(array_merge(
-                                    [DB::raw($mainRecord->getKey())],
-                                    array_diff($columns, [$relation->getForeignPivotKeyName()])
-                                ))
-                                ->when(
-                                    $relation instanceof MorphToMany && $relation->getInverse() === false,
-                                    fn ($query) => $query->where(
-                                        $relation->getQualifiedMorphTypeName(),
-                                        $mainRecord->getMorphClass()
-                                    )
-                                )
-                                ->whereIn(
-                                    $relation->getQualifiedForeignPivotKeyName(),
-                                    $this->getData('merge_records.*.id')
-                                )
-                                ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
-                                ->when(
-                                    ! $pivotColumns,
-                                    fn (Builder $query) => $query
-                                        ->whereNotIn(
-                                            $relation->getQualifiedRelatedPivotKeyName(),
-                                            $existingRelatedIds
-                                        )
-                                        ->groupBy(array_merge(
-                                            [$relation->getRelatedPivotKeyName()],
-                                            $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
-                                        ))
-                                )
+                        // If the relation has pivot columns, we assume that duplicate entries are allowed
+                        $pivotColumns = $relation->getPivotColumns();
+                        $columns = array_merge(
+                            [
+                                $relation->getForeignPivotKeyName(),
+                                $relation->getRelatedPivotKeyName(),
+                            ],
+                            $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
+                            $pivotColumns
                         );
-                    break;
+                        $wheres = array_filter(
+                            $relation->toBase()->wheres,
+                            fn (array $where) => str_starts_with(
+                                data_get($where, 'column') ?? '',
+                                $relation->getTable() . '.'
+                            )
+                                && data_get($where, 'column') !== $relation->getQualifiedForeignPivotKeyName()
+                        );
+
+                        $existingRelatedIds = $relation->newPivotStatement()
+                            ->where($relation->getQualifiedForeignPivotKeyName(), $mainRecord->getKey())
+                            ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
+                            ->when(
+                                $relation instanceof MorphToMany && $relation->getInverse() === false,
+                                fn (Builder $query) => $query->where(
+                                    $relation->getQualifiedMorphTypeName(),
+                                    $mainRecord->getMorphClass()
+                                )
+                            )
+                            ->pluck($relation->getQualifiedRelatedPivotKeyName())
+                            ->unique()
+                            ->toArray();
+
+                        $relation->newPivotStatement()
+                            ->insertUsing(
+                                $columns,
+                                $relation->newPivotStatement()
+                                    ->select(array_merge(
+                                        [DB::raw($mainRecord->getKey())],
+                                        array_diff($columns, [$relation->getForeignPivotKeyName()])
+                                    ))
+                                    ->when(
+                                        $relation instanceof MorphToMany && $relation->getInverse() === false,
+                                        fn ($query) => $query->where(
+                                            $relation->getQualifiedMorphTypeName(),
+                                            $mainRecord->getMorphClass()
+                                        )
+                                    )
+                                    ->whereIn(
+                                        $relation->getQualifiedForeignPivotKeyName(),
+                                        $this->getData('merge_records.*.id')
+                                    )
+                                    ->when($wheres, fn (Builder $query) => $this->addWheresToQuery($query, $wheres))
+                                    ->when(
+                                        ! $pivotColumns,
+                                        fn (Builder $query) => $query
+                                            ->whereNotIn(
+                                                $relation->getQualifiedRelatedPivotKeyName(),
+                                                $existingRelatedIds
+                                            )
+                                            ->groupBy(array_merge(
+                                                [$relation->getRelatedPivotKeyName()],
+                                                $relation instanceof MorphToMany ? [$relation->getMorphType()] : [],
+                                            ))
+                                    )
+                            );
+                        break;
+                }
+            } catch (ReflectionException|QueryException) {
+                continue;
             }
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@ use Illuminate\Foundation\Testing\WithCachedRoutes;
 use Illuminate\Support\Facades\File;
 use Laravel\Scout\ScoutServiceProvider;
 use Livewire\LivewireServiceProvider;
-use Maatwebsite\Excel\ExcelServiceProvider;
 use NotificationChannels\WebPush\WebPushServiceProvider;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use Spatie\Activitylog\ActivitylogServiceProvider;
@@ -47,7 +46,6 @@ abstract class TestCase extends BaseTestCase
             FluxServiceProvider::class,
             WebPushServiceProvider::class,
             ServiceProvider::class,
-            ExcelServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Summary
Spatie Permission 7.4 added a public `teams()` accessor on `HasRoles` that returns a `BelongsToMany` even when `permission.teams` is disabled. `MergeRecords` iterates over relations and runs pivot queries against the related table — for the disabled teams relation that table column (`model_has_roles.team_id`) doesn't exist, so the whole merge crashes.

Treat `QueryException` the same way `ReflectionException` is already treated: skip that relation and continue. Real DB errors on legitimately-broken relations now get skipped instead of crashing the merge — that's the trade-off.

## Summary by Sourcery

Bug Fixes:
- Skip relations that throw a QueryException while merging records so merges no longer crash on invalid or unavailable pivot tables or columns.