### PR TITLE
Add refresh button in header for PWA and native app users

### DIFF
--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -11,12 +11,23 @@ function promptValue(id) {
     return el.value;
 }
 
+let appModeCache = null;
+
 function isAppMode() {
-    return (
-        window.matchMedia('(display-mode: standalone)').matches ||
-        window.navigator.standalone === true ||
-        (window.nuxbeAppBridge?.isNative?.() ?? false)
-    );
+    if (appModeCache !== null) {
+        return appModeCache;
+    }
+
+    if (typeof window === 'undefined') {
+        return false;
+    }
+
+    appModeCache =
+        window.matchMedia?.('(display-mode: standalone)')?.matches === true ||
+        window.navigator?.standalone === true ||
+        (window.nuxbeAppBridge?.isNative?.() ?? false);
+
+    return appModeCache;
 }
 
 const nuxbe = {

--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -11,7 +11,21 @@ function promptValue(id) {
     return el.value;
 }
 
-const nuxbe = { format, parseNumber, openDetailModal, promptValue };
+function isAppMode() {
+    return (
+        window.matchMedia('(display-mode: standalone)').matches ||
+        window.navigator.standalone === true ||
+        (window.nuxbeAppBridge?.isNative?.() ?? false)
+    );
+}
+
+const nuxbe = {
+    format,
+    parseNumber,
+    openDetailModal,
+    promptValue,
+    isAppMode,
+};
 
 window.$nuxbe = nuxbe;
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -132,6 +132,16 @@
                             </div>
                         @endauth
 
+                        <x-button
+                            x-data
+                            x-show="$nuxbe.isAppMode()"
+                            x-cloak
+                            flat
+                            icon="arrow-path"
+                            :title="__('Refresh')"
+                            x-on:click="window.location.reload()"
+                        />
+
                         @if(resolve_static(\FluxErp\Models\PriceList::class, 'default'))
                             @persist('layout.header.cart')
                                 @canAction(\FluxErp\Actions\Cart\CreateCart::class)


### PR DESCRIPTION
## Summary
- Adds a refresh button next to the cart icon that hard-reloads the page via `window.location.reload()`
- Button is only visible when the app runs as an installed PWA (`display-mode: standalone` / iOS `navigator.standalone`) or inside the Capacitor-based Nuxbe native app — in regular browser tabs the user already has the browser refresh
- Adds `$nuxbe.isAppMode()` helper in `resources/js/nuxbe.js` so the detection can be reused

## Summary by Sourcery

Add a header refresh control that is only shown when the application runs in an installed PWA or native app context.

New Features:
- Expose a reusable $nuxbe.isAppMode() helper to detect standalone PWA or native app environments.
- Add a conditional refresh button in the header that reloads the page when used in app mode.