### PR TITLE
fix(migration): backfill order_types.order_column without MySQL-specific syntax

### DIFF
--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -14,11 +14,13 @@ return new class() extends Migration
         });
 
         DB::table('order_types')
-            ->whereRaw('0 = (@rownum := 0)')
             ->orderBy('id')
-            ->update([
-                'order_column' => DB::raw('@rownum := @rownum + 1'),
-            ]);
+            ->pluck('id')
+            ->each(function ($id, $index): void {
+                DB::table('order_types')
+                    ->where('id', $id)
+                    ->update(['order_column' => $index + 1]);
+            });
     }
 
     public function down(): void


### PR DESCRIPTION
## Summary
The 2026-04-17 migration that added `order_types.order_column` backfilled it with `@rownum := @rownum + 1`. That's MySQL session-variable syntax, which SQLite does not parse. Test suites using SQLite (most package CIs in our ecosystem) failed at `schema:migrate` with `unrecognized token: ":"`.

Replace the single update with a portable PHP loop that assigns sequential values by id. The end state is identical on MySQL; the per-row overhead is irrelevant given the size of `order_types`.

## Summary by Sourcery

Bug Fixes:
- Fix schema migration failures on SQLite by removing MySQL session-variable syntax from the order_types.order_column backfill step.