### PR TITLE
Shard browser tests across 3 parallel jobs

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -291,7 +291,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
 
       - name: Run Browser Tests
-        run: ./vendor/bin/testbench package:test --parallel --testsuite Browser --shard=${{ matrix.shard }}
+        run: ./vendor/bin/testbench package:test --testsuite Browser --shard=${{ matrix.shard }}
         env:
           PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
 

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -209,9 +209,13 @@ jobs:
         run: composer test-livewire
 
   browser:
-    name: Browser Tests
+    name: Browser Tests (shard ${{ matrix.shard }})
     needs: lint
     runs-on: [self-hosted, Linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
     container:
       image: ghcr.io/team-nifty-gmbh/flux-ci:php8.5
       credentials:
@@ -287,7 +291,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
 
       - name: Run Browser Tests
-        run: composer test-browser
+        run: ./vendor/bin/testbench package:test --parallel --testsuite Browser --shard=${{ matrix.shard }}
         env:
           PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
 
@@ -295,7 +299,7 @@ jobs:
         uses: actions/upload-artifact@v5
         if: failure()
         with:
-          name: browser-test-artifacts
+          name: browser-test-artifacts-shard-${{ strategy.job-index }}
           path: |
             tests/Browser/Screenshots/
             vendor/orchestra/testbench-core/laravel/storage/logs/

--- a/tests/Feature/Api/MediaTest.php
+++ b/tests/Feature/Api/MediaTest.php
@@ -651,7 +651,15 @@ function createMedia(array $attributes, Task $task, Illuminate\Http\Testing\File
             )
         );
 
-    Storage::disk($disk)->put($media->getPathRelativeToRoot(), $file->getContent());
+    $relativePath = $media->getPathRelativeToRoot();
+    $directory = dirname($relativePath);
+    $directory = $directory === '.' ? '' : $directory;
+
+    Storage::disk($disk)->putFileAs(
+        $directory,
+        $file,
+        basename($relativePath)
+    );
 
     return $media;
 }


### PR DESCRIPTION
## Summary
- Use Pest 4 `--shard=N/M` to split the browser test suite into 3 parallel jobs
- Each shard runs on its own runner, well under the 300s composer process timeout
- Eliminates timeout failures caused by suite size growing past the composer-default timeout

## Summary by Sourcery

Shard browser test workflow into three parallel jobs to reduce runtime and avoid timeouts.

CI:
- Run browser test suite as three matrix shards using Pest's shard option instead of a single job.
- Include shard identifier in the browser job name and artifact name to distinguish parallel runs.