### PR TITLE
Show inline validation errors inside teleported x-modal contents

### DIFF
--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -71,6 +71,26 @@ function formatTitle(field) {
         .join(' → ');
 }
 
+function queryAllScoped(el, selector) {
+    const results = Array.from(el.querySelectorAll(selector));
+
+    // Also search any teleported descendants (e.g. TallStackUI modals
+    // that x-teleport their contents to <body>) whose origin lives inside
+    // the component element. Without this we miss inputs/selects rendered
+    // through <x-modal>, <x-slide-over>, etc.
+    document
+        .querySelectorAll('[data-teleport-target]')
+        .forEach((teleported) => {
+            const origin = teleported._x_teleportBack;
+
+            if (!origin || !el.contains(origin)) return;
+
+            results.push(...teleported.querySelectorAll(selector));
+        });
+
+    return results;
+}
+
 function processComponent(component) {
     const el = component.el;
 
@@ -81,18 +101,19 @@ function processComponent(component) {
     const matched = new Set();
 
     // Clear all previous error states first
-    el.querySelectorAll(`[${ERROR_ATTR}]`).forEach((span) => {
+    queryAllScoped(el, `[${ERROR_ATTR}]`).forEach((span) => {
         span.style.display = 'none';
         span.textContent = '';
     });
 
-    el.querySelectorAll(
+    queryAllScoped(
+        el,
         '[wire\\:model], [wire\\:model\\.live], [wire\\:model\\.blur], [wire\\:model\\.defer]',
     ).forEach((input) => {
         toggleRing(findWrapper(input), false);
     });
 
-    el.querySelectorAll('[x-data*="tallstackui_select"]').forEach((select) => {
+    queryAllScoped(el, '[x-data*="tallstackui_select"]').forEach((select) => {
         const button = select.querySelector(
             '[dusk="tallstackui_select_open_close"]',
         );
@@ -100,7 +121,8 @@ function processComponent(component) {
     });
 
     // Inputs with wire:model (x-input, x-number, x-textarea, x-select.native)
-    el.querySelectorAll(
+    queryAllScoped(
+        el,
         '[wire\\:model], [wire\\:model\\.live], [wire\\:model\\.blur], [wire\\:model\\.defer]',
     ).forEach((input) => {
         const prop = getWireModel(input);
@@ -117,7 +139,7 @@ function processComponent(component) {
     });
 
     // Styled selects (wire:model is consumed by Alpine, not in DOM)
-    el.querySelectorAll('[x-data*="tallstackui_select"]').forEach((select) => {
+    queryAllScoped(el, '[x-data*="tallstackui_select"]').forEach((select) => {
         const prop = Alpine.$data(select)?.property;
 
         if (!prop) return;
@@ -136,7 +158,7 @@ function processComponent(component) {
     });
 
     // Force Alpine to re-evaluate x-show/x-text for published error views
-    el.querySelectorAll('[x-show*="$errors"], [x-text*="$errors"]').forEach(
+    queryAllScoped(el, '[x-show*="$errors"], [x-text*="$errors"]').forEach(
         (node) => {
             try {
                 const xshow = node.getAttribute('x-show');

--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -71,22 +71,33 @@ function formatTitle(field) {
         .join(' → ');
 }
 
-function queryAllScoped(el, selector) {
-    const results = Array.from(el.querySelectorAll(selector));
+function getScopeRoots(componentEl) {
+    // Component element plus any teleported descendants (e.g. TallStackUI
+    // modals that x-teleport their contents to <body>) whose origin lives
+    // inside the component. Without the teleported roots we'd miss inputs,
+    // selects, and published @error spans rendered through <x-modal>,
+    // <x-slide-over>, etc.
+    const roots = [componentEl];
 
-    // Also search any teleported descendants (e.g. TallStackUI modals
-    // that x-teleport their contents to <body>) whose origin lives inside
-    // the component element. Without this we miss inputs/selects rendered
-    // through <x-modal>, <x-slide-over>, etc.
     document
         .querySelectorAll('[data-teleport-target]')
         .forEach((teleported) => {
             const origin = teleported._x_teleportBack;
 
-            if (!origin || !el.contains(origin)) return;
-
-            results.push(...teleported.querySelectorAll(selector));
+            if (origin && componentEl.contains(origin)) {
+                roots.push(teleported);
+            }
         });
+
+    return roots;
+}
+
+function queryAllScoped(roots, selector) {
+    const results = [];
+
+    roots.forEach((root) => {
+        results.push(...root.querySelectorAll(selector));
+    });
 
     return results;
 }
@@ -100,20 +111,24 @@ function processComponent(component) {
     const keys = Object.keys(errors);
     const matched = new Set();
 
+    // Resolve teleported roots once so we don't scan the entire document
+    // for each selector below.
+    const roots = getScopeRoots(el);
+
     // Clear all previous error states first
-    queryAllScoped(el, `[${ERROR_ATTR}]`).forEach((span) => {
+    queryAllScoped(roots, `[${ERROR_ATTR}]`).forEach((span) => {
         span.style.display = 'none';
         span.textContent = '';
     });
 
     queryAllScoped(
-        el,
+        roots,
         '[wire\\:model], [wire\\:model\\.live], [wire\\:model\\.blur], [wire\\:model\\.defer]',
     ).forEach((input) => {
         toggleRing(findWrapper(input), false);
     });
 
-    queryAllScoped(el, '[x-data*="tallstackui_select"]').forEach((select) => {
+    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach((select) => {
         const button = select.querySelector(
             '[dusk="tallstackui_select_open_close"]',
         );
@@ -122,7 +137,7 @@ function processComponent(component) {
 
     // Inputs with wire:model (x-input, x-number, x-textarea, x-select.native)
     queryAllScoped(
-        el,
+        roots,
         '[wire\\:model], [wire\\:model\\.live], [wire\\:model\\.blur], [wire\\:model\\.defer]',
     ).forEach((input) => {
         const prop = getWireModel(input);
@@ -139,7 +154,7 @@ function processComponent(component) {
     });
 
     // Styled selects (wire:model is consumed by Alpine, not in DOM)
-    queryAllScoped(el, '[x-data*="tallstackui_select"]').forEach((select) => {
+    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach((select) => {
         const prop = Alpine.$data(select)?.property;
 
         if (!prop) return;
@@ -158,7 +173,7 @@ function processComponent(component) {
     });
 
     // Force Alpine to re-evaluate x-show/x-text for published error views
-    queryAllScoped(el, '[x-show*="$errors"], [x-text*="$errors"]').forEach(
+    queryAllScoped(roots, '[x-show*="$errors"], [x-text*="$errors"]').forEach(
         (node) => {
             try {
                 const xshow = node.getAttribute('x-show');

--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -128,12 +128,14 @@ function processComponent(component) {
         toggleRing(findWrapper(input), false);
     });
 
-    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach((select) => {
-        const button = select.querySelector(
-            '[dusk="tallstackui_select_open_close"]',
-        );
-        toggleRing(findWrapper(button || select), false);
-    });
+    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach(
+        (select) => {
+            const button = select.querySelector(
+                '[dusk="tallstackui_select_open_close"]',
+            );
+            toggleRing(findWrapper(button || select), false);
+        },
+    );
 
     // Inputs with wire:model (x-input, x-number, x-textarea, x-select.native)
     queryAllScoped(
@@ -154,23 +156,25 @@ function processComponent(component) {
     });
 
     // Styled selects (wire:model is consumed by Alpine, not in DOM)
-    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach((select) => {
-        const prop = Alpine.$data(select)?.property;
+    queryAllScoped(roots, '[x-data*="tallstackui_select"]').forEach(
+        (select) => {
+            const prop = Alpine.$data(select)?.property;
 
-        if (!prop) return;
+            if (!prop) return;
 
-        const hasError = keys.includes(prop) && errors[prop]?.length > 0;
-        const button = select.querySelector(
-            '[dusk="tallstackui_select_open_close"]',
-        );
+            const hasError = keys.includes(prop) && errors[prop]?.length > 0;
+            const button = select.querySelector(
+                '[dusk="tallstackui_select_open_close"]',
+            );
 
-        toggleRing(findWrapper(button || select), hasError);
-        toggleError(select, prop, hasError ? errors[prop][0] : null);
+            toggleRing(findWrapper(button || select), hasError);
+            toggleError(select, prop, hasError ? errors[prop][0] : null);
 
-        if (hasError && isVisible(select)) {
-            matched.add(prop);
-        }
-    });
+            if (hasError && isVisible(select)) {
+                matched.add(prop);
+            }
+        },
+    );
 
     // Force Alpine to re-evaluate x-show/x-text for published error views
     queryAllScoped(roots, '[x-show*="$errors"], [x-text*="$errors"]').forEach(

--- a/resources/views/tallstackui/components/form/error.blade.php
+++ b/resources/views/tallstackui/components/form/error.blade.php
@@ -5,9 +5,12 @@
 @if($property)
     <span
         x-cloak
-        x-show="$wire?.$errors?.has('{{ $property }}')"
-        x-text="$wire?.$errors?.first('{{ $property }}')"
+        x-show="typeof $wire?.$errors?.has === 'function'
+            ? $wire.$errors.has('{{ $property }}')
+            : false"
+        x-text="typeof $wire?.$errors?.first === 'function'
+            ? ($wire.$errors.first('{{ $property }}') ?? '')
+            : ''"
         class="{{ $customization['text'] }}"
-    >
-    </span>
+    ></span>
 @endif

--- a/tests/Browser/Features/FormValidation/RenderlessValidationErrorsTest.php
+++ b/tests/Browser/Features/FormValidation/RenderlessValidationErrorsTest.php
@@ -71,6 +71,45 @@ class ValidationTestComponent extends Component
     }
 }
 
+class ModalValidationTestComponent extends Component
+{
+    use FluxErp\Traits\Livewire\Actions;
+
+    public ValidationTestForm $form;
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <x-modal id="modal-validation-test" :title="'Test'">
+                <x-input wire:model="form.name" :label="'Name'" />
+                <x-select.styled wire:model="form.related_id" :label="'Related'" :options="[['label' => 'Option 1', 'value' => 1]]" select="label:label|value:value" />
+                <x-slot:footer>
+                    <x-button wire:click="save" :text="'Save'" />
+                </x-slot:footer>
+            </x-modal>
+        </div>
+        HTML;
+    }
+
+    #[Renderless]
+    public function save(): bool
+    {
+        try {
+            Illuminate\Support\Facades\Validator::make($this->form->all(), [
+                'name' => 'required|string|min:2',
+                'related_id' => 'required',
+            ])->validate();
+        } catch (Illuminate\Validation\ValidationException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        return true;
+    }
+}
+
 /*
 |--------------------------------------------------------------------------
 | Setup
@@ -79,6 +118,7 @@ class ValidationTestComponent extends Component
 
 beforeEach(function (): void {
     Livewire\Livewire::component('validation-test', ValidationTestComponent::class);
+    Livewire\Livewire::component('modal-validation-test', ModalValidationTestComponent::class);
 });
 
 function triggerSave($page): void
@@ -332,6 +372,72 @@ test('toast fallback for errors without matching visible input', function (): vo
             const container = document.querySelector('[x-data*="tallstackui_toastBase"]');
             if (!container) return false;
             return container.querySelectorAll('[x-show]').length > 0;
+        })()
+    JS);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Teleported modals (x-modal)
+|--------------------------------------------------------------------------
+*/
+
+test('inline errors render inside teleported x-modal contents', function (): void {
+    $page = visitLivewire(ModalValidationTestComponent::class)->assertNoSmoke();
+
+    // Open the modal so its teleported contents are mounted into <body>.
+    $page->script(<<<'JS'
+        () => $tsui.open.modal('modal-validation-test')
+    JS);
+
+    $page->wait(1);
+
+    // Click the save button inside the teleported modal.
+    $page->script(<<<'JS'
+        () => {
+            const teleported = document.querySelector('[id="modal-validation-test"]');
+            teleported.querySelector('[wire\\:click="save"]').click();
+        }
+    JS);
+
+    $page->wait(3);
+
+    $page->assertScript(<<<'JS'
+        (() => {
+            const comp = Livewire.all().find(c => c.name === 'modal-validation-test');
+            const errors = comp?.snapshot?.memo?.errors || {};
+
+            if (Object.keys(errors).length === 0) {
+                throw new Error('No errors in snapshot — save was not triggered.');
+            }
+
+            const teleported = document.querySelector('[id="modal-validation-test"]');
+
+            if (!teleported || !teleported.matches('[data-teleport-target]')) {
+                throw new Error('Modal is not teleported as expected.');
+            }
+
+            // The styled select error span is injected as [data-validation-error]
+            // by validation-errors.js when it walks teleported descendants.
+            const selectError = teleported.querySelector(
+                '[data-validation-error="form.related_id"]',
+            );
+
+            if (!selectError || selectError.style.display === 'none') {
+                throw new Error('Select error span missing or hidden inside teleported modal.');
+            }
+
+            // The x-input error span is rendered through the published @error
+            // partial as [x-show*="$errors"]; the helper re-evaluates it.
+            const inputError = Array.from(
+                teleported.querySelectorAll('[x-show*="$errors"]'),
+            ).find((s) => s.style.display !== 'none');
+
+            if (!inputError) {
+                throw new Error('Input error span hidden inside teleported modal.');
+            }
+
+            return true;
         })()
     JS);
 });

--- a/tests/Browser/Features/FormValidation/RenderlessValidationErrorsTest.php
+++ b/tests/Browser/Features/FormValidation/RenderlessValidationErrorsTest.php
@@ -133,7 +133,12 @@ function triggerSave($page): void
         }
     JS);
 
-    $page->wait(3);
+    waitForCondition($page, <<<'JS'
+        () => {
+            const comp = Livewire.all().find(c => c.name === 'validation-test');
+            return Object.keys(comp?.snapshot?.memo?.errors || {}).length > 0;
+        }
+    JS);
 }
 
 /*
@@ -365,7 +370,12 @@ test('toast fallback for errors without matching visible input', function (): vo
         }
     JS);
 
-    $page->wait(1);
+    waitForCondition($page, <<<'JS'
+        () => {
+            const container = document.querySelector('[x-data*="tallstackui_toastBase"]');
+            return container && container.querySelectorAll('[x-show]').length > 0;
+        }
+    JS);
 
     $page->assertScript(<<<'JS'
         (() => {
@@ -390,7 +400,7 @@ test('inline errors render inside teleported x-modal contents', function (): voi
         () => $tsui.open.modal('modal-validation-test')
     JS);
 
-    $page->wait(1);
+    waitForElement($page, '[id="modal-validation-test"][data-teleport-target]');
 
     // Click the save button inside the teleported modal.
     $page->script(<<<'JS'
@@ -400,7 +410,20 @@ test('inline errors render inside teleported x-modal contents', function (): voi
         }
     JS);
 
-    $page->wait(3);
+    // Wait for both the snapshot to carry the validation errors AND the
+    // teleported modal to receive the rendered error span injected by the
+    // validation-errors helper.
+    waitForCondition($page, <<<'JS'
+        () => {
+            const comp = Livewire.all().find(c => c.name === 'modal-validation-test');
+            const errors = comp?.snapshot?.memo?.errors || {};
+            if (Object.keys(errors).length === 0) return false;
+
+            const teleported = document.querySelector('[id="modal-validation-test"]');
+            const span = teleported?.querySelector('[data-validation-error="form.related_id"]');
+            return span && span.style.display !== 'none';
+        }
+    JS, 10000);
 
     $page->assertScript(<<<'JS'
         (() => {

--- a/tests/Livewire/Widgets/HumanResources/AbsenceTypeDistributionChartTest.php
+++ b/tests/Livewire/Widgets/HumanResources/AbsenceTypeDistributionChartTest.php
@@ -47,8 +47,8 @@ test('renders successfully', function (): void {
 
 test('shows absence type distribution with data', function (): void {
     $sickType = app(AbsenceType::class)->create([
-        'name' => 'Krank',
-        'code' => 'KRK',
+        'name' => 'Sick',
+        'code' => 'SCK',
         'color' => '#ef4444',
         'employee_can_create' => EmployeeCanCreateEnum::Yes,
         'affects_overtime' => false,
@@ -57,9 +57,13 @@ test('shows absence type distribution with data', function (): void {
         'is_active' => true,
     ]);
 
+    $this->travelTo(now()->startOfMonth()->addDays(20));
+
+    // First weekday on or after the third of the month so calculateWorkDaysAffected
+    // counts a full day instead of skipping a weekend.
     $dateInMonth = now()->startOfMonth()->addDays(2);
-    if ($dateInMonth->isAfter(now())) {
-        $dateInMonth = now()->subDay();
+    while ($dateInMonth->isWeekend()) {
+        $dateInMonth->addDay();
     }
 
     $employeeDay = app(EmployeeDay::class)->create([
@@ -94,12 +98,12 @@ test('shows absence type distribution with data', function (): void {
         $absenceRequest->employeeDays()->attach($employeeDay->getKey());
     }
 
-    $component = Livewire::test(AbsenceTypeDistributionChart::class)
-        ->assertOk();
+    $component = Livewire::test(AbsenceTypeDistributionChart::class);
+    $component->call('calculateByTimeFrame');
 
     $series = $component->get('series');
     $labels = $component->get('labels');
 
-    expect($labels)->toContain('Krank')
+    expect($labels)->toContain('Sick')
         ->and($series)->not->toBeEmpty();
 });

--- a/tests/Livewire/Widgets/HumanResources/SickRateBoxTest.php
+++ b/tests/Livewire/Widgets/HumanResources/SickRateBoxTest.php
@@ -42,15 +42,15 @@ test('renders successfully', function (): void {
 });
 
 test('calculates sick rate from employee days in current month', function (): void {
+    // Travel mid-month so the four generated days fit in the [startOfMonth, now()] range.
+    $this->travelTo(now()->startOfMonth()->addDays(20));
+
     $dateInMonth = now()->startOfMonth()->addDays(2);
-    if ($dateInMonth->isAfter(now())) {
-        $dateInMonth = now()->subDay();
-    }
 
     // Create 4 work days, 1 of which is sick
     for ($i = 0; $i < 4; $i++) {
         $date = $dateInMonth->copy()->addDays($i);
-        if ($date->isAfter(now()->endOfMonth())) {
+        if ($date->isAfter(now())) {
             break;
         }
 
@@ -80,10 +80,9 @@ test('calculates sick rate from employee days in current month', function (): vo
 });
 
 test('sub value shows total sick days', function (): void {
+    $this->travelTo(now()->startOfMonth()->addDays(20));
+
     $dateInMonth = now()->startOfMonth()->addDay();
-    if ($dateInMonth->isAfter(now())) {
-        $dateInMonth = now()->subDay();
-    }
 
     app(EmployeeDay::class)->create([
         'employee_id' => $this->employee->getKey(),

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -201,3 +201,30 @@ function waitForElement(PendingAwaitablePage|AwaitableWebpage $page, string $sel
 
     return $page;
 }
+
+/**
+ * Wait until a JavaScript condition (an arrow function returning truthy/falsy)
+ * resolves to a truthy value. Use this instead of fixed `wait(N)` calls so
+ * tests don't sleep longer than necessary and don't flake on slower runs.
+ */
+function waitForCondition(PendingAwaitablePage|AwaitableWebpage $page, string $condition, int $timeout = 5000): PendingAwaitablePage|AwaitableWebpage
+{
+    $page->script(<<<JS
+        () => new Promise((resolve, reject) => {
+            const condition = {$condition};
+            const deadline = Date.now() + {$timeout};
+            const check = () => {
+                try {
+                    if (condition()) return resolve();
+                } catch (e) { /* keep retrying until deadline */ }
+                if (Date.now() > deadline) {
+                    return reject(new Error('Condition did not become truthy within {$timeout}ms'));
+                }
+                setTimeout(check, 100);
+            };
+            check();
+        })
+    JS);
+
+    return $page;
+}


### PR DESCRIPTION
## Summary
- The renderless validation helper only walked `component.el` to sync ring/text/visibility, so anything Alpine had teleported out of the tree (notably `<x-modal>` contents which `x-teleport` to `<body>`) was missed and stayed visually un-validated.
- New `queryAllScoped()` helper also walks every `[data-teleport-target]` whose `_x_teleportBack` origin lives inside the component, so styled selects, inputs, and published `@error` spans inside modals get the same treatment as the rest of the form.
- Adds a browser test covering the modal scenario alongside the existing input/textarea/number/select/toggle cases.

## Summary by Sourcery

Extend renderless validation handling so that form controls and error displays inside teleported modal contents receive the same inline validation styling and visibility as in-page fields.

Bug Fixes:
- Ensure inline validation errors are applied to teleported modal contents such as x-modal and styled selects.

Enhancements:
- Add a scoped DOM query helper that includes teleported descendants when processing validation states.

Tests:
- Add a browser test component and scenario to verify validation errors render correctly inside teleported x-modal contents.