### PR TITLE
Honor format and formatted parameters in async datatable export

### DIFF
--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -1,3 +1,24 @@
+// TODO: revisit once https://github.com/tallstackui/tallstackui/pull/1254
+// ships in a TallStackUI release.
+//
+// That PR drops the @error gate from the form/error.blade.php and the
+// surrounding wrapper components, so the reactive span is in the DOM
+// from the first render. Combined with Livewire >= 4.3.0 (which made
+// $wire.$errors actually reactive — livewire/livewire#10229), most of
+// the work this file does becomes redundant: ring/text/visibility all
+// update through native reactive bindings.
+//
+// What can likely go after the upgrade:
+//   - the published flux-core overrides under
+//     resources/views/tallstackui/components/{form/error,wrapper/*}.blade.php
+//   - ring + error span management below (toggleRing, toggleError, the
+//     manual Alpine.evaluate fallback)
+//
+// What to keep:
+//   - the toast fallback for errors that don't have a visible matching
+//     input on the page (separate UX feature)
+//   - teleport-aware scoping (modals, slides) for whichever logic
+//     actually still has work to do at that point.
 const ERROR_RING = [
     'ring-red-300',
     'focus-within:ring-red-500',

--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -49,7 +49,7 @@ class ExportDataTableJob implements ShouldQueue
         [$exportClass, $extension] = match ($this->format) {
             'csv' => [CsvExport::class, '.csv'],
             'json' => [JsonExport::class, '.json'],
-            default => [DataTableExport::class, '.xlsx'],
+            'xlsx' => [DataTableExport::class, '.xlsx'],
         };
 
         $fileName = morph_alias($this->modelClass) . '_' . now()->toDateTimeLocalString('minute') . $extension;

--- a/src/Jobs/ExportDataTableJob.php
+++ b/src/Jobs/ExportDataTableJob.php
@@ -7,7 +7,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use TeamNiftyGmbH\DataTable\Exports\CsvExport;
 use TeamNiftyGmbH\DataTable\Exports\DataTableExport;
+use TeamNiftyGmbH\DataTable\Exports\JsonExport;
 use function Livewire\invade;
 
 class ExportDataTableJob implements ShouldQueue
@@ -18,7 +20,9 @@ class ExportDataTableJob implements ShouldQueue
         protected string $component,
         protected string $modelClass,
         protected array $columns,
-        protected string $userMorph
+        protected string $userMorph,
+        protected string $format = 'xlsx',
+        protected bool $formatted = true,
     ) {
         $this->columns = array_filter($columns);
     }
@@ -32,22 +36,36 @@ class ExportDataTableJob implements ShouldQueue
             ->withProperties([
                 'model' => $this->modelClass,
                 'columns' => $this->columns,
+                'format' => $this->format,
+                'formatted' => $this->formatted,
             ])
             ->useLog('export')
             ->event('export_started')
             ->log(morph_alias($this->modelClass) . ' export started');
 
-        $query = invade(unserialize($this->component))->buildSearch();
+        $component = unserialize($this->component);
+        $query = invade($component)->buildSearch();
 
-        $fileName = morph_alias($this->modelClass) . '_' . now()->toDateTimeLocalString('minute') . '.xlsx';
+        [$exportClass, $extension] = match ($this->format) {
+            'csv' => [CsvExport::class, '.csv'],
+            'json' => [JsonExport::class, '.json'],
+            default => [DataTableExport::class, '.xlsx'],
+        };
+
+        $fileName = morph_alias($this->modelClass) . '_' . now()->toDateTimeLocalString('minute') . $extension;
         $folder = 'exports/' . str_replace(':', '_', $this->userMorph) . '/';
         $filePath = $folder . str_replace(['<', '>', ':', '"', '/', '\\', '|', '?', '*'], '_', $fileName);
 
+        $formatters = $this->formatted
+            ? invade($component)->resolveExportFormatters(app($this->modelClass), $this->columns)
+            : [];
+
         app(
-            DataTableExport::class,
+            $exportClass,
             [
                 'builder' => $query,
                 'exportColumns' => $this->columns,
+                'formatters' => $formatters,
             ]
         )
             ->store($filePath);

--- a/src/Livewire/DataTables/BaseDataTable.php
+++ b/src/Livewire/DataTables/BaseDataTable.php
@@ -19,11 +19,15 @@ abstract class BaseDataTable extends DataTable
     #[Renderless]
     public function export(array $columns = [], string $format = 'xlsx', bool $formatted = true): Response|BinaryFileResponse|StreamedResponse
     {
+        $columns = array_filter($columns) ?: $this->enabledCols;
+
         ExportDataTableJob::dispatch(
             serialize($this),
             $this->getModel(),
             $columns,
-            auth()->user()->getMorphClass() . ':' . auth()->id()
+            auth()->user()->getMorphClass() . ':' . auth()->id(),
+            $format,
+            $formatted,
         );
 
         $this->toast()

--- a/src/Livewire/DataTables/OrderTransactionList.php
+++ b/src/Livewire/DataTables/OrderTransactionList.php
@@ -6,5 +6,12 @@ use FluxErp\Models\Pivots\OrderTransaction;
 
 class OrderTransactionList extends BaseDataTable
 {
+    public array $enabledCols = [
+        'order_id',
+        'transaction_id',
+        'amount',
+        'is_accepted',
+    ];
+
     protected string $model = OrderTransaction::class;
 }

--- a/tests/Unit/Livewire/DataTable/ExportTest.php
+++ b/tests/Unit/Livewire/DataTable/ExportTest.php
@@ -34,12 +34,27 @@ function readJobOutput(ExportDataTableJob $job): array
     ];
 }
 
+function readXlsxRows(string $contents): array
+{
+    $tmp = tempnam(sys_get_temp_dir(), 'flux-export-test-');
+    file_put_contents($tmp, $contents);
+
+    try {
+        return IOFactory::createReaderForFile($tmp)
+            ->load($tmp)
+            ->getActiveSheet()
+            ->toArray();
+    } finally {
+        unlink($tmp);
+    }
+}
+
 test('can export data with explicit columns', function (): void {
     Queue::fake([ExportDataTableJob::class]);
     Notification::fake();
     Storage::fake(config('filesystems.default'));
 
-    app(Tenant::class)->create([
+    Tenant::factory()->create([
         'name' => 'Acme Inc',
         'tenant_code' => 'ACME',
         'is_active' => true,
@@ -58,27 +73,17 @@ test('can export data with explicit columns', function (): void {
 
     expect($output['path'])->toEndWith('.xlsx');
 
-    $tmp = tempnam(sys_get_temp_dir(), 'flux-export-test-');
-    file_put_contents($tmp, $output['contents']);
+    $rows = readXlsxRows($output['contents']);
 
-    try {
-        $rows = IOFactory::createReaderForFile($tmp)
-            ->load($tmp)
-            ->getActiveSheet()
-            ->toArray();
-
-        expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
-        expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Acme Inc');
-    } finally {
-        @unlink($tmp);
-    }
+    expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
+    expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Acme Inc');
 });
 
 test('export with empty columns falls back to enabledCols', function (): void {
     Queue::fake([ExportDataTableJob::class]);
     Storage::fake(config('filesystems.default'));
 
-    app(Tenant::class)->create([
+    Tenant::factory()->create([
         'name' => 'Globex Corp',
         'tenant_code' => 'GLOB',
         'is_active' => true,
@@ -91,27 +96,17 @@ test('export with empty columns falls back to enabledCols', function (): void {
     $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
     $output = readJobOutput($job);
 
-    $tmp = tempnam(sys_get_temp_dir(), 'flux-export-test-');
-    file_put_contents($tmp, $output['contents']);
+    $rows = readXlsxRows($output['contents']);
 
-    try {
-        $rows = IOFactory::createReaderForFile($tmp)
-            ->load($tmp)
-            ->getActiveSheet()
-            ->toArray();
-
-        expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
-        expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Globex Corp');
-    } finally {
-        @unlink($tmp);
-    }
+    expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
+    expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Globex Corp');
 });
 
 test('csv format produces a csv file with semicolon-separated rows', function (): void {
     Queue::fake([ExportDataTableJob::class]);
     Storage::fake(config('filesystems.default'));
 
-    app(Tenant::class)->create([
+    Tenant::factory()->create([
         'name' => 'Sirius Cybernetics',
         'tenant_code' => 'SC',
         'is_active' => true,
@@ -141,7 +136,7 @@ test('json format produces a valid json file', function (): void {
     Queue::fake([ExportDataTableJob::class]);
     Storage::fake(config('filesystems.default'));
 
-    app(Tenant::class)->create([
+    Tenant::factory()->create([
         'name' => 'Stark Industries',
         'tenant_code' => 'STARK',
         'is_active' => true,

--- a/tests/Unit/Livewire/DataTable/ExportTest.php
+++ b/tests/Unit/Livewire/DataTable/ExportTest.php
@@ -8,52 +8,170 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use Spatie\Activitylog\Models\Activity;
 use function Livewire\invade;
 
-test('can export data', function (): void {
-    Queue::fake([ExportDataTableJob::class]);
+function readJobOutput(ExportDataTableJob $job): array
+{
     Notification::fake();
-    Storage::fake(config('filesystems.default'));
-
-    Livewire::test(ExportTestDataTable::class)
-        ->assertOk()
-        ->call('export')
-        ->assertToastNotification(type: 'success');
-
-    Queue::assertPushed(ExportDataTableJob::class);
-    Queue::assertCount(1);
-
-    /** @var ExportDataTableJob $job */
-    $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
     $job->handle();
 
+    $filePath = null;
     Notification::assertSentTo(
-        $this->user,
+        test()->user,
         ExportReady::class,
-        function (ExportReady $notification) {
-            $invaded = invade($notification);
-            Storage::disk(config('filesystems.default'))->assertExists($invaded->filePath);
-            $toast = invade($invaded->toToastNotification($this->user));
-            expect($downloadUrl = invade($toast->accept)->url)->toBe(route('private-storage', ['path' => $invaded->filePath]));
-
-            $this->get($downloadUrl)
-                ->assertOk()
-                ->assertDownload(pathinfo($invaded->filePath, PATHINFO_BASENAME));
+        function (ExportReady $notification) use (&$filePath): bool {
+            $filePath = invade($notification)->filePath;
 
             return true;
         }
     );
+
+    return [
+        'path' => $filePath,
+        'contents' => Storage::disk(config('filesystems.default'))->get($filePath),
+    ];
+}
+
+test('can export data with explicit columns', function (): void {
+    Queue::fake([ExportDataTableJob::class]);
+    Notification::fake();
+    Storage::fake(config('filesystems.default'));
+
+    app(Tenant::class)->create([
+        'name' => 'Acme Inc',
+        'tenant_code' => 'ACME',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(ExportTestDataTable::class)
+        ->assertOk()
+        ->call('export', ['name', 'tenant_code'])
+        ->assertToastNotification(type: 'success');
+
+    Queue::assertPushed(ExportDataTableJob::class);
+
+    /** @var ExportDataTableJob $job */
+    $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
+    $output = readJobOutput($job);
+
+    expect($output['path'])->toEndWith('.xlsx');
+
+    $tmp = tempnam(sys_get_temp_dir(), 'flux-export-test-');
+    file_put_contents($tmp, $output['contents']);
+
+    try {
+        $rows = IOFactory::createReaderForFile($tmp)
+            ->load($tmp)
+            ->getActiveSheet()
+            ->toArray();
+
+        expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
+        expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Acme Inc');
+    } finally {
+        @unlink($tmp);
+    }
 });
 
-test('export logs activity', function (): void {
+test('export with empty columns falls back to enabledCols', function (): void {
+    Queue::fake([ExportDataTableJob::class]);
+    Storage::fake(config('filesystems.default'));
+
+    app(Tenant::class)->create([
+        'name' => 'Globex Corp',
+        'tenant_code' => 'GLOB',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(ExportTestDataTable::class)
+        ->call('export', []);
+
+    /** @var ExportDataTableJob $job */
+    $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
+    $output = readJobOutput($job);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'flux-export-test-');
+    file_put_contents($tmp, $output['contents']);
+
+    try {
+        $rows = IOFactory::createReaderForFile($tmp)
+            ->load($tmp)
+            ->getActiveSheet()
+            ->toArray();
+
+        expect($rows[0])->toBe([__('Name'), __('Tenant Code')]);
+        expect(collect($rows)->skip(1)->pluck(0)->all())->toContain('Globex Corp');
+    } finally {
+        @unlink($tmp);
+    }
+});
+
+test('csv format produces a csv file with semicolon-separated rows', function (): void {
+    Queue::fake([ExportDataTableJob::class]);
+    Storage::fake(config('filesystems.default'));
+
+    app(Tenant::class)->create([
+        'name' => 'Sirius Cybernetics',
+        'tenant_code' => 'SC',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(ExportTestDataTable::class)
+        ->call('export', ['name', 'tenant_code'], 'csv', true);
+
+    /** @var ExportDataTableJob $job */
+    $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
+    $output = readJobOutput($job);
+
+    expect($output['path'])->toEndWith('.csv');
+
+    $bom = "\xEF\xBB\xBF";
+    expect($output['contents'])->toStartWith($bom);
+
+    $body = substr($output['contents'], strlen($bom));
+    $lines = explode("\n", trim($body));
+
+    expect(str_getcsv($lines[0], ';'))->toBe([__('Name'), __('Tenant Code')]);
+    expect(collect($lines)->skip(1)->map(fn (string $line): array => str_getcsv($line, ';'))->all())
+        ->toContain(['Sirius Cybernetics', 'SC']);
+});
+
+test('json format produces a valid json file', function (): void {
+    Queue::fake([ExportDataTableJob::class]);
+    Storage::fake(config('filesystems.default'));
+
+    app(Tenant::class)->create([
+        'name' => 'Stark Industries',
+        'tenant_code' => 'STARK',
+        'is_active' => true,
+    ]);
+
+    Livewire::test(ExportTestDataTable::class)
+        ->call('export', ['name', 'tenant_code'], 'json', true);
+
+    /** @var ExportDataTableJob $job */
+    $job = data_get(Queue::pushedJobs(), ExportDataTableJob::class . '.0.job');
+    $output = readJobOutput($job);
+
+    expect($output['path'])->toEndWith('.json');
+
+    $decoded = json_decode($output['contents'], true);
+
+    expect($decoded)->toBeArray();
+    expect(collect($decoded)->pluck('name')->all())->toContain('Stark Industries');
+});
+
+test('export logs activity with format and formatted properties', function (): void {
     Storage::fake(config('filesystems.default'));
 
     $job = new ExportDataTableJob(
         serialize(Livewire::test(ExportTestDataTable::class)->instance()),
         Tenant::class,
-        [],
-        $this->user->getMorphClass() . ':' . $this->user->getKey()
+        ['name'],
+        $this->user->getMorphClass() . ':' . $this->user->getKey(),
+        'json',
+        false,
     );
 
     $job->handle();
@@ -66,6 +184,8 @@ test('export logs activity', function (): void {
         ->log_name->toBe('export')
         ->and($activity->properties->toArray())->toMatchArray([
             'model' => Tenant::class,
-            'columns' => [],
+            'columns' => ['name'],
+            'format' => 'json',
+            'formatted' => false,
         ]);
 });

--- a/tests/Unit/Livewire/DataTable/ExportTestDataTable.php
+++ b/tests/Unit/Livewire/DataTable/ExportTestDataTable.php
@@ -6,5 +6,10 @@ use FluxErp\Livewire\DataTables\BaseDataTable;
 
 class ExportTestDataTable extends BaseDataTable
 {
+    public array $enabledCols = [
+        'name',
+        'tenant_code',
+    ];
+
     protected string $model = \FluxErp\Models\Tenant::class;
 }


### PR DESCRIPTION
## Summary

- Pass \`format\` and \`formatted\` from \`BaseDataTable::export()\` through to \`ExportDataTableJob\` so the user's choice in the export sidebar (xlsx / csv / json, formatted toggle) actually drives the produced file.
- The job picks \`DataTableExport\` / \`CsvExport\` / \`JsonExport\` via match, uses the matching extension, and resolves formatters through the deserialized component when \`formatted\` is true. All three export classes expose \`store()\` since tall-datatables 2.4.13.
- Empty \`\$columns\` falls back to the data table's \`\$enabledCols\` so an empty selection no longer produces a header-less file.
- \`OrderTransactionList\` gets an explicit \`\$enabledCols\` — the only flux-core data table that previously left it empty.
- Tests rewritten to read the produced file content and assert headers + data rows, correct file extension per format, and the activity log captures \`format\` / \`formatted\` alongside \`columns\`.

## Background

The export action received \`format\` and \`formatted\` parameters from Livewire and silently dropped them — every export became an unformatted xlsx regardless of the user's pick. The matching package release (tall-datatables 2.4.13) added \`store()\` to \`CsvExport\` and \`JsonExport\` so the queue worker can write csv/json to filesystem storage uniformly with \`DataTableExport\`. The empty-columns fallback covers any caller (UI race, missing \`\$enabledCols\` on a data table) that would otherwise produce a useless export.

## Summary by Sourcery

Honor export format and formatted options in async datatable exports and ensure sensible default columns and logging.

New Features:
- Support CSV and JSON formats alongside XLSX in async datatable exports, driven by the export sidebar options.
- Allow toggling formatted vs raw exports by resolving formatters only when requested.

Bug Fixes:
- Ensure empty column selections fall back to the datatable's enabled columns instead of producing header-less exports.
- Fix async exports always producing XLSX files regardless of the selected format or formatting option.
- Record export format and formatted flags in the activity log for better traceability.

Enhancements:
- Add explicit enabled column definitions for relevant datatables, including OrderTransactionList, to support consistent exports.
- Expand export tests to validate file contents, extensions, and logging across XLSX, CSV, and JSON outputs.

Tests:
- Refactor export tests to execute the queued job, read the generated files, and assert headers, data rows, file extensions, and activity log metadata.