### PR TITLE
Fix postal_address attribute losing lastname/city due to operator precedence

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -716,10 +716,10 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
             fn (mixed $value, array $attributes) => array_values(
                 array_filter([
                     $attributes['company'] ?? null,
-                    trim($attributes['firstname'] ?? null . ' ' . $attributes['lastname'] ?? null),
+                    trim(($attributes['firstname'] ?? '') . ' ' . ($attributes['lastname'] ?? '')),
                     $attributes['addition'] ?? null,
                     $attributes['street'] ?? null,
-                    trim($attributes['zip'] ?? null . ' ' . $attributes['city'] ?? null),
+                    trim(($attributes['zip'] ?? '') . ' ' . ($attributes['city'] ?? '')),
                     $this->country_name,
                 ])
             )

--- a/tests/Unit/Models/AddressPostalAddressTest.php
+++ b/tests/Unit/Models/AddressPostalAddressTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Tenant;
+
+it('includes both firstname and lastname in postal_address', function (): void {
+    $tenant = Tenant::factory()->create();
+    $contact = Contact::factory()
+        ->hasAttached($tenant, relationship: 'tenants')
+        ->create();
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'company' => 'Acme Corp',
+        'firstname' => 'Jane',
+        'lastname' => 'Doe',
+        'street' => 'Example Street 1',
+        'zip' => '12345',
+        'city' => 'Example City',
+    ]);
+
+    expect($address->postal_address)->toContain('Jane Doe');
+});
+
+it('combines zip and city in postal_address', function (): void {
+    $tenant = Tenant::factory()->create();
+    $contact = Contact::factory()
+        ->hasAttached($tenant, relationship: 'tenants')
+        ->create();
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'company' => 'Acme Corp',
+        'firstname' => null,
+        'lastname' => null,
+        'street' => 'Example Street 1',
+        'zip' => '12345',
+        'city' => 'Example City',
+    ]);
+
+    expect($address->postal_address)->toContain('12345 Example City');
+});
+
+it('falls back to lastname only when firstname is missing', function (): void {
+    $tenant = Tenant::factory()->create();
+    $contact = Contact::factory()
+        ->hasAttached($tenant, relationship: 'tenants')
+        ->create();
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'company' => 'Acme Corp',
+        'firstname' => null,
+        'lastname' => 'Doe',
+        'street' => 'Example Street 1',
+        'zip' => '12345',
+        'city' => 'Example City',
+    ]);
+
+    expect($address->postal_address)->toContain('Doe');
+});


### PR DESCRIPTION
## Summary

- The `postalAddress` attribute on `Address` used `??` chained with `.` without parentheses, causing the lastname (and city) to be dropped whenever the firstname (or zip) was set.
- Added explicit parentheses so each component is null-coalesced before concatenation.
- Added unit tests covering both the firstname+lastname and zip+city combinations, plus the firstname-missing fallback.

## Summary by Sourcery

Correct the Address postalAddress attribute formatting and add coverage for common address combinations.

Bug Fixes:
- Ensure postal_address always includes lastname and city when present by fixing null-coalescing and concatenation order.

Tests:
- Add unit tests verifying postal_address formatting for firstname+lastname, zip+city, and lastname-only fallback scenarios.