### PR TITLE
Fix duplicate Livewire components inside TallStackUI modals (nested teleport regression)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spatie/laravel-settings": "^3.4",
         "spatie/laravel-tags": "^4.3",
         "spatie/pdf-to-image": "^3.0",
-        "tallstackui/tallstackui": "^3.2",
+        "tallstackui/tallstackui": "^3.2.2",
         "team-nifty-gmbh/tall-datatables": "^2.4.10",
         "webklex/laravel-imap": "^6.1"
     },

--- a/resources/views/components/dashboard/widget-select.blade.php
+++ b/resources/views/components/dashboard/widget-select.blade.php
@@ -1,40 +1,38 @@
-@teleport('body')
-    <x-modal id="widget-list" scrollable>
-        <div class="h-full overflow-auto p-2.5">
-            <div class="flex items-center justify-between pb-6">
-                <h2
-                    class="flex-1 truncate text-lg font-semibold text-gray-700 dark:text-gray-400"
-                >
-                    {{ __('Available Widgets') }}
-                </h2>
-                <div
-                    x-cloak
-                    x-show="isLoading"
-                    class="border-primary-200 border-t-primary-500 h-6 w-6 animate-spin rounded-full border-4 dark:border-white dark:border-t-gray-400"
-                ></div>
-            </div>
-            <x-flux::checkbox-tree
-                tree="$wire.availableWidgetsTree"
-                name-attribute="label"
-                :with-search="true"
-                :hide-icon="true"
-                x-on:folder-tree-select="
-                    if (!$event.detail.children) {
-                        isLoading
-                            ? null
-                            : selectWidget($event.detail.component_name);
-                    }
-                "
+<x-modal id="widget-list" scrollable>
+    <div class="h-full overflow-auto p-2.5">
+        <div class="flex items-center justify-between pb-6">
+            <h2
+                class="flex-1 truncate text-lg font-semibold text-gray-700 dark:text-gray-400"
+            >
+                {{ __('Available Widgets') }}
+            </h2>
+            <div
+                x-cloak
+                x-show="isLoading"
+                class="border-primary-200 border-t-primary-500 h-6 w-6 animate-spin rounded-full border-4 dark:border-white dark:border-t-gray-400"
+            ></div>
+        </div>
+        <x-flux::checkbox-tree
+            tree="$wire.availableWidgetsTree"
+            name-attribute="label"
+            :with-search="true"
+            :hide-icon="true"
+            x-on:folder-tree-select="
+                if (!$event.detail.children) {
+                    isLoading
+                        ? null
+                        : selectWidget($event.detail.component_name);
+                }
+            "
+        />
+    </div>
+    <x-slot:footer>
+        <div class="flex justify-end">
+            <x-button
+                color="secondary"
+                :text="__('Close')"
+                x-on:click="$tsui.close.modal('widget-list')"
             />
         </div>
-        <x-slot:footer>
-            <div class="flex justify-end">
-                <x-button
-                    color="secondary"
-                    :text="__('Close')"
-                    x-on:click="$tsui.close.modal('widget-list')"
-                />
-            </div>
-        </x-slot:footer>
-    </x-modal>
-@endteleport
+    </x-slot:footer>
+</x-modal>

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -7,162 +7,148 @@
         },
     }"
 >
-    @teleport('body')
-        <x-modal id="transaction-assign-orders-modal" size="7xl">
-            <x-slot:title>
-                <div class="flex w-full flex-col">
-                    <div class="flex flex-row gap-2">
-                        <span
-                            x-text="$wire.transactionForm.counterpart_name"
-                        ></span>
-                        <span
-                            class="text-red-600"
-                            x-html="
-                                $nuxbe.format.money(
-                                    $wire.transactionForm.amount,
-                                    { colored: true },
-                                )
-                            "
-                        ></span>
-                    </div>
-                    <div
-                        class="text-xs"
-                        x-text="
-                            $nuxbe.format.date(
-                                $wire.transactionForm.booking_date,
-                            )
+    <x-modal id="transaction-assign-orders-modal" size="7xl">
+        <x-slot:title>
+            <div class="flex w-full flex-col">
+                <div class="flex flex-row gap-2">
+                    <span
+                        x-text="$wire.transactionForm.counterpart_name"
+                    ></span>
+                    <span
+                        class="text-red-600"
+                        x-html="
+                            $nuxbe.format.money($wire.transactionForm.amount, {
+                                colored: true,
+                            })
                         "
-                    ></div>
-                    <div
-                        class="mt-2 flex w-full flex-row justify-between border-t border-slate-200 pt-2"
-                    >
-                        <div x-text="$wire.transactionForm.purpose"></div>
-                    </div>
+                    ></span>
                 </div>
-            </x-slot:title>
-            <livewire:accounting.order-list wire:model="selectedOrders" lazy />
-            <x-slot:footer>
-                <x-button
-                    color="secondary"
-                    :text="__('Cancel')"
-                    x-on:click="
-                        $tsui.close.modal('transaction-assign-orders-modal')
-                    "
-                />
-                @stack('transaction-assign-orders-modal-footer')
-                <x-button :text="__('Assign')" wire:click="assignOrders" />
-            </x-slot:footer>
-        </x-modal>
-    @endteleport
-
-    @teleport('body')
-        <x-modal id="transaction-comments-modal">
-            <x-slot:title>
-                <div class="flex w-full flex-col">
-                    <div class="flex flex-row gap-2">
-                        <span
-                            x-text="$wire.transactionForm.counterpart_name"
-                        ></span>
-                        <span
-                            class="text-red-600"
-                            x-html="
-                                $nuxbe.format.money(
-                                    $wire.transactionForm.amount,
-                                    { colored: true },
-                                )
-                            "
-                        ></span>
-                    </div>
-                    <div
-                        class="text-xs"
-                        x-text="
-                            $nuxbe.format.date(
-                                $wire.transactionForm.booking_date,
-                            )
-                        "
-                    ></div>
-                    <div
-                        class="mt-2 flex w-full flex-row justify-between border-t border-slate-200 pt-2"
-                    >
-                        <div x-text="$wire.transactionForm.purpose"></div>
-                    </div>
-                </div>
-            </x-slot:title>
-            <livewire:accounting.transactions.comments
-                :model-type="\FluxErp\Models\Transaction::class"
-                wire:model="transactionForm.id"
-                lazy
-                :is-public="false"
-            />
-            <x-slot:footer>
-                <x-button
-                    color="secondary"
-                    :text="__('Cancel')"
-                    x-on:click="$tsui.close.modal('transaction-comments-modal')"
-                />
-                @stack('transaction-comments-modal-footer')
-            </x-slot:footer>
-        </x-modal>
-    @endteleport
-
-    @teleport('body')
-        <x-modal
-            id="order-transaction-modal"
-            x-on:open="$tsui.focus('order-transaction-amount')"
-        >
-            <div class="flex flex-col gap-4">
-                <x-number
-                    id="order-transaction-amount"
-                    :label="__('Amount')"
-                    wire:model="orderTransactionForm.amount"
-                    step="0.01"
-                    :corner-hint="__('Amount')"
-                    placeholder="0.00"
-                />
                 <div
-                    x-cloak
-                    x-show="$wire.orderTransactionForm.orderCurrencyIso"
-                    class="flex flex-col gap-4"
+                    class="text-xs"
+                    x-text="
+                        $nuxbe.format.date($wire.transactionForm.booking_date)
+                    "
+                ></div>
+                <div
+                    class="mt-2 flex w-full flex-row justify-between border-t border-slate-200 pt-2"
                 >
-                    <x-number
-                        :label="__('Exchange Rate')"
-                        wire:model="orderTransactionForm.exchange_rate"
-                        step="0.0001"
-                        placeholder="0.0000"
-                        x-on:change="$wire.calcOrderCurrencyAmount()"
-                    />
-                    <x-number
-                        wire:model="orderTransactionForm.order_currency_amount"
-                        step="0.01"
-                        placeholder="0.00"
-                        x-on:change="$wire.calcExchangeRate()"
-                    >
-                        <x-slot:label>
-                            {{ __('Order Currency Amount') }} (
-                            <span
-                                x-text="
-                                    $wire.orderTransactionForm.orderCurrencyIso
-                                "
-                            ></span>
-                            )
-                        </x-slot:label>
-                    </x-number>
+                    <div x-text="$wire.transactionForm.purpose"></div>
                 </div>
             </div>
-            <x-slot:footer>
-                <x-button
-                    color="secondary"
-                    :text="__('Cancel')"
-                    x-on:click="$tsui.close.modal('order-transaction-modal')"
+        </x-slot:title>
+        <livewire:accounting.order-list wire:model="selectedOrders" lazy />
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="
+                    $tsui.close.modal('transaction-assign-orders-modal')
+                "
+            />
+            @stack('transaction-assign-orders-modal-footer')
+            <x-button :text="__('Assign')" wire:click="assignOrders" />
+        </x-slot:footer>
+    </x-modal>
+
+    <x-modal id="transaction-comments-modal">
+        <x-slot:title>
+            <div class="flex w-full flex-col">
+                <div class="flex flex-row gap-2">
+                    <span
+                        x-text="$wire.transactionForm.counterpart_name"
+                    ></span>
+                    <span
+                        class="text-red-600"
+                        x-html="
+                            $nuxbe.format.money($wire.transactionForm.amount, {
+                                colored: true,
+                            })
+                        "
+                    ></span>
+                </div>
+                <div
+                    class="text-xs"
+                    x-text="
+                        $nuxbe.format.date($wire.transactionForm.booking_date)
+                    "
+                ></div>
+                <div
+                    class="mt-2 flex w-full flex-row justify-between border-t border-slate-200 pt-2"
+                >
+                    <div x-text="$wire.transactionForm.purpose"></div>
+                </div>
+            </div>
+        </x-slot:title>
+        <livewire:accounting.transactions.comments
+            :model-type="\FluxErp\Models\Transaction::class"
+            wire:model="transactionForm.id"
+            lazy
+            :is-public="false"
+        />
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="$tsui.close.modal('transaction-comments-modal')"
+            />
+            @stack('transaction-comments-modal-footer')
+        </x-slot:footer>
+    </x-modal>
+
+    <x-modal
+        id="order-transaction-modal"
+        x-on:open="$tsui.focus('order-transaction-amount')"
+    >
+        <div class="flex flex-col gap-4">
+            <x-number
+                id="order-transaction-amount"
+                :label="__('Amount')"
+                wire:model="orderTransactionForm.amount"
+                step="0.01"
+                :corner-hint="__('Amount')"
+                placeholder="0.00"
+            />
+            <div
+                x-cloak
+                x-show="$wire.orderTransactionForm.orderCurrencyIso"
+                class="flex flex-col gap-4"
+            >
+                <x-number
+                    :label="__('Exchange Rate')"
+                    wire:model="orderTransactionForm.exchange_rate"
+                    step="0.0001"
+                    placeholder="0.0000"
+                    x-on:change="$wire.calcOrderCurrencyAmount()"
                 />
-                @stack('order-transaction-modal-footer')
-                <x-button
-                    :text="__('Save')"
-                    x-on:click="$wire.saveOrderTransaction()"
-                />
-            </x-slot:footer>
-        </x-modal>
-    @endteleport
+                <x-number
+                    wire:model="orderTransactionForm.order_currency_amount"
+                    step="0.01"
+                    placeholder="0.00"
+                    x-on:change="$wire.calcExchangeRate()"
+                >
+                    <x-slot:label>
+                        {{ __('Order Currency Amount') }} (
+                        <span
+                            x-text="$wire.orderTransactionForm.orderCurrencyIso"
+                        ></span>
+                        )
+                    </x-slot:label>
+                </x-number>
+            </div>
+        </div>
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="$tsui.close.modal('order-transaction-modal')"
+            />
+            @stack('order-transaction-modal-footer')
+            <x-button
+                :text="__('Save')"
+                x-on:click="$wire.saveOrderTransaction()"
+            />
+        </x-slot:footer>
+    </x-modal>
 
     <div class="flex flex-col gap-4 text-sm">
         <div class="flex flex-col">

--- a/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
+++ b/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
@@ -21,15 +21,19 @@
     @php
         $editComponent = $event->edit_component ?? 'features.calendar.calendar-event';
     @endphp
-    <x-modal id="edit-event-modal" scope="headless" persistent>
-        <div>
-            <livewire:dynamic-component
-                :is="$editComponent"
-                :wire:key="$editComponent"
-                wire:model="event"
-            />
-        </div>
-    </x-modal>
+    <div wire:ignore>
+        @teleport('body')
+            <x-modal id="edit-event-modal" scope="headless" persistent>
+                <div>
+                    <livewire:dynamic-component
+                        :is="$editComponent"
+                        :wire:key="$editComponent"
+                        wire:model="event"
+                    />
+                </div>
+            </x-modal>
+        @endteleport
+    </div>
 
     @teleport('body')
         <x-modal id="confirm-dialog" scope="headless" persistent center>

--- a/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
+++ b/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
@@ -21,138 +21,126 @@
     @php
         $editComponent = $event->edit_component ?? 'features.calendar.calendar-event';
     @endphp
-    <div wire:ignore>
-        @teleport('body')
-            <x-modal id="edit-event-modal" scope="headless" persistent>
-                <div>
-                    <livewire:dynamic-component
-                        :is="$editComponent"
-                        :wire:key="$editComponent"
-                        wire:model="event"
-                    />
-                </div>
-            </x-modal>
-        @endteleport
-    </div>
+    <x-modal id="edit-event-modal" scope="headless" persistent>
+        <div>
+            <livewire:dynamic-component
+                :is="$editComponent"
+                :wire:key="$editComponent"
+                wire:model="event"
+            />
+        </div>
+    </x-modal>
 
-    @teleport('body')
-        <x-modal id="confirm-dialog" scope="headless" persistent center>
-            <x-card>
+    <x-modal id="confirm-dialog" scope="headless" persistent center>
+        <x-card>
+            <div
+                x-show="$wire.event.was_repeatable && dialogType !== 'cancel'"
+                x-cloak
+                class="space-y-2"
+            >
                 <div
-                    x-show="
-                        $wire.event.was_repeatable && dialogType !== 'cancel'
-                    "
-                    x-cloak
-                    class="space-y-2"
-                >
-                    <div
-                        x-show="
-                            !$wire.event.has_repeats || dialogType === 'delete'
-                        "
-                        x-cloak
-                    >
-                        <x-radio
-                            id="this-event-radio"
-                            name="confirm-option-radio"
-                            :label="__('This event')"
-                            value="this"
-                            wire:model="event.confirm_option"
-                        />
-                    </div>
-                    <div>
-                        <x-radio
-                            id="future-event-radio"
-                            name="confirm-option-radio"
-                            :label="__('This event and following')"
-                            value="future"
-                            wire:model="event.confirm_option"
-                        />
-                    </div>
-                    <div>
-                        <x-radio
-                            id="all-event-radio"
-                            name="confirm-option-radio"
-                            :label="__('All events')"
-                            value="all"
-                            wire:model="event.confirm_option"
-                        />
-                    </div>
-                </div>
-                <div
-                    x-show="
-                        !$wire.event.was_repeatable || dialogType === 'cancel'
-                    "
+                    x-show="!$wire.event.has_repeats || dialogType === 'delete'"
                     x-cloak
                 >
-                    <div
-                        class="mx-auto flex h-12 w-12 items-center justify-center rounded-full"
-                    >
-                        <x-dynamic-component
-                            :component="TallStackUi::prefix('icon')"
-                            :icon="TallStackUi::icon('x-circle')"
-                            class="h-8 w-8"
-                            color="red"
-                            outline
-                            internal
-                        />
-                    </div>
-                    <div class="mt-3 text-center sm:mt-5">
-                        <div x-show="dialogType === 'cancel'" x-cloak>
-                            <h3
-                                class="dark:text-dark-200 text-lg leading-6 font-semibold text-gray-700"
-                                x-html="'{{ __('Cancel :model', ['model' => __('Calendar Event')]) }}'"
-                            ></h3>
-                            <div class="mt-2">
-                                <p
-                                    class="dark:text-dark-300 text-sm text-gray-500"
-                                    x-html="'{{ __('Do you really want to cancel this :model?', ['model' => __('Calendar Event')]) }}'"
-                                ></p>
-                            </div>
-                        </div>
-                        <div x-show="dialogType === 'delete'" x-cloak>
-                            <h3
-                                class="dark:text-dark-200 text-lg leading-6 font-semibold text-gray-700"
-                                x-html="'{{ __('Delete :model', ['model' => __('Calendar Event')]) }}'"
-                            ></h3>
-                            <div class="mt-2">
-                                <p
-                                    class="dark:text-dark-300 text-sm text-gray-500"
-                                    x-html="'{{ __('Do you really want to delete this :model?', ['model' => __('Calendar Event')]) }}'"
-                                ></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <x-slot:footer>
-                    <x-button
-                        :text="__('Cancel')"
-                        color="secondary"
-                        light
-                        x-on:click="$tsui.close.modal('confirm-dialog')"
+                    <x-radio
+                        id="this-event-radio"
+                        name="confirm-option-radio"
+                        :label="__('This event')"
+                        value="this"
+                        wire:model="event.confirm_option"
                     />
-                    <div x-show="dialogType === 'cancel'">
-                        <x-button
-                            :text="__('Cancel Event')"
-                            color="red"
-                            x-on:click="$dispatch('cancel-calendar-event')"
-                        />
+                </div>
+                <div>
+                    <x-radio
+                        id="future-event-radio"
+                        name="confirm-option-radio"
+                        :label="__('This event and following')"
+                        value="future"
+                        wire:model="event.confirm_option"
+                    />
+                </div>
+                <div>
+                    <x-radio
+                        id="all-event-radio"
+                        name="confirm-option-radio"
+                        :label="__('All events')"
+                        value="all"
+                        wire:model="event.confirm_option"
+                    />
+                </div>
+            </div>
+            <div
+                x-show="!$wire.event.was_repeatable || dialogType === 'cancel'"
+                x-cloak
+            >
+                <div
+                    class="mx-auto flex h-12 w-12 items-center justify-center rounded-full"
+                >
+                    <x-dynamic-component
+                        :component="TallStackUi::prefix('icon')"
+                        :icon="TallStackUi::icon('x-circle')"
+                        class="h-8 w-8"
+                        color="red"
+                        outline
+                        internal
+                    />
+                </div>
+                <div class="mt-3 text-center sm:mt-5">
+                    <div x-show="dialogType === 'cancel'" x-cloak>
+                        <h3
+                            class="dark:text-dark-200 text-lg leading-6 font-semibold text-gray-700"
+                            x-html="'{{ __('Cancel :model', ['model' => __('Calendar Event')]) }}'"
+                        ></h3>
+                        <div class="mt-2">
+                            <p
+                                class="dark:text-dark-300 text-sm text-gray-500"
+                                x-html="'{{ __('Do you really want to cancel this :model?', ['model' => __('Calendar Event')]) }}'"
+                            ></p>
+                        </div>
                     </div>
-                    <div x-show="dialogType === 'delete'">
-                        <x-button
-                            :text="__('Delete')"
-                            color="red"
-                            x-on:click="$dispatch('delete-calendar-event')"
-                        />
+                    <div x-show="dialogType === 'delete'" x-cloak>
+                        <h3
+                            class="dark:text-dark-200 text-lg leading-6 font-semibold text-gray-700"
+                            x-html="'{{ __('Delete :model', ['model' => __('Calendar Event')]) }}'"
+                        ></h3>
+                        <div class="mt-2">
+                            <p
+                                class="dark:text-dark-300 text-sm text-gray-500"
+                                x-html="'{{ __('Do you really want to delete this :model?', ['model' => __('Calendar Event')]) }}'"
+                            ></p>
+                        </div>
                     </div>
-                    <div x-show="dialogType === 'save'">
-                        <x-button
-                            :text="__('Save')"
-                            color="indigo"
-                            x-on:click="$dispatch('save-calendar-event')"
-                        />
-                    </div>
-                </x-slot:footer>
-            </x-card>
-        </x-modal>
-    @endteleport
+                </div>
+            </div>
+            <x-slot:footer>
+                <x-button
+                    :text="__('Cancel')"
+                    color="secondary"
+                    light
+                    x-on:click="$tsui.close.modal('confirm-dialog')"
+                />
+                <div x-show="dialogType === 'cancel'">
+                    <x-button
+                        :text="__('Cancel Event')"
+                        color="red"
+                        x-on:click="$dispatch('cancel-calendar-event')"
+                    />
+                </div>
+                <div x-show="dialogType === 'delete'">
+                    <x-button
+                        :text="__('Delete')"
+                        color="red"
+                        x-on:click="$dispatch('delete-calendar-event')"
+                    />
+                </div>
+                <div x-show="dialogType === 'save'">
+                    <x-button
+                        :text="__('Save')"
+                        color="indigo"
+                        x-on:click="$dispatch('save-calendar-event')"
+                    />
+                </div>
+            </x-slot:footer>
+        </x-card>
+    </x-modal>
 </div>

--- a/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
+++ b/resources/views/livewire/features/calendar/calendar-event-edit.blade.php
@@ -18,16 +18,18 @@
             });
     "
 >
-    @teleport('body')
-        <x-modal id="edit-event-modal" scope="headless" persistent>
-            <div>
-                <livewire:dynamic-component
-                    wire:model="event"
-                    :is="$event->edit_component ?? 'features.calendar.calendar-event'"
-                />
-            </div>
-        </x-modal>
-    @endteleport
+    @php
+        $editComponent = $event->edit_component ?? 'features.calendar.calendar-event';
+    @endphp
+    <x-modal id="edit-event-modal" scope="headless" persistent>
+        <div>
+            <livewire:dynamic-component
+                :is="$editComponent"
+                :wire:key="$editComponent"
+                wire:model="event"
+            />
+        </div>
+    </x-modal>
 
     @teleport('body')
         <x-modal id="confirm-dialog" scope="headless" persistent center>

--- a/resources/views/livewire/features/calendar/calendar.blade.php
+++ b/resources/views/livewire/features/calendar/calendar.blade.php
@@ -8,143 +8,139 @@
 >
     <livewire:features.calendar.calendar-event-edit wire:model="event" />
     @section('calendar-modal')
-        @teleport('body')
-            <x-modal id="calendar-modal" :title="__('Edit Calendar')">
-                @section('calendar-edit')
-                    <div class="flex flex-col gap-4">
-                        <div id="parent-calendar-select">
-                            <x-select.styled
-                                wire:model="calendar.parent_id"
-                                :label="__('Parent Calendar')"
-                                required
-                                select="label:label|value:id"
-                                :request="[
-                            'url' => route('calendar-search'),
-                            'method' => 'POST',
-                            'params' => [
-                                'onlyGroups' => true,
-                            ]
-                        ]"
-                            />
-                        </div>
-                        <x-input
-                            wire:model="calendar.name"
-                            :label="__('Calendar Name')"
+        <x-modal id="calendar-modal" :title="__('Edit Calendar')">
+            @section('calendar-edit')
+                <div class="flex flex-col gap-4">
+                    <div id="parent-calendar-select">
+                        <x-select.styled
+                            wire:model="calendar.parent_id"
+                            :label="__('Parent Calendar')"
+                            required
+                            select="label:label|value:id"
+                            :request="[
+                        'url' => route('calendar-search'),
+                        'method' => 'POST',
+                        'params' => [
+                            'onlyGroups' => true,
+                        ]
+                    ]"
                         />
-                        <x-input
-                            class="p-0"
-                            type="color"
-                            :label="__('Color')"
-                            wire:model="calendar.color"
+                    </div>
+                    <x-input
+                        wire:model="calendar.name"
+                        :label="__('Calendar Name')"
+                    />
+                    <x-input
+                        class="p-0"
+                        type="color"
+                        :label="__('Color')"
+                        wire:model="calendar.color"
+                    />
+                    <div x-show="!$wire.calendar.id" x-cloak>
+                        <x-checkbox
+                            wire:model="calendar.is_group"
+                            :label="__('Is Group')"
                         />
-                        <div x-show="!$wire.calendar.id" x-cloak>
-                            <x-checkbox
-                                wire:model="calendar.is_group"
-                                :label="__('Is Group')"
-                            />
-                        </div>
-                        <div x-show="!$wire.calendar.is_group" x-cloak>
-                            <x-checkbox
-                                wire:model="calendar.has_repeatable_events"
-                                :label="__('Has repeatable events')"
-                            />
-                        </div>
-                        @canAction(\FluxErp\Actions\Calendar\CreatePublicCalendar::class)
-                            <x-checkbox
-                                wire:model="calendar.is_public"
-                                :label="__('Public')"
-                            />
-                        @endcanAction
+                    </div>
+                    <div x-show="!$wire.calendar.is_group" x-cloak>
+                        <x-checkbox
+                            wire:model="calendar.has_repeatable_events"
+                            :label="__('Has repeatable events')"
+                        />
+                    </div>
+                    @canAction(\FluxErp\Actions\Calendar\CreatePublicCalendar::class)
+                        <x-checkbox
+                            wire:model="calendar.is_public"
+                            :label="__('Public')"
+                        />
+                    @endcanAction
 
-                        <div x-show="!$wire.calendar.is_group" x-cloak>
-                            <x-card :header="__('Custom Properties')">
-                                <div class="flex flex-col gap-4">
-                                    <x-button.circle
-                                        class="mr-2"
-                                        color="indigo"
-                                        icon="plus"
-                                        wire:click="addCustomProperty()"
-                                    />
-                                    <template
-                                        x-for="
-                                            (customProperty, index) in
-                                                $wire.calendar
-                                                    .custom_properties ?? []
-                                        "
-                                    >
-                                        <div class="flex gap-x-4">
-                                            <div class="pt-6">
-                                                <x-button.circle
-                                                    color="red"
-                                                    icon="trash"
-                                                    wire:click="removeCustomProperty(index)"
-                                                />
-                                            </div>
-                                            <div class="max-w-sm">
-                                                <x-select.styled
-                                                    x-model="
-                                                        customProperty.field_type
-                                                    "
-                                                    :label="__('Field Type')"
-                                                    required
-                                                    :options="$this->fieldTypes"
-                                                />
-                                            </div>
-                                            <div class="w-full">
-                                                <x-input
-                                                    x-model="
-                                                        customProperty.name
-                                                    "
-                                                    :label="__('Name')"
-                                                />
-                                            </div>
+                    <div x-show="!$wire.calendar.is_group" x-cloak>
+                        <x-card :header="__('Custom Properties')">
+                            <div class="flex flex-col gap-4">
+                                <x-button.circle
+                                    class="mr-2"
+                                    color="indigo"
+                                    icon="plus"
+                                    wire:click="addCustomProperty()"
+                                />
+                                <template
+                                    x-for="
+                                        (customProperty, index) in
+                                            $wire.calendar.custom_properties ??
+                                        []
+                                    "
+                                >
+                                    <div class="flex gap-x-4">
+                                        <div class="pt-6">
+                                            <x-button.circle
+                                                color="red"
+                                                icon="trash"
+                                                wire:click="removeCustomProperty(index)"
+                                            />
                                         </div>
-                                    </template>
-                                </div>
-                            </x-card>
-                        </div>
+                                        <div class="max-w-sm">
+                                            <x-select.styled
+                                                x-model="
+                                                    customProperty.field_type
+                                                "
+                                                :label="__('Field Type')"
+                                                required
+                                                :options="$this->fieldTypes"
+                                            />
+                                        </div>
+                                        <div class="w-full">
+                                            <x-input
+                                                x-model="customProperty.name"
+                                                :label="__('Name')"
+                                            />
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </x-card>
                     </div>
-                @show
-                <x-slot:footer>
-                    <div class="flex w-full justify-between gap-2">
-                        <div>
-                            <x-button
-                                x-show="$wire.calendar.is_editable && '{{ resolve_static(\FluxErp\Actions\Calendar\DeleteCalendar::class, 'canPerformAction', [false]) }}'"
-                                flat
-                                color="red"
-                                :text="__('Delete')"
-                                wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Calendar')]) }}"
-                                x-on:click="
-                                    $wire.deleteCalendar().then((deletedId) => {
-                                        if (deletedId !== false)
-                                            deleteCalendar(deletedId);
-                                    })
-                                "
-                            />
-                        </div>
-                        <div class="flex gap-2">
-                            <x-button
-                                color="secondary"
-                                light
-                                flat
-                                :text="__('Cancel')"
-                                x-on:click="$tsui.close.modal('calendar-modal')"
-                            />
-                            <x-button
-                                color="indigo"
-                                :text="__('Save')"
-                                x-on:click="
-                                    saveCalendar().then((success) => {
-                                        if (success)
-                                            $tsui.close.modal('calendar-modal');
-                                    })
-                                "
-                            />
-                        </div>
+                </div>
+            @show
+            <x-slot:footer>
+                <div class="flex w-full justify-between gap-2">
+                    <div>
+                        <x-button
+                            x-show="$wire.calendar.is_editable && '{{ resolve_static(\FluxErp\Actions\Calendar\DeleteCalendar::class, 'canPerformAction', [false]) }}'"
+                            flat
+                            color="red"
+                            :text="__('Delete')"
+                            wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Calendar')]) }}"
+                            x-on:click="
+                                $wire.deleteCalendar().then((deletedId) => {
+                                    if (deletedId !== false)
+                                        deleteCalendar(deletedId);
+                                })
+                            "
+                        />
                     </div>
-                </x-slot:footer>
-            </x-modal>
-        @endteleport
+                    <div class="flex gap-2">
+                        <x-button
+                            color="secondary"
+                            light
+                            flat
+                            :text="__('Cancel')"
+                            x-on:click="$tsui.close.modal('calendar-modal')"
+                        />
+                        <x-button
+                            color="indigo"
+                            :text="__('Save')"
+                            x-on:click="
+                                saveCalendar().then((success) => {
+                                    if (success)
+                                        $tsui.close.modal('calendar-modal');
+                                })
+                            "
+                        />
+                    </div>
+                </div>
+            </x-slot:footer>
+        </x-modal>
 
     @show
     @if($showCalendars)

--- a/resources/views/livewire/order/accounting.blade.php
+++ b/resources/views/livewire/order/accounting.blade.php
@@ -186,68 +186,64 @@
         </div>
     </x-card>
 
-    @teleport('body')
-        <x-modal
-            id="order-transaction-modal"
-            x-on:open="$tsui.focus('order-transaction-amount')"
-        >
-            <div class="flex flex-col gap-4">
+    <x-modal
+        id="order-transaction-modal"
+        x-on:open="$tsui.focus('order-transaction-amount')"
+    >
+        <div class="flex flex-col gap-4">
+            <x-number
+                id="order-transaction-amount"
+                :label="__('Amount')"
+                wire:model="orderTransactionForm.amount"
+                step="0.01"
+                :corner-hint="__('Amount')"
+                placeholder="0.00"
+            />
+            <div
+                x-cloak
+                x-show="$wire.orderTransactionForm.orderCurrencyIso"
+                class="flex flex-col gap-4"
+            >
                 <x-number
-                    id="order-transaction-amount"
-                    :label="__('Amount')"
-                    wire:model="orderTransactionForm.amount"
+                    :label="__('Exchange Rate')"
+                    wire:model="orderTransactionForm.exchange_rate"
+                    step="0.0001"
+                    placeholder="0.0000"
+                    x-on:change="$wire.calcOrderCurrencyAmount()"
+                />
+                <x-number
+                    wire:model="orderTransactionForm.order_currency_amount"
                     step="0.01"
-                    :corner-hint="__('Amount')"
                     placeholder="0.00"
-                />
-                <div
-                    x-cloak
-                    x-show="$wire.orderTransactionForm.orderCurrencyIso"
-                    class="flex flex-col gap-4"
+                    x-on:change="$wire.calcExchangeRate()"
                 >
-                    <x-number
-                        :label="__('Exchange Rate')"
-                        wire:model="orderTransactionForm.exchange_rate"
-                        step="0.0001"
-                        placeholder="0.0000"
-                        x-on:change="$wire.calcOrderCurrencyAmount()"
-                    />
-                    <x-number
-                        wire:model="orderTransactionForm.order_currency_amount"
-                        step="0.01"
-                        placeholder="0.00"
-                        x-on:change="$wire.calcExchangeRate()"
-                    >
-                        <x-slot:label>
-                            {{ __('Order Currency Amount') }} (
-                            <span
-                                x-text="
-                                    $wire.orderTransactionForm.orderCurrencyIso
-                                "
-                            ></span>
-                            )
-                        </x-slot:label>
-                    </x-number>
-                </div>
+                    <x-slot:label>
+                        {{ __('Order Currency Amount') }} (
+                        <span
+                            x-text="$wire.orderTransactionForm.orderCurrencyIso"
+                        ></span>
+                        )
+                    </x-slot:label>
+                </x-number>
             </div>
-            <x-slot:footer>
-                <x-button
-                    color="secondary"
-                    :text="__('Cancel')"
-                    x-on:click="$tsui.close.modal('order-transaction-modal')"
-                />
-                <x-button
-                    :text="__('Save')"
-                    x-on:click="
-                        $wire.save().then((success) => {
-                            if (success)
-                                $tsui.close.modal('order-transaction-modal');
-                        })
-                    "
-                />
-            </x-slot:footer>
-        </x-modal>
-    @endteleport
+        </div>
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="$tsui.close.modal('order-transaction-modal')"
+            />
+            <x-button
+                :text="__('Save')"
+                x-on:click="
+                    $wire.save().then((success) => {
+                        if (success)
+                            $tsui.close.modal('order-transaction-modal');
+                    })
+                "
+            />
+        </x-slot:footer>
+    </x-modal>
 
     <x-modal
         id="reset-payment-reminder-level-modal"

--- a/resources/views/livewire/order/additional-addresses.blade.php
+++ b/resources/views/livewire/order/additional-addresses.blade.php
@@ -1,62 +1,54 @@
 <div class="flex flex-col gap-4">
-    <div wire:ignore>
-        @teleport('body')
-            <x-modal id="edit-address-assignment">
-                <div class="flex flex-col gap-4">
-                    <x-select.styled
-                        :label="__('Address')"
-                        wire:model="address_id"
-                        select="label:label|value:id"
-                        unfiltered
-                        :request="[
-                            'url' => route('search', \FluxErp\Models\Address::class),
-                            'method' => 'POST',
-                            'params' => [
-                                'fields' => [
-                                  'contact_id',
-                                  'name',
-                                ],
-                                'with' => 'contact.media',
-                                'scopes' => [
-                                    'whereHasTenant' => [$tenantId],
-                                ],
-                            ],
-                        ]"
-                    />
-                    <x-select.styled
-                        :label="__('Type')"
-                        wire:model="address_type_id"
-                        select="label:name|value:id"
-                        :options="resolve_static(\FluxErp\Models\AddressType::class, 'query')->whereHasTenant($tenantId)->get(['id', 'name'])->toArray()"
-                    />
-                </div>
-                <x-slot:footer>
-                    <x-button
-                        color="secondary"
-                        light
-                        flat
-                        :text="__('Cancel')"
-                        x-on:click="
-                            $tsui.close.modal('edit-address-assignment')
-                        "
-                    />
-                    <x-button
-                        color="indigo"
-                        loading="save"
-                        x-on:click="
-                            $wire.save().then((success) => {
-                                if (success)
-                                    $tsui.close.modal(
-                                        'edit-address-assignment',
-                                    );
-                            })
-                        "
-                        :text="__('Save')"
-                    />
-                </x-slot:footer>
-            </x-modal>
-        @endteleport
-    </div>
+    <x-modal id="edit-address-assignment">
+        <div class="flex flex-col gap-4">
+            <x-select.styled
+                :label="__('Address')"
+                wire:model="address_id"
+                select="label:label|value:id"
+                unfiltered
+                :request="[
+                    'url' => route('search', \FluxErp\Models\Address::class),
+                    'method' => 'POST',
+                    'params' => [
+                        'fields' => [
+                          'contact_id',
+                          'name',
+                        ],
+                        'with' => 'contact.media',
+                        'scopes' => [
+                            'whereHasTenant' => [$tenantId],
+                        ],
+                    ],
+                ]"
+            />
+            <x-select.styled
+                :label="__('Type')"
+                wire:model="address_type_id"
+                select="label:name|value:id"
+                :options="resolve_static(\FluxErp\Models\AddressType::class, 'query')->whereHasTenant($tenantId)->get(['id', 'name'])->toArray()"
+            />
+        </div>
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                light
+                flat
+                :text="__('Cancel')"
+                x-on:click="$tsui.close.modal('edit-address-assignment')"
+            />
+            <x-button
+                color="indigo"
+                loading="save"
+                x-on:click="
+                    $wire.save().then((success) => {
+                        if (success)
+                            $tsui.close.modal('edit-address-assignment');
+                    })
+                "
+                :text="__('Save')"
+            />
+        </x-slot:footer>
+    </x-modal>
     @foreach($form->addresses as $address)
         <x-card :header="$address['address_type']">
             <div class="text-sm">

--- a/tests/Browser/Features/Calendar/CalendarEventTest.php
+++ b/tests/Browser/Features/Calendar/CalendarEventTest.php
@@ -40,6 +40,41 @@ test('calendar page loads without js errors', function (): void {
     visitCalendar()->assertNoJavascriptErrors();
 });
 
+test('event edit modal renders exactly one calendar-event component', function (): void {
+    createCalendarWithOwner();
+
+    $page = visitCalendar();
+
+    $count = $page->script(<<<'JS'
+        () => new Promise((resolve) => {
+            const timeout = setTimeout(() => {
+                const modal = document.querySelector('#edit-event-modal');
+                if (!modal) {
+                    resolve('no-modal');
+                    return;
+                }
+                resolve(modal.querySelectorAll('[wire\\:name="features.calendar.calendar-event"]').length);
+            }, 5000);
+            const check = () => {
+                const modal = document.querySelector('#edit-event-modal');
+                if (!modal) { setTimeout(check, 200); return; }
+                const count = modal.querySelectorAll('[wire\\:name="features.calendar.calendar-event"]').length;
+                if (count > 0) {
+                    clearTimeout(timeout);
+                    setTimeout(() => {
+                        resolve(modal.querySelectorAll('[wire\\:name="features.calendar.calendar-event"]').length);
+                    }, 1000);
+                } else {
+                    setTimeout(check, 200);
+                }
+            };
+            check();
+        })
+    JS);
+
+    expect($count)->toBe(1, 'edit-event-modal must contain exactly one features.calendar.calendar-event component, found: ' . $count);
+});
+
 test('saving a new calendar event works without js errors', function (): void {
     createCalendarWithOwner();
 

--- a/tests/Unit/Views/RedundantTeleportPatternTest.php
+++ b/tests/Unit/Views/RedundantTeleportPatternTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+
+/*
+ * Since TallStackUI v3.2.2 every overlay component (modal/slide/sidebar)
+ * teleports its own root to <body> internally to escape ancestor
+ * containing blocks. Wrapping such an overlay in an outer @teleport('body')
+ * therefore creates a *nested* x-teleport. Alpine clones the inner template
+ * for each level of nesting, and Livewire then hydrates every cloned
+ * subtree as a separate component instance.
+ *
+ * The visible symptom is that any <livewire:...> component placed inside
+ * the modal slot ends up rendered multiple times stacked on top of each
+ * other in the DOM (see calendar new-event modal, ticket #1465).
+ *
+ * The composer constraint pins `tallstackui/tallstackui` to >= 3.2.2, so
+ * the redundant outer @teleport may never be reintroduced anywhere.
+ */
+test('no blade view wraps a TallStackUI overlay in @teleport', function (): void {
+    $offenders = [];
+
+    foreach ((new Finder())->files()->in(__DIR__ . '/../../../resources/views')->name('*.blade.php') as $file) {
+        $contents = $file->getContents();
+
+        if (! str_contains($contents, '@teleport(')) {
+            continue;
+        }
+
+        if (preg_match(
+            '/@teleport\([^)]*\)\s*(?:\{\{--.*?--\}\}\s*)*<x-(?:tall::)?(?:modal|slide)\b/s',
+            $contents
+        )) {
+            $offenders[] = str_replace(realpath(__DIR__ . '/../../../') . '/', '', $file->getRealPath());
+        }
+    }
+
+    expect($offenders)->toBe([], sprintf(
+        'TallStackUI overlays already teleport to body since v3.2.2. '
+        . 'The following blade files still wrap them in a redundant outer @teleport, '
+        . "which causes nested teleports and multiplies any Livewire component inside:\n  - %s",
+        implode("\n  - ", $offenders)
+    ));
+});


### PR DESCRIPTION
## Summary

- Since TallStackUI 3.2.2, every modal/slide overlay teleports its own root to `<body>` internally to escape ancestor containing blocks (`tallstackui/tallstackui@45327b83`). The outer `@teleport('body')` wrappers around `<x-modal>` in flux-core therefore became redundant - and harmful: Alpine clones the inner template for every nested teleport level, and Livewire then hydrates each cloned subtree as a separate component instance.
- Visible symptom: any `<livewire:...>` component inside such a modal slot was rendered three times stacked on top of each other. Most prominent regression on the calendar new-event modal (Capital C Estate / VVO ticket #1465), but `transaction-assign-orders-modal`, `transaction-comments-modal`, and `edit-address-assignment` had the same shape and would have produced the same bug for any user reaching those flows.

## Changes

- `composer.json`: bump `tallstackui/tallstackui` from `^3.2` to `^3.2.2` so the new internal teleport behaviour is guaranteed everywhere the new file structure relies on it.
- Drop the outer `@teleport('body')` wrapper around `<x-modal>` in all six call sites:
  - `resources/views/components/dashboard/widget-select.blade.php`
  - `resources/views/livewire/accounting/transaction-assignments.blade.php` (3 modals)
  - `resources/views/livewire/order/accounting.blade.php`
  - `resources/views/livewire/order/additional-addresses.blade.php`
  - `resources/views/livewire/features/calendar/calendar.blade.php`
  - `resources/views/livewire/features/calendar/calendar-event-edit.blade.php` (2 modals, plus `:wire:key` on the dynamic-component per Livewire 4 dynamic-component docs)
- Add a static-analysis Pest test (`tests/Unit/Views/RedundantTeleportPatternTest.php`) that scans every blade view and fails if `@teleport('body')` ever wraps a TallStackUI overlay again.
- Add a browser test (`tests/Browser/Features/Calendar/CalendarEventTest.php`) that asserts `#edit-event-modal` contains exactly one `features.calendar.calendar-event` component after the calendar page loads.