### PR TITLE
Bump composer process timeout to 600s for CI

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -16,6 +16,7 @@ env:
   PHP_VERSION: '8.5'
   LARAVEL_VERSION: '13.*'
   TESTBENCH_VERSION: '11.*'
+  COMPOSER_PROCESS_TIMEOUT: '600'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Set `COMPOSER_PROCESS_TIMEOUT=600` as a global env in the CI workflow
- Composer's default `ProcessExecutor` timeout is 300s, which is too tight for the browser test suite when the runner is loaded
- Doubling to 600s gives headroom without splitting the suite

## Summary by Sourcery

CI:
- Set COMPOSER_PROCESS_TIMEOUT to 600 seconds as a global environment variable in the PR test workflow to prevent Composer processes from timing out on busy runners.