### PR TITLE
Link upstream TSUI PR in validation-errors helper

### DIFF
--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -1,3 +1,24 @@
+// TODO: revisit once https://github.com/tallstackui/tallstackui/pull/1254
+// ships in a TallStackUI release.
+//
+// That PR drops the @error gate from the form/error.blade.php and the
+// surrounding wrapper components, so the reactive span is in the DOM
+// from the first render. Combined with Livewire >= 4.3.0 (which made
+// $wire.$errors actually reactive — livewire/livewire#10229), most of
+// the work this file does becomes redundant: ring/text/visibility all
+// update through native reactive bindings.
+//
+// What can likely go after the upgrade:
+//   - the published flux-core overrides under
+//     resources/views/tallstackui/components/{form/error,wrapper/*}.blade.php
+//   - ring + error span management below (toggleRing, toggleError, the
+//     manual Alpine.evaluate fallback)
+//
+// What to keep:
+//   - the toast fallback for errors that don't have a visible matching
+//     input on the page (separate UX feature)
+//   - teleport-aware scoping (modals, slides) for whichever logic
+//     actually still has work to do at that point.
 const ERROR_RING = [
     'ring-red-300',
     'focus-within:ring-red-500',


### PR DESCRIPTION
## Summary
- Drops a TODO at the top of \`resources/js/components/validation-errors.js\` pointing at [tallstackui/tallstackui#1254](https://github.com/tallstackui/tallstackui/pull/1254) so we revisit the helper once that PR ships in a TSUI release.
- Notes which pieces of this file (and which published view overrides) become redundant once the always-mount + Livewire 4.3.0 reactivity combo is in place, and which pieces (toast fallback, teleport scoping) we keep.

## Summary by Sourcery

Documentation:
- Document which parts of the validation-errors helper and related view overrides can be removed or should be retained after the referenced TallStackUI and Livewire upgrades.