### PR TITLE
Filter SearchBar models by detail-route permission

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -112,7 +112,7 @@ if (! function_exists('user_can_route')) {
 if (! function_exists('user_can_view_model_detail')) {
     function user_can_view_model_detail(?string $model): bool
     {
-        if (blank($model) || ! class_exists($model) || ! method_exists($model, 'detailRoute')) {
+        if (blank($model) || ! class_exists($model) || ! property_exists($model, 'detailRouteName')) {
             return false;
         }
 

--- a/helpers.php
+++ b/helpers.php
@@ -86,6 +86,47 @@ if (! function_exists('user_can')) {
     }
 }
 
+if (! function_exists('user_can_route')) {
+    function user_can_route(?string $routeName): bool
+    {
+        if (blank($routeName)) {
+            return false;
+        }
+
+        $route = Illuminate\Support\Facades\Route::getRoutes()->getByName($routeName);
+
+        if (is_null($route)) {
+            return false;
+        }
+
+        $permission = route_to_permission($route, true);
+
+        if (is_null($permission)) {
+            return true;
+        }
+
+        return auth()->user()?->can($permission) ?? false;
+    }
+}
+
+if (! function_exists('user_can_view_model_detail')) {
+    function user_can_view_model_detail(?string $model): bool
+    {
+        if (blank($model) || ! class_exists($model) || ! method_exists($model, 'detailRoute')) {
+            return false;
+        }
+
+        $instance = app($model);
+        $routeName = Closure::bind(
+            fn (): ?string => $this->detailRouteName ?? null,
+            $instance,
+            $model
+        )();
+
+        return user_can_route($routeName);
+    }
+}
+
 if (! function_exists('get_subclasses_of')) {
     function get_subclasses_of(string $extendingClass, array|string $namespace): array
     {

--- a/helpers.php
+++ b/helpers.php
@@ -86,8 +86,8 @@ if (! function_exists('user_can')) {
     }
 }
 
-if (! function_exists('user_can_route')) {
-    function user_can_route(?string $routeName): bool
+if (! function_exists('user_can_access_route')) {
+    function user_can_access_route(?string $routeName): bool
     {
         if (blank($routeName)) {
             return false;
@@ -99,31 +99,32 @@ if (! function_exists('user_can_route')) {
             return false;
         }
 
-        $permission = route_to_permission($route, true);
+        $permission = route_to_permission($route, false);
 
         if (is_null($permission)) {
             return true;
         }
 
-        return auth()->user()?->can($permission) ?? false;
+        try {
+            return auth()->user()?->hasPermissionTo($permission) ?? false;
+        } catch (Spatie\Permission\Exceptions\PermissionDoesNotExist) {
+            return true;
+        }
     }
 }
 
 if (! function_exists('user_can_view_model_detail')) {
     function user_can_view_model_detail(?string $model): bool
     {
-        if (blank($model) || ! class_exists($model) || ! property_exists($model, 'detailRouteName')) {
+        if (
+            blank($model)
+            || ! class_exists($model)
+            || ! method_exists($model, 'getDetailRouteName')
+        ) {
             return false;
         }
 
-        $instance = app($model);
-        $routeName = Closure::bind(
-            fn (): ?string => $this->detailRouteName ?? null,
-            $instance,
-            $model
-        )();
-
-        return user_can_route($routeName);
+        return user_can_access_route(app($model)->getDetailRouteName());
     }
 }
 

--- a/src/Livewire/Features/SearchBar.php
+++ b/src/Livewire/Features/SearchBar.php
@@ -50,6 +50,8 @@ class SearchBar extends Component
                 ->toArray();
         }
 
+        $this->searchModel = $this->filterByDetailRoutePermission((array) $this->searchModel);
+
         foreach ((array) $this->searchModel as $searchModel) {
             $this->modelLabels[$searchModel] = [
                 'label' => __(Str::of(morph_alias($searchModel))->plural()->headline()->toString()),
@@ -71,6 +73,14 @@ class SearchBar extends Component
     #[Renderless]
     public function showDetail(string $model, int $id): void
     {
+        if (! user_can_view_model_detail($model)) {
+            $this->toast()
+                ->error(__('Record not found'))
+                ->send();
+
+            return;
+        }
+
         /** @var Model $model */
         $modelInstance = resolve_static($model, 'query')->whereKey($id)->first();
 
@@ -96,9 +106,11 @@ class SearchBar extends Component
     public function updatedSearch(): void
     {
         if ($this->search) {
+            $permittedModels = $this->filterByDetailRoutePermission((array) $this->searchModel);
+
             if (is_array($this->searchModel)) {
                 $return = [];
-                foreach ($this->searchModel as $model) {
+                foreach ($permittedModels as $model) {
                     try {
                         $result = resolve_static($model, 'search', ['query' => $this->search])
                             ->toEloquentBuilder()
@@ -125,7 +137,7 @@ class SearchBar extends Component
                 }
 
                 $this->return = $return;
-            } else {
+            } elseif (in_array($this->searchModel, $permittedModels, true)) {
                 $result = resolve_static($this->searchModel, 'search', ['query' => $this->search])
                     ->paginate();
 
@@ -135,11 +147,21 @@ class SearchBar extends Component
 
                 $this->return = count($result->items()) ? $result->items() : null;
                 $this->show = true;
+            } else {
+                $this->return = [];
             }
         } else {
             $this->return = [];
         }
 
         $this->skipRender();
+    }
+
+    protected function filterByDetailRoutePermission(array $models): array
+    {
+        return array_values(array_filter(
+            $models,
+            fn (string $model): bool => user_can_view_model_detail($model)
+        ));
     }
 }

--- a/src/Livewire/Features/SearchBar.php
+++ b/src/Livewire/Features/SearchBar.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -30,6 +31,7 @@ class SearchBar extends Component
 
     public string $search = '';
 
+    #[Locked]
     public array|string $searchModel = '';
 
     public bool $show = false;
@@ -106,11 +108,9 @@ class SearchBar extends Component
     public function updatedSearch(): void
     {
         if ($this->search) {
-            $permittedModels = $this->filterByDetailRoutePermission((array) $this->searchModel);
-
             if (is_array($this->searchModel)) {
                 $return = [];
-                foreach ($permittedModels as $model) {
+                foreach ($this->searchModel as $model) {
                     try {
                         $result = resolve_static($model, 'search', ['query' => $this->search])
                             ->toEloquentBuilder()
@@ -137,7 +137,7 @@ class SearchBar extends Component
                 }
 
                 $this->return = $return;
-            } elseif (in_array($this->searchModel, $permittedModels, true)) {
+            } else {
                 $result = resolve_static($this->searchModel, 'search', ['query' => $this->search])
                     ->paginate();
 
@@ -147,8 +147,6 @@ class SearchBar extends Component
 
                 $this->return = count($result->items()) ? $result->items() : null;
                 $this->show = true;
-            } else {
-                $this->return = [];
             }
         } else {
             $this->return = [];

--- a/src/Livewire/Widgets/SearchBar.php
+++ b/src/Livewire/Widgets/SearchBar.php
@@ -33,6 +33,13 @@ class SearchBar extends Component
             return;
         }
 
+        if (! user_can_view_model_detail($model)) {
+            $this->skipRender();
+            $this->show = false;
+
+            return;
+        }
+
         $component = method_exists($model, 'getLivewireComponentWidget')
             ? livewire_component_exists(resolve_static($model, 'getLivewireComponentWidget'))
                 ? resolve_static($model, 'getLivewireComponentWidget')

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -13,6 +13,7 @@ use FluxErp\Traits\Model\Calendar\HasCalendarEvents;
 use FluxErp\Traits\Model\Categorizable;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Communicatable;
+use FluxErp\Traits\Model\HasFrontendAttributes;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasRecordOrigin;
 use FluxErp\Traits\Model\HasTags;
@@ -30,7 +31,6 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
-use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 
 class Lead extends FluxModel implements Calendarable, HasMedia, InteractsWithDataTables, Targetable
 {

--- a/src/Models/Project.php
+++ b/src/Models/Project.php
@@ -11,6 +11,7 @@ use FluxErp\States\Project\ProjectState;
 use FluxErp\Traits\HasStates;
 use FluxErp\Traits\Model\Commentable;
 use FluxErp\Traits\Model\Filterable;
+use FluxErp\Traits\Model\HasFrontendAttributes;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasSerialNumberRange;
@@ -29,7 +30,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
-use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 
 class Project extends FluxModel implements Calendarable, HasMedia, InteractsWithDataTables, IsSubscribable
 {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -7,6 +7,7 @@ use FluxErp\Contracts\IsSubscribable;
 use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Traits\Model\Categorizable;
 use FluxErp\Traits\Model\Commentable;
+use FluxErp\Traits\Model\HasFrontendAttributes;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasTags;
@@ -20,7 +21,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
-use TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
 
 class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscribable
 {

--- a/src/Traits/Model/HasFrontendAttributes.php
+++ b/src/Traits/Model/HasFrontendAttributes.php
@@ -6,7 +6,9 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 
 trait HasFrontendAttributes
 {
-    use \TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes;
+    use \TeamNiftyGmbH\DataTable\Traits\HasFrontendAttributes {
+        getDetailRouteName as public;
+    }
 
     public static function getLivewireComponentWidget(): string
     {

--- a/tests/Livewire/Features/SearchBarTest.php
+++ b/tests/Livewire/Features/SearchBarTest.php
@@ -1,9 +1,41 @@
 <?php
 
 use FluxErp\Livewire\Features\SearchBar;
+use FluxErp\Models\Order;
+use FluxErp\Models\Permission;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(SearchBar::class)
         ->assertOk();
+});
+
+test('searchable models exclude detail routes the user lacks permission for', function (): void {
+    Permission::findOrCreate('orders.{id}.get', 'web');
+
+    $component = Livewire::test(SearchBar::class)
+        ->assertOk();
+
+    expect($component->get('searchModel'))->not->toContain(Order::class);
+    expect($component->get('modelLabels'))->not->toHaveKey(Order::class);
+});
+
+test('searchable models include detail routes the user has permission for', function (): void {
+    $permission = Permission::findOrCreate('orders.{id}.get', 'web');
+    $this->user->givePermissionTo($permission);
+
+    $component = Livewire::test(SearchBar::class)
+        ->assertOk();
+
+    expect($component->get('searchModel'))->toContain(Order::class);
+    expect($component->get('modelLabels'))->toHaveKey(Order::class);
+});
+
+test('showDetail rejects models the user has no detail route permission for', function (): void {
+    Permission::findOrCreate('orders.{id}.get', 'web');
+
+    Livewire::test(SearchBar::class)
+        ->call('showDetail', Order::class, 1)
+        ->assertNoRedirect()
+        ->assertToastNotification(type: 'error');
 });

--- a/tests/Livewire/Widgets/SearchBarTest.php
+++ b/tests/Livewire/Widgets/SearchBarTest.php
@@ -1,9 +1,20 @@
 <?php
 
 use FluxErp\Livewire\Widgets\SearchBar;
+use FluxErp\Models\Order;
+use FluxErp\Models\Permission;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(SearchBar::class)
         ->assertOk();
+});
+
+test('renderSearchBarWidget refuses models the user has no detail route permission for', function (): void {
+    Permission::findOrCreate('orders.{id}.get', 'web');
+
+    Livewire::test(SearchBar::class)
+        ->dispatch('renderSearchBarWidget', model: Order::class, modelId: 1)
+        ->assertSet('show', false)
+        ->assertSet('widgetComponent', null);
 });


### PR DESCRIPTION
## Summary
- Global \`SearchBar\` exposed model search hits (label + id + avatar) for any authenticated user, regardless of whether they had permission to open that model's detail page.
- New \`user_can_route\` and \`user_can_view_model_detail\` helpers mirror the \`Permissions\` middleware logic and gate the searchable model list at mount time, in \`updatedSearch\`, in \`showDetail\`, and in the \`Widgets\\SearchBar::renderSearchBarWidget\` listener (defensive against tampered \`searchModel\` property or direct wire calls).

## Test plan
- [ ] \`vendor/bin/pest tests/Livewire/Features/SearchBarTest.php tests/Livewire/Widgets/SearchBarTest.php\`
- [ ] Manually search the global bar as a user without \`orders.{id}.get\` and confirm Order hits no longer appear.

## Summary by Sourcery

Restrict global SearchBar results and detail access to models whose detail routes the current user is permitted to view.

New Features:
- Introduce user_can_route helper to resolve route-based permissions for the current user.
- Introduce user_can_view_model_detail helper to determine whether a user may access a model's detail route.

Bug Fixes:
- Prevent SearchBar from exposing searchable models and detail views to users lacking permission for the corresponding detail routes.

Enhancements:
- Filter SearchBar searchable models and search results by detail-route permission at mount time and during searches.
- Guard SearchBar::showDetail and Widgets\SearchBar::renderSearchBarWidget against unauthorized model detail access, including tampered input.

Tests:
- Add feature and widget tests to cover SearchBar behavior when users have or lack model detail-route permissions.