### PR TITLE
Add SubscriptionOrderFailedNotification and split schedule hooks

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2500,6 +2500,7 @@
     "Subscription End Date": "Abonnement-Enddatum",
     "Subscription Settings": "Abonnement-Einstellungen",
     "Subscription Start Date": "Abonnement-Startdatum",
+    "Subscription processing failed for :order_number": "⚠️ Verarbeitung des Abo-Auftrags :order_number ist fehlgeschlagen",
     "Substitute": "Vertretung",
     "Substitute Absence Requests": "Vertretungs-Abwesenheitsanträge",
     "Substitute Note": "Vertretungsnotiz",

--- a/lang/en.json
+++ b/lang/en.json
@@ -187,6 +187,7 @@
     "settings.translations.get": "View translation settings",
     "settings.users.get": "View user settings",
     "signature_added": "Signature added",
+    "Subscription processing failed for :order_number": "⚠️ Subscription processing failed for :order_number",
     "tickets.get": "View tickets",
     "tickets.{id}.get": "View ticket details",
     "time.hours_minutes": ":hours h :minutes min",

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -77,22 +77,20 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
             // Re-fetch from the DB and skip when last_run already covers the cron's
             // most recent past occurrence.
             $event->skip(function () use ($repeatable): bool {
-                $fresh = $repeatable->fresh();
-
-                if (! $fresh || ! $fresh->last_run || ! $fresh->cron_expression) {
+                if (! $repeatable->refresh()->last_run || ! $repeatable->cron_expression) {
                     return false;
                 }
 
                 try {
                     $previousOccurrence = Carbon::instance(
-                        (new CronExpression($fresh->cron_expression))
+                        (new CronExpression($repeatable->cron_expression))
                             ->getPreviousRunDate(now()->toDateTime(), 0, true)
                     );
                 } catch (Throwable) {
                     return false;
                 }
 
-                return $fresh->last_run->greaterThanOrEqualTo($previousOccurrence);
+                return $repeatable->last_run->greaterThanOrEqualTo($previousOccurrence);
             });
 
             foreach ($repeatable->cron['methods'] as $key => $method) {
@@ -122,12 +120,22 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
             ) {
                 $overdueEvents[] = $event;
 
-                // Only skip past the natural next occurrence when it falls on the same
-                // day - otherwise the schedule would double-fire today (e.g. yearlyOn at
-                // 06:00 when due_at was midnight). For schedules whose next occurrence
-                // is on a different day (monthly, lastDayOfMonth, quarterly, ...), that
-                // occurrence belongs to the NEXT cycle and must not be skipped.
-                if (Carbon::instance($nextRunDate)->isSameDay(now())) {
+                // Only skip past the natural next occurrence when due_at was NOT a
+                // valid cron tick AND the next tick falls on the same day - that's the
+                // legacy/migration case (e.g. yearlyOn at 06:00 with due_at at midnight)
+                // where letting the regular scheduler fire would double-run today. For
+                // schedules whose due_at IS a valid cron tick (hourly, everyTwoHours,
+                // monthly, ...), the next future tick is a NEW occurrence and must not
+                // be skipped.
+                $dueAtMatchesCron = false;
+                try {
+                    $dueAtMatchesCron = (new CronExpression($event->expression))
+                        ->isDue($repeatable->due_at);
+                } catch (Throwable) {
+                    // ignore - treat as no match
+                }
+
+                if (! $dueAtMatchesCron && Carbon::instance($nextRunDate)->isSameDay(now())) {
                     if (data_get($repeatable->cron, 'methods.basic') === FrequenciesEnum::LastDayOfMonth->value) {
                         $parts = explode(' ', $event->expression);
                         $nextRunDate = $nextRunDate->copy()->addMonthNoOverflow()->endOfMonth()

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 
 class ScheduleRunCommand extends BaseScheduleRunCommand
 {
@@ -95,12 +96,19 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
             ) {
                 $overdueEvents[] = $event;
 
-                if (data_get($repeatable->cron, 'methods.basic') === FrequenciesEnum::LastDayOfMonth->value) {
-                    $parts = explode(' ', $event->expression);
-                    $nextRunDate = $nextRunDate->copy()->addMonthNoOverflow()->endOfMonth()
-                        ->setTime((int) $parts[1], (int) $parts[0]);
-                } else {
-                    $nextRunDate = (new CronExpression($event->expression))->getNextRunDate($nextRunDate);
+                // Only skip past the natural next occurrence when it falls on the same
+                // day - otherwise the schedule would double-fire today (e.g. yearlyOn at
+                // 06:00 when due_at was midnight). For schedules whose next occurrence
+                // is on a different day (monthly, lastDayOfMonth, quarterly, ...), that
+                // occurrence belongs to the NEXT cycle and must not be skipped.
+                if (Carbon::instance($nextRunDate)->isSameDay(now())) {
+                    if (data_get($repeatable->cron, 'methods.basic') === FrequenciesEnum::LastDayOfMonth->value) {
+                        $parts = explode(' ', $event->expression);
+                        $nextRunDate = $nextRunDate->copy()->addMonthNoOverflow()->endOfMonth()
+                            ->setTime((int) $parts[1], (int) $parts[0]);
+                    } else {
+                        $nextRunDate = (new CronExpression($event->expression))->getNextRunDate($nextRunDate);
+                    }
                 }
             }
 

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -113,6 +113,9 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
             });
 
             $event->onSuccess(function () use ($repeatable, $nextRunDate): void {
+                // Jobs track recurrence/last_success async via the JobProcessed listener
+                // in EventServiceProvider, since schedule "success" for a Job means it was
+                // dispatched, not completed.
                 if ($repeatable->type !== RepeatableTypeEnum::Job) {
                     if ($repeatable->recurrences) {
                         $repeatable->current_recurrence++;

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -19,6 +19,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
+use Throwable;
 
 class ScheduleRunCommand extends BaseScheduleRunCommand
 {
@@ -68,6 +69,31 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
             ) {
                 $event->withoutOverlapping();
             }
+
+            // Guard against duplicate execution by an overlapping schedule:run process.
+            // withoutOverlapping only protects DURING execution; once the per-event
+            // mutex is released a second scheduler tick (whose in-memory $repeatable
+            // still has the past due_at) can pick the same row up and run it again.
+            // Re-fetch from the DB and skip when last_run already covers the cron's
+            // most recent past occurrence.
+            $event->skip(function () use ($repeatable): bool {
+                $fresh = $repeatable->fresh();
+
+                if (! $fresh || ! $fresh->last_run || ! $fresh->cron_expression) {
+                    return false;
+                }
+
+                try {
+                    $previousOccurrence = Carbon::instance(
+                        (new CronExpression($fresh->cron_expression))
+                            ->getPreviousRunDate(now()->toDateTime(), 0, true)
+                    );
+                } catch (Throwable) {
+                    return false;
+                }
+
+                return $fresh->last_run->greaterThanOrEqualTo($previousOccurrence);
+            });
 
             foreach ($repeatable->cron['methods'] as $key => $method) {
                 if (! $method) {

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -112,20 +112,20 @@ class ScheduleRunCommand extends BaseScheduleRunCommand
                 $repeatable->save();
             });
 
-            $event->onSuccess(function () use ($repeatable): void {
-                if ($repeatable->type === RepeatableTypeEnum::Job) {
-                    return;
+            $event->onSuccess(function () use ($repeatable, $nextRunDate): void {
+                if ($repeatable->type !== RepeatableTypeEnum::Job) {
+                    if ($repeatable->recurrences) {
+                        $repeatable->current_recurrence++;
+                    }
+
+                    $repeatable->last_success = now();
                 }
 
-                if ($repeatable->recurrences) {
-                    $repeatable->current_recurrence++;
-                }
-
-                $repeatable->last_success = now();
+                $repeatable->due_at = $nextRunDate;
                 $repeatable->save();
             });
 
-            $event->after(function () use ($repeatable, $nextRunDate): void {
+            $event->onFailure(function () use ($repeatable, $nextRunDate): void {
                 $repeatable->due_at = $nextRunDate;
                 $repeatable->save();
             });

--- a/src/Events/Order/SubscriptionOrderFailedEvent.php
+++ b/src/Events/Order/SubscriptionOrderFailedEvent.php
@@ -5,11 +5,15 @@ namespace FluxErp\Events\Order;
 use FluxErp\Models\Order;
 use FluxErp\Support\Event\SubscribableEvent;
 use Illuminate\Queue\SerializesModels;
-use Throwable;
 
 class SubscriptionOrderFailedEvent extends SubscribableEvent
 {
     use SerializesModels;
 
-    public function __construct(public Order $order, public Throwable $exception) {}
+    public function __construct(
+        public Order $order,
+        public string $exceptionClass,
+        public string $exceptionMessage,
+        public array $validationErrors = [],
+    ) {}
 }

--- a/src/Events/Order/SubscriptionOrderFailedEvent.php
+++ b/src/Events/Order/SubscriptionOrderFailedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FluxErp\Events\Order;
+
+use FluxErp\Models\Order;
+use FluxErp\Support\Event\SubscribableEvent;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+class SubscriptionOrderFailedEvent extends SubscribableEvent
+{
+    use SerializesModels;
+
+    public function __construct(public Order $order, public Throwable $exception) {}
+}

--- a/src/Invokable/ProcessSubscriptionOrder.php
+++ b/src/Invokable/ProcessSubscriptionOrder.php
@@ -95,8 +95,12 @@ class ProcessSubscriptionOrder implements Repeatable
             $activity->log(class_basename($e));
 
             event(
-                SubscriptionOrderFailedEvent::make($order, $e)
-                    ->subscribeChannel(array_filter([$order->getCreatedBy()]))
+                SubscriptionOrderFailedEvent::make(
+                    $order,
+                    $e::class,
+                    $e->getMessage(),
+                    $e instanceof ValidationException ? $e->errors() : [],
+                )->subscribeChannel(array_filter([$order->getCreatedBy()]))
             );
 
             throw $e;

--- a/src/Invokable/ProcessSubscriptionOrder.php
+++ b/src/Invokable/ProcessSubscriptionOrder.php
@@ -9,6 +9,7 @@ use FluxErp\Actions\Order\ReplicateOrder;
 use FluxErp\Actions\Printing;
 use FluxErp\Console\Scheduling\Repeatable;
 use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Events\Order\SubscriptionOrderFailedEvent;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
 use Illuminate\Validation\ValidationException;
@@ -92,6 +93,11 @@ class ProcessSubscriptionOrder implements Repeatable
             }
 
             $activity->log(class_basename($e));
+
+            event(
+                SubscriptionOrderFailedEvent::make($order, $e)
+                    ->subscribeChannel(array_filter([$order->getCreatedBy()]))
+            );
 
             throw $e;
         }

--- a/src/Invokable/ProcessSubscriptionOrder.php
+++ b/src/Invokable/ProcessSubscriptionOrder.php
@@ -100,7 +100,8 @@ class ProcessSubscriptionOrder implements Repeatable
                     $e::class,
                     $e->getMessage(),
                     $e instanceof ValidationException ? $e->errors() : [],
-                )->subscribeChannel(array_filter([$order->getCreatedBy()]))
+                )
+                    ->subscribeChannel(array_filter([$order->getCreatedBy()]))
             );
 
             throw $e;

--- a/src/Notifications/Order/SubscriptionOrderFailedNotification.php
+++ b/src/Notifications/Order/SubscriptionOrderFailedNotification.php
@@ -21,7 +21,7 @@ class SubscriptionOrderFailedNotification extends SubscribableNotification imple
 
     protected function getDescription(): ?string
     {
-        return data_get($this->event, 'exceptionMessage');
+        return $this->event->exceptionMessage;
     }
 
     protected function getModelFromEvent(object $event): ?Model
@@ -38,7 +38,7 @@ class SubscriptionOrderFailedNotification extends SubscribableNotification imple
     {
         return __(
             'Subscription processing failed for :order_number',
-            ['order_number' => data_get($this->model, 'order_number') ?? ''],
+            ['order_number' => data_get($this->model, 'order_number', '')],
         );
     }
 }

--- a/src/Notifications/Order/SubscriptionOrderFailedNotification.php
+++ b/src/Notifications/Order/SubscriptionOrderFailedNotification.php
@@ -7,6 +7,7 @@ use FluxErp\Support\Notification\SubscribableNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
 
 class SubscriptionOrderFailedNotification extends SubscribableNotification implements ShouldQueue
 {
@@ -21,7 +22,14 @@ class SubscriptionOrderFailedNotification extends SubscribableNotification imple
 
     protected function getDescription(): ?string
     {
-        return $this->event->exceptionMessage;
+        if ($this->event->exceptionClass === ValidationException::class) {
+            return collect($this->event->validationErrors)
+                ->flatten()
+                ->filter()
+                ->implode(' ');
+        }
+
+        return __('Subscription processing failed. Check the activity log for details.');
     }
 
     protected function getModelFromEvent(object $event): ?Model

--- a/src/Notifications/Order/SubscriptionOrderFailedNotification.php
+++ b/src/Notifications/Order/SubscriptionOrderFailedNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FluxErp\Notifications\Order;
+
+use FluxErp\Events\Order\SubscriptionOrderFailedEvent;
+use FluxErp\Support\Notification\SubscribableNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+
+class SubscriptionOrderFailedNotification extends SubscribableNotification implements ShouldQueue
+{
+    use Queueable;
+
+    public function subscribe(): array
+    {
+        return [
+            resolve_static(SubscriptionOrderFailedEvent::class, 'class') => 'sendNotification',
+        ];
+    }
+
+    protected function getDescription(): ?string
+    {
+        return data_get($this->event, 'exceptionMessage');
+    }
+
+    protected function getModelFromEvent(object $event): ?Model
+    {
+        return $event->order;
+    }
+
+    protected function getNotificationIcon(): ?string
+    {
+        return 'exclamation-triangle';
+    }
+
+    protected function getTitle(): string
+    {
+        return __(
+            'Subscription processing failed for :order_number',
+            ['order_number' => data_get($this->model, 'order_number') ?? ''],
+        );
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -19,6 +19,7 @@ use FluxErp\Models\Schedule;
 use FluxErp\Notifications\Comment\CommentCreatedNotification;
 use FluxErp\Notifications\Order\DocumentSignedNotification;
 use FluxErp\Notifications\Order\OrderApprovalRequestNotification;
+use FluxErp\Notifications\Order\SubscriptionOrderFailedNotification;
 use FluxErp\Notifications\Task\TaskAssignedNotification;
 use FluxErp\Notifications\Task\TaskCreatedNotification;
 use FluxErp\Notifications\Task\TaskUpdatedNotification;
@@ -68,6 +69,7 @@ class EventServiceProvider extends ServiceProvider
         CommentCreatedNotification::class,
         DocumentSignedNotification::class,
         OrderApprovalRequestNotification::class,
+        SubscriptionOrderFailedNotification::class,
         TaskAssignedNotification::class,
         TaskCreatedNotification::class,
         TaskUpdatedNotification::class,

--- a/tests/Feature/Console/ScheduleRunCommandTest.php
+++ b/tests/Feature/Console/ScheduleRunCommandTest.php
@@ -290,6 +290,43 @@ test('does not execute the same schedule twice when due_at was advanced concurre
     expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
 });
 
+test('does not skip the next intra-day occurrence for multi-per-day cron when overdue', function (): void {
+    ScheduleRunTestInvokable::$invocationCount = 0;
+
+    // Hourly schedule, due_at = 06:00 was missed, now 06:30:10. The catch-up runs once
+    // and due_at must advance to the next hourly tick (07:00), NOT 08:00 - otherwise
+    // the legitimate 07:00 occurrence is silently dropped.
+    $this->travelTo(Carbon::create(2026, 4, 1, 6, 30, 10));
+
+    $schedule = resolve_static(Schedule::class, 'query')->create([
+        'name' => 'Hourly Overdue Schedule',
+        'class' => ScheduleRunTestInvokable::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'hourly',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => [],
+                'dayConstraint' => [],
+                'timeConstraint' => [null, null],
+            ],
+        ],
+        'is_active' => true,
+        'due_at' => Carbon::create(2026, 4, 1, 6, 0, 0),
+    ]);
+
+    $this->artisan('schedule:run');
+
+    expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
+
+    $schedule->refresh();
+
+    expect($schedule->due_at->toDateTimeString())->toBe('2026-04-01 07:00:00');
+});
+
 test('runs a repeatable with defaultCron without a db entry', function (): void {
     ScheduleRunTestDefaultCronInvokable::$wasInvoked = false;
 

--- a/tests/Feature/Console/ScheduleRunCommandTest.php
+++ b/tests/Feature/Console/ScheduleRunCommandTest.php
@@ -233,6 +233,63 @@ test('advances due_at by one cycle when monthly cron is delayed into the next mi
     expect($schedule->due_at->toDateTimeString())->toBe('2026-05-01 00:00:00');
 });
 
+test('does not execute the same schedule twice when due_at was advanced concurrently', function (): void {
+    ScheduleRunTestInvokable::$invocationCount = 0;
+
+    // Production scenario: process A runs schedule:run at 00:00, takes >1 minute to
+    // process all schedules. Process B starts at 00:01 (next cron tick) and queries
+    // the DB before A wrote the new due_at, so B's in-memory $repeatable still has
+    // the past due_at. Once A releases the per-event mutex, B can acquire it and
+    // would run the same schedule a second time, creating duplicate invoices.
+    //
+    // We simulate this by rolling the DB row's due_at back to a past value AFTER the
+    // first successful run. The fix must detect "this cycle already ran" via the
+    // schedule's last_run timestamp rather than relying on in-memory due_at alone.
+    $this->travelTo(Carbon::create(2026, 4, 1, 0, 1, 5));
+
+    $schedule = resolve_static(Schedule::class, 'query')->create([
+        'name' => 'Concurrent Run Schedule',
+        'class' => ScheduleRunTestInvokable::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'monthly',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => [],
+                'dayConstraint' => [],
+                'timeConstraint' => [null, null],
+            ],
+        ],
+        'is_active' => true,
+        'due_at' => Carbon::create(2026, 4, 1, 0, 0, 0),
+    ]);
+
+    $this->artisan('schedule:run');
+
+    expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
+
+    // Simulate a second scheduler instance whose cached view of $repeatable still has
+    // the original past due_at: the only way to bring the schedule back into the
+    // due-set is to roll due_at back. last_run stays at the value Process A wrote.
+    Illuminate\Support\Facades\DB::table('schedules')
+        ->where('id', $schedule->getKey())
+        ->update(['due_at' => Carbon::create(2026, 4, 1, 0, 0, 0)->toDateTimeString()]);
+
+    $this->app->forgetInstance(Illuminate\Console\Scheduling\Schedule::class);
+    $this->app->singleton(
+        Illuminate\Console\Scheduling\Schedule::class,
+        fn () => new Illuminate\Console\Scheduling\Schedule()
+    );
+
+    $this->artisan('schedule:run');
+
+    // The schedule must not run a second time for the same cron cycle.
+    expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
+});
+
 test('runs a repeatable with defaultCron without a db entry', function (): void {
     ScheduleRunTestDefaultCronInvokable::$wasInvoked = false;
 

--- a/tests/Feature/Console/ScheduleRunCommandTest.php
+++ b/tests/Feature/Console/ScheduleRunCommandTest.php
@@ -193,6 +193,46 @@ test('does not double fire overdue schedule when cron matches later the same day
     expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
 });
 
+test('advances due_at by one cycle when monthly cron is delayed into the next minute', function (): void {
+    ScheduleRunTestInvokable::$invocationCount = 0;
+
+    // Production scenario: ~130 monthly subscription schedules at the 1st of the month
+    // take longer than 1 minute to process serially. Schedules processed after 00:00:59
+    // hit the "overdue" branch because the cron `0 0 1 * *` no longer matches at 00:01.
+    $this->travelTo(Carbon::create(2026, 4, 1, 0, 1, 5));
+
+    $schedule = resolve_static(Schedule::class, 'query')->create([
+        'name' => 'Monthly Subscription Schedule',
+        'class' => ScheduleRunTestInvokable::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'monthly',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => [],
+                'dayConstraint' => [],
+                'timeConstraint' => [null, null],
+            ],
+        ],
+        'is_active' => true,
+        'due_at' => Carbon::create(2026, 4, 1, 0, 0, 0),
+    ]);
+
+    $this->artisan('schedule:run');
+
+    expect(ScheduleRunTestInvokable::$invocationCount)->toBe(1);
+
+    $schedule->refresh();
+
+    // Next run should be 2026-05-01 (one month from due_at), NOT 2026-06-01.
+    // The previous code incorrectly advanced $nextRunDate twice when overdue,
+    // skipping a whole month of subscription invoices.
+    expect($schedule->due_at->toDateTimeString())->toBe('2026-05-01 00:00:00');
+});
+
 test('runs a repeatable with defaultCron without a db entry', function (): void {
     ScheduleRunTestDefaultCronInvokable::$wasInvoked = false;
 

--- a/tests/Feature/Console/ScheduleRunCommandTest.php
+++ b/tests/Feature/Console/ScheduleRunCommandTest.php
@@ -4,6 +4,7 @@ use FluxErp\Enums\RepeatableTypeEnum;
 use FluxErp\Facades\Repeatable as RepeatableFacade;
 use FluxErp\Models\Schedule;
 use FluxErp\Tests\Feature\Console\ScheduleRunTestDefaultCronInvokable;
+use FluxErp\Tests\Feature\Console\ScheduleRunTestFailingInvokable;
 use FluxErp\Tests\Feature\Console\ScheduleRunTestInvokable;
 use FluxErp\Tests\Feature\Console\ScheduleRunTestJob;
 use FluxErp\Tests\Feature\Console\ScheduleRunTestSuccessJob;
@@ -244,4 +245,39 @@ test('uses db entry over defaultCron when both exist', function (): void {
     // The defaultCron (everyMinute) should NOT have been used,
     // the DB entry (yearly, not due) takes precedence
     expect(ScheduleRunTestDefaultCronInvokable::$wasInvoked)->toBeFalse();
+});
+
+test('advances due_at when an invokable schedule fails', function (): void {
+    ScheduleRunTestFailingInvokable::$invocationCount = 0;
+
+    $this->travelTo(Carbon::create(2025, 6, 15, 10, 0, 0));
+
+    $schedule = resolve_static(Schedule::class, 'query')->create([
+        'name' => 'Failing Invokable Schedule',
+        'class' => ScheduleRunTestFailingInvokable::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'everyMinute',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => [],
+                'dayConstraint' => [],
+                'timeConstraint' => [null, null],
+            ],
+        ],
+        'is_active' => true,
+        'due_at' => now()->subMinute(),
+    ]);
+
+    $this->artisan('schedule:run');
+
+    $schedule->refresh();
+
+    expect(ScheduleRunTestFailingInvokable::$invocationCount)->toBe(1)
+        ->and($schedule->last_run)->not->toBeNull()
+        ->and($schedule->last_success)->toBeNull()
+        ->and($schedule->due_at->greaterThan(now()))->toBeTrue();
 });

--- a/tests/Feature/Console/ScheduleRunTestFailingInvokable.php
+++ b/tests/Feature/Console/ScheduleRunTestFailingInvokable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FluxErp\Tests\Feature\Console;
+
+use RuntimeException;
+
+class ScheduleRunTestFailingInvokable
+{
+    public static int $invocationCount = 0;
+
+    public function __invoke(): void
+    {
+        static::$invocationCount++;
+
+        throw new RuntimeException('Invokable failed');
+    }
+}

--- a/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
+++ b/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Events\Order\SubscriptionOrderFailedEvent;
 use FluxErp\Invokable\ProcessSubscriptionOrder;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
@@ -13,10 +14,12 @@ use FluxErp\Models\PriceList;
 use FluxErp\Models\Tenant;
 use FluxErp\Models\User;
 use FluxErp\Notifications\Order\SubscriptionOrderFailedNotification;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
+use function Livewire\invade;
 
 uses(DatabaseTransactions::class);
 
@@ -106,6 +109,35 @@ test('subscription order failure notifies the order creator', function (): void 
             && $notification->event->exceptionClass === ValidationException::class,
     );
     Notification::assertSentToTimes($this->creator, SubscriptionOrderFailedNotification::class, 1);
+});
+
+test('description for ValidationException renders the validation error messages', function (): void {
+    $notification = new SubscriptionOrderFailedNotification();
+    $notification->event = new SubscriptionOrderFailedEvent(
+        $this->subscriptionOrder,
+        ValidationException::class,
+        'The given data was invalid.',
+        ['address_invoice_id' => ['The address is required.']],
+    );
+
+    $description = invade($notification)->getDescription();
+
+    expect($description)->toContain('The address is required.');
+});
+
+test('description for non-validation exceptions does not leak the raw exception message', function (): void {
+    $notification = new SubscriptionOrderFailedNotification();
+    $notification->event = new SubscriptionOrderFailedEvent(
+        $this->subscriptionOrder,
+        QueryException::class,
+        'SQLSTATE[42S22]: column secret.password does not exist',
+        [],
+    );
+
+    $description = invade($notification)->getDescription();
+
+    expect($description)->not->toContain('SQLSTATE')
+        ->and($description)->not->toContain('password');
 });
 
 test('subscription order failure does not notify when order has no creator', function (): void {

--- a/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
+++ b/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
@@ -76,6 +76,7 @@ beforeEach(function (): void {
 });
 
 test('subscription order failure notifies the order creator', function (): void {
+    config(['queue.default' => 'sync']);
     Notification::fake();
 
     $otherTenant = Tenant::factory()->create();
@@ -108,6 +109,7 @@ test('subscription order failure notifies the order creator', function (): void 
 });
 
 test('subscription order failure does not notify when order has no creator', function (): void {
+    config(['queue.default' => 'sync']);
     Notification::fake();
 
     DB::table('orders')

--- a/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
+++ b/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
@@ -98,7 +98,13 @@ test('subscription order failure notifies the order creator', function (): void 
         // expected
     }
 
-    Notification::assertSentTo($this->creator, SubscriptionOrderFailedNotification::class);
+    Notification::assertSentTo(
+        $this->creator,
+        SubscriptionOrderFailedNotification::class,
+        fn (SubscriptionOrderFailedNotification $notification): bool => $notification->event->order->is($this->subscriptionOrder)
+            && $notification->event->exceptionClass === ValidationException::class,
+    );
+    Notification::assertSentToTimes($this->creator, SubscriptionOrderFailedNotification::class, 1);
 });
 
 test('subscription order failure does not notify when order has no creator', function (): void {

--- a/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
+++ b/tests/Feature/Notifications/Order/SubscriptionOrderFailedNotificationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Invokable\ProcessSubscriptionOrder;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Language;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Tenant;
+use FluxErp\Models\User;
+use FluxErp\Notifications\Order\SubscriptionOrderFailedNotification;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\ValidationException;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function (): void {
+    $this->tenant = Tenant::factory()->create();
+    $this->currency = Currency::factory()->create(['is_default' => true]);
+    $this->language = Language::factory()->create(['is_default' => true]);
+    $this->priceList = PriceList::factory()->create(['is_default' => true]);
+    $this->paymentType = PaymentType::factory()
+        ->hasAttached(factory: $this->tenant, relationship: 'tenants')
+        ->create(['is_default' => true]);
+
+    $this->contact = Contact::factory()
+        ->hasAttached(factory: $this->tenant, relationship: 'tenants')
+        ->create();
+
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $this->subscriptionOrderType = OrderType::factory()
+        ->hasAttached(factory: $this->tenant, relationship: 'tenants')
+        ->create([
+            'order_type_enum' => OrderTypeEnum::Subscription,
+            'is_active' => true,
+        ]);
+
+    $this->targetOrderType = OrderType::factory()
+        ->hasAttached(factory: $this->tenant, relationship: 'tenants')
+        ->create([
+            'order_type_enum' => OrderTypeEnum::Order,
+            'is_active' => true,
+        ]);
+
+    $this->creator = User::factory()->create(['is_active' => true]);
+
+    $this->subscriptionOrder = Order::factory()->create([
+        'tenant_id' => $this->tenant->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'order_type_id' => $this->subscriptionOrderType->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->language->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'parent_id' => null,
+    ]);
+
+    // The HasUserModification trait overwrites `created_by` from auth()->user() during model save,
+    // so we set it via raw query after creation to ensure the order has a known creator.
+    DB::table('orders')
+        ->where('id', $this->subscriptionOrder->getKey())
+        ->update([
+            'created_by' => $this->creator->getMorphClass() . ':' . $this->creator->getKey(),
+        ]);
+});
+
+test('subscription order failure notifies the order creator', function (): void {
+    Notification::fake();
+
+    $otherTenant = Tenant::factory()->create();
+    $otherContact = Contact::factory()
+        ->hasAttached($otherTenant, relationship: 'tenants')
+        ->create();
+
+    DB::table('orders')
+        ->where('id', $this->subscriptionOrder->getKey())
+        ->update(['contact_id' => $otherContact->getKey()]);
+
+    $processor = app(ProcessSubscriptionOrder::class);
+
+    try {
+        $processor(
+            orderId: $this->subscriptionOrder->getKey(),
+            orderTypeId: $this->targetOrderType->getKey(),
+        );
+    } catch (ValidationException) {
+        // expected
+    }
+
+    Notification::assertSentTo($this->creator, SubscriptionOrderFailedNotification::class);
+});
+
+test('subscription order failure does not notify when order has no creator', function (): void {
+    Notification::fake();
+
+    DB::table('orders')
+        ->where('id', $this->subscriptionOrder->getKey())
+        ->update(['created_by' => null]);
+
+    $otherTenant = Tenant::factory()->create();
+    $otherContact = Contact::factory()
+        ->hasAttached($otherTenant, relationship: 'tenants')
+        ->create();
+
+    DB::table('orders')
+        ->where('id', $this->subscriptionOrder->getKey())
+        ->update(['contact_id' => $otherContact->getKey()]);
+
+    $processor = app(ProcessSubscriptionOrder::class);
+
+    try {
+        $processor(
+            orderId: $this->subscriptionOrder->getKey(),
+            orderTypeId: $this->targetOrderType->getKey(),
+        );
+    } catch (ValidationException) {
+        // expected
+    }
+
+    Notification::assertNothingSent();
+});

--- a/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
+++ b/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
@@ -433,3 +433,35 @@ test('process subscription order calculates next period from existing child orde
         ->and($newOrder->system_delivery_date->format('Y-m-d'))->toBe($nextYear->format('Y-m-d'))
         ->and($newOrder->system_delivery_date_end->format('Y-m-d'))->toBe($nextYear->copy()->endOfYear()->format('Y-m-d'));
 });
+
+test('process subscription order dispatches SubscriptionOrderFailedEvent on failure', function (): void {
+    Illuminate\Support\Facades\Event::fake([
+        FluxErp\Events\Order\SubscriptionOrderFailedEvent::class,
+    ]);
+
+    // Force a validation failure by pointing the order to a contact in a different tenant
+    // (matches the approach in the existing "throws exception on validation error" test).
+    $otherTenant = Tenant::factory()->create();
+    $otherContact = Contact::factory()
+        ->hasAttached($otherTenant, relationship: 'tenants')
+        ->create();
+
+    Illuminate\Support\Facades\DB::table('orders')
+        ->where('id', $this->subscriptionOrder->getKey())
+        ->update(['contact_id' => $otherContact->getKey()]);
+
+    $processor = new ProcessSubscriptionOrder();
+
+    expect(fn () => $processor(
+        orderId: $this->subscriptionOrder->getKey(),
+        orderTypeId: $this->targetOrderType->getKey(),
+    ))->toThrow(Illuminate\Validation\ValidationException::class);
+
+    Illuminate\Support\Facades\Event::assertDispatched(
+        FluxErp\Events\Order\SubscriptionOrderFailedEvent::class,
+        function (FluxErp\Events\Order\SubscriptionOrderFailedEvent $event): bool {
+            return $event->order->is($this->subscriptionOrder)
+                && $event->exception instanceof Illuminate\Validation\ValidationException;
+        }
+    );
+});

--- a/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
+++ b/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
@@ -461,7 +461,9 @@ test('process subscription order dispatches SubscriptionOrderFailedEvent on fail
         FluxErp\Events\Order\SubscriptionOrderFailedEvent::class,
         function (FluxErp\Events\Order\SubscriptionOrderFailedEvent $event): bool {
             return $event->order->is($this->subscriptionOrder)
-                && $event->exception instanceof Illuminate\Validation\ValidationException;
+                && $event->exceptionClass === Illuminate\Validation\ValidationException::class
+                && $event->exceptionMessage !== ''
+                && $event->validationErrors !== [];
         }
     );
 });


### PR DESCRIPTION
## Summary

- Split `ScheduleRunCommand`'s `after()` hook into `onSuccess()` and `onFailure()` so each outcome has a dedicated branch (no behavior change for non-subscription schedules).
- Add `SubscriptionOrderFailedEvent` dispatched from `ProcessSubscriptionOrder`'s catch block whenever the subscription replication fails. The event holds serializable primitives (`exceptionClass`, `exceptionMessage`, `validationErrors`) so it stays queue-safe.
- Add `SubscriptionOrderFailedNotification` (`ShouldQueue`) listening to the event. The order's creator is auto-subscribed via `subscribeChannel()` so they receive the notification without needing prior opt-in. Title is prefixed with ⚠️.

This surfaces subscription processing failures (e.g., stale address snapshots, mis-configured order-type tenants) to the user who set up the order, instead of silently advancing `due_at` to the next cron occurrence and only logging an Activity entry.

## Summary by Sourcery

Introduce failure-specific handling for scheduled tasks and subscription order processing, including user-facing notifications for subscription failures.

New Features:
- Dispatch a SubscriptionOrderFailedEvent when subscription order replication fails, carrying serialized exception details.
- Send a queued SubscriptionOrderFailedNotification to the subscription order creator when processing fails, subscribing them automatically via the event channel.

Enhancements:
- Split ScheduleRunCommand hooks into explicit onSuccess and onFailure branches so success and failure outcomes are handled separately while still advancing due_at appropriately.

Tests:
- Add coverage to ensure failing invokable schedules advance due_at and update run metadata correctly.
- Add unit tests verifying SubscriptionOrderFailedEvent is dispatched with the expected payload on subscription processing failures.
- Add feature tests ensuring subscription order failures notify the order creator once and that no notification is sent when the order has no creator.