### PR TITLE
validate employed on CloseEmployeeDay action

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1040,6 +1040,7 @@
     "Employee Department Id": "Mitarbeiter-Abteilungs-ID",
     "Employee Departments": "Mitarbeiter-Abteilungen",
     "Employee Id": "Mitarbeiter-ID",
+    "Employee is not employed during the given date.": "Mitarbeiter ist nicht angestellt während des gegebenen Datums",
     "Employee Number": "Mitarbeiternummer",
     "Employees": "Mitarbeiter",
     "Employment Date": "Eintrittsdatum",

--- a/resources/views/components/employee/general.blade.php
+++ b/resources/views/components/employee/general.blade.php
@@ -84,6 +84,11 @@
                 wire:model="employee.account_holder"
                 x-bind:disabled="!isEditing"
             />
+            <x-checkbox
+                :label="__('Is Active')"
+                wire:model="employee.is_active"
+                x-bind:disabled="!isEditing"
+            />
         </div>
     </x-card>
 

--- a/src/Actions/EmployeeDay/CloseEmployeeDay.php
+++ b/src/Actions/EmployeeDay/CloseEmployeeDay.php
@@ -15,6 +15,7 @@ use FluxErp\Models\WorkTime;
 use FluxErp\Rulesets\EmployeeDay\CloseEmployeeDayRuleset;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 
 class CloseEmployeeDay extends FluxAction
 {
@@ -245,5 +246,21 @@ class CloseEmployeeDay extends FluxAction
         $employeeDay->absenceRequests()->sync($absenceRequests);
 
         return $employeeDay->withoutRelations()->fresh();
+    }
+
+    protected function validateData(): void
+    {
+        parent::validateData();
+
+        if (resolve_static(Employee::class, 'query')
+            ->whereKey($this->getData('employee_id'))
+            ->employed(Carbon::parse($this->getData('date')))
+            ->doesntExist()
+        ) {
+            throw ValidationException::withMessages([
+                'date' => ['Employee is not employed during the given date.'],
+            ])
+                ->errorBag('closeEmployeeDay');
+        }
     }
 }

--- a/src/Models/Employee.php
+++ b/src/Models/Employee.php
@@ -452,12 +452,16 @@ class Employee extends FluxModel implements HasMedia, InteractsWithDataTables, O
     // Scopes
     protected function scopeEmployed(Builder $query, DateTime $untilDate): void
     {
+        $date = $untilDate->format('Ymd');
         $query->whereHas('workTimeModelHistory')
             ->where('is_active', true)
-            ->where(function (Builder $query) use ($untilDate): void {
-                $query->where('employment_date', '<=', $untilDate)
-                    ->whereNull('termination_date')
-                    ->orWhereValueBetween($untilDate->startOfDay(), ['employment_date', 'termination_date']);
-            });
+            ->whereRaw(
+                'REPLACE(COALESCE(employment_date, 0), \'-\', \'\') <= ? '
+                . 'AND REPLACE(COALESCE(termination_date, 99999999), \'-\', \'\') >= ?',
+                [
+                    $date,
+                    $date,
+                ]
+            );
     }
 }

--- a/src/Models/Employee.php
+++ b/src/Models/Employee.php
@@ -452,12 +452,12 @@ class Employee extends FluxModel implements HasMedia, InteractsWithDataTables, O
     // Scopes
     protected function scopeEmployed(Builder $query, DateTime $untilDate): void
     {
-        $date = $untilDate->format('Ymd');
+        $date = $untilDate->format('Y-m-d');
         $query->whereHas('workTimeModelHistory')
             ->where('is_active', true)
             ->whereRaw(
-                'REPLACE(COALESCE(employment_date, 0), \'-\', \'\') <= ? '
-                . 'AND REPLACE(COALESCE(termination_date, 99999999), \'-\', \'\') >= ?',
+                'COALESCE(employment_date, 0) <= ? '
+                . 'AND COALESCE(termination_date, \'9999-12-31\') >= ?',
                 [
                     $date,
                     $date,


### PR DESCRIPTION
adjust employed local scope
add is_active checkbox to employee general view

## Summary by Sourcery

Validate that employees are employed on the selected date when closing an employee day and align employment scope and UI to support active status.

New Features:
- Add an 'Is Active' checkbox to the employee general view.

Bug Fixes:
- Prevent closing an employee day for dates when the selected employee is not employed.

Enhancements:
- Adjust the Employee 'employed' scope to use date range checks based on normalized employment and termination dates.