### PR TITLE
Fix passkey morph storage and improve two-factor input UX

### DIFF
--- a/resources/views/livewire/auth/force-two-factor-setup.blade.php
+++ b/resources/views/livewire/auth/force-two-factor-setup.blade.php
@@ -108,12 +108,15 @@
                                     wire:submit="confirmTotp()"
                                 >
                                     <div class="flex justify-center">
-                                        <x-pin
+                                        <x-input
+                                            id="totp-confirm-code"
                                             wire:model.live="confirmCode"
                                             :label="__('Verification Code')"
-                                            :length="6"
-                                            numbers
-                                            smart
+                                            type="text"
+                                            inputmode="numeric"
+                                            autocomplete="one-time-code"
+                                            pattern="[0-9]*"
+                                            maxlength="6"
                                         />
                                     </div>
                                     <div class="flex justify-between gap-2">

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -31,7 +31,13 @@
                     </x-modal>
                 @show
                 @section('totp-challenge')
-                    <div x-show="$wire.showTotpChallenge" x-cloak>
+                    <div
+                        x-show="$wire.showTotpChallenge"
+                        x-effect="
+                            $wire.showTotpChallenge && $tsui.focus('totp-code')
+                        "
+                        x-cloak
+                    >
                         <form
                             class="flex flex-col gap-6"
                             wire:submit="verifyTotpCode()"
@@ -51,13 +57,14 @@
                                 </p>
                             </div>
                             <div class="flex justify-center">
-                                <x-pin
+                                <x-input
                                     id="totp-code"
                                     wire:model="totpCode"
-                                    :length="6"
-                                    numbers
-                                    smart
-                                    autofocus
+                                    type="text"
+                                    inputmode="numeric"
+                                    autocomplete="one-time-code"
+                                    pattern="[0-9]*"
+                                    maxlength="6"
                                 />
                                 @error('totpCode')
                                     <p class="text-sm text-red-600">

--- a/resources/views/livewire/settings/two-factor-setup.blade.php
+++ b/resources/views/livewire/settings/two-factor-setup.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="space-y-6">
     @section('two-factor-setup')
         <x-card>
             <div class="space-y-4">
@@ -23,7 +23,13 @@
                     </div>
                 </div>
 
-                <div x-show="$wire.showSetup" x-cloak>
+                <div
+                    x-show="$wire.showSetup"
+                    x-effect="
+                        $wire.showSetup && $tsui.focus('totp-confirm-code')
+                    "
+                    x-cloak
+                >
                     <div class="space-y-4">
                         <p class="text-sm text-gray-600 dark:text-gray-400">
                             {{ __('Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.) and enter the verification code below.') }}
@@ -43,12 +49,15 @@
                         </div>
                         <form wire:submit="confirmSetup()" class="space-y-4">
                             <div class="flex justify-center">
-                                <x-pin
+                                <x-input
+                                    id="totp-confirm-code"
                                     wire:model.live="confirmCode"
                                     :label="__('Verification Code')"
-                                    :length="6"
-                                    numbers
-                                    smart
+                                    type="text"
+                                    inputmode="numeric"
+                                    autocomplete="one-time-code"
+                                    pattern="[0-9]*"
+                                    maxlength="6"
                                 />
                             </div>
                             <div class="flex justify-end gap-2">
@@ -117,7 +126,7 @@
 
     @section('passkey-management')
         <div x-show="browserSupportsWebAuthn" x-cloak>
-            <x-card class="mt-6">
+            <x-card>
                 <div class="space-y-4">
                     <div
                         class="flex items-center justify-between border-b pb-4 dark:border-gray-700"

--- a/src/Actions/Passkey/StorePasskeyAction.php
+++ b/src/Actions/Passkey/StorePasskeyAction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FluxErp\Actions\Passkey;
+
+use Spatie\LaravelPasskeys\Actions\StorePasskeyAction as BaseStorePasskeyAction;
+use Spatie\LaravelPasskeys\Models\Concerns\HasPasskeys;
+use Spatie\LaravelPasskeys\Models\Passkey;
+
+class StorePasskeyAction extends BaseStorePasskeyAction
+{
+    public function execute(
+        HasPasskeys $authenticatable,
+        string $passkeyJson,
+        string $passkeyOptionsJson,
+        string $hostName,
+        array $additionalProperties = [],
+    ): Passkey {
+        $additionalProperties['authenticatable_type'] ??= $authenticatable->getMorphClass();
+
+        return parent::execute(
+            $authenticatable,
+            $passkeyJson,
+            $passkeyOptionsJson,
+            $hostName,
+            $additionalProperties,
+        );
+    }
+}

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp;
 
+use FluxErp\Actions\Passkey\StorePasskeyAction;
 use FluxErp\Assets\AssetManager;
 use FluxErp\Facades\ProductType;
 use FluxErp\Helpers\Composer;
@@ -242,6 +243,7 @@ class FluxServiceProvider extends ServiceProvider
             config(['activitylog.activitymodel' => resolve_static(Activity::class, 'class')]);
             config(['media-library.media_downloader' => MediaLibraryDownloader::class]);
             config(['two-factor.recovery.enabled' => false]);
+            config(['passkeys.actions.store_passkey' => resolve_static(StorePasskeyAction::class, 'class')]);
         });
         $this->mergeConfigFrom(__DIR__ . '/../config/flux.php', 'flux');
         $this->mergeConfigFrom(__DIR__ . '/../config/notifications.php', 'notifications');

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -19,6 +19,7 @@ use FluxErp\Models\Currency;
 use FluxErp\Models\Notification;
 use FluxErp\Models\Permission;
 use FluxErp\Models\Role;
+use FluxErp\Models\User;
 use FluxErp\Providers\ActionServiceProvider;
 use FluxErp\Providers\AuthServiceProvider;
 use FluxErp\Providers\BindingServiceProvider;
@@ -243,6 +244,7 @@ class FluxServiceProvider extends ServiceProvider
             config(['activitylog.activitymodel' => resolve_static(Activity::class, 'class')]);
             config(['media-library.media_downloader' => MediaLibraryDownloader::class]);
             config(['two-factor.recovery.enabled' => false]);
+            config(['passkeys.models.authenticatable' => resolve_static(User::class, 'class')]);
             config(['passkeys.actions.store_passkey' => resolve_static(StorePasskeyAction::class, 'class')]);
         });
         $this->mergeConfigFrom(__DIR__ . '/../config/flux.php', 'flux');


### PR DESCRIPTION
## Summary
- Override Spatie's `StorePasskeyAction` to default `authenticatable_type` to the user's morph class so the insert no longer fails on the morphed `passkeys` table.
- Configure `passkeys.models.authenticatable` to `FluxErp\Models\User` so the login flow resolves the correct user model instead of Spatie's default `App\Models\User`.
- Replace `x-pin` with `x-input` + `autocomplete="one-time-code"` on the TOTP challenge, setup and forced-setup forms so password managers can fill the code. Use `$tsui.focus()` via `x-effect` because `autofocus` does not fire after a Livewire morph.
- Add `space-y-6` to the two-factor-setup wrapper so the TOTP and passkey cards no longer stick together.

## Summary by Sourcery

Fix passkey storage for morphed user models and improve the UX of TOTP input flows during login and two-factor setup.

Bug Fixes:
- Default the passkey authenticatable_type to the user's morph class so inserts succeed on the morphed passkeys table.
- Configure the passkeys authenticatable model to use FluxErp\Models\User instead of the package default.
- Override the default passkey storage action to ensure correct morph type handling when storing new passkeys.

Enhancements:
- Replace custom PIN inputs with numeric text inputs that support one-time-code autocomplete across TOTP challenge and setup forms.
- Automatically focus TOTP input fields when the corresponding Livewire sections become visible to streamline two-factor entry.
- Adjust two-factor setup layout spacing so TOTP and passkey sections are visually separated.