### PR TITLE
Bypass Super Admin in user_can_access_route helper

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -105,8 +105,18 @@ if (! function_exists('user_can_access_route')) {
             return true;
         }
 
+        $user = auth()->user();
+
+        if (
+            $user
+            && in_array(Spatie\Permission\Traits\HasRoles::class, class_uses_recursive($user))
+            && $user->hasRole('Super Admin')
+        ) {
+            return true;
+        }
+
         try {
-            return auth()->user()?->hasPermissionTo($permission) ?? false;
+            return $user?->hasPermissionTo($permission) ?? false;
         } catch (Spatie\Permission\Exceptions\PermissionDoesNotExist) {
             return true;
         }

--- a/tests/Livewire/Features/SearchBarTest.php
+++ b/tests/Livewire/Features/SearchBarTest.php
@@ -4,6 +4,7 @@ use FluxErp\Livewire\Features\SearchBar;
 use FluxErp\Models\Order;
 use FluxErp\Models\Permission;
 use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
 
 test('renders successfully', function (): void {
     Livewire::test(SearchBar::class)
@@ -23,6 +24,17 @@ test('searchable models exclude detail routes the user lacks permission for', fu
 test('searchable models include detail routes the user has permission for', function (): void {
     $permission = Permission::findOrCreate('orders.{id}.get', 'web');
     $this->user->givePermissionTo($permission);
+
+    $component = Livewire::test(SearchBar::class)
+        ->assertOk();
+
+    expect($component->get('searchModel'))->toContain(Order::class);
+    expect($component->get('modelLabels'))->toHaveKey(Order::class);
+});
+
+test('searchable models include all detail routes for super admin', function (): void {
+    Permission::findOrCreate('orders.{id}.get', 'web');
+    $this->user->assignRole(Role::findOrCreate('Super Admin'));
 
     $component = Livewire::test(SearchBar::class)
         ->assertOk();


### PR DESCRIPTION
## Summary
- The `Permissions` middleware short-circuits requests for users with the `Super Admin` role before ever calling `hasPermissionTo`, but the new `user_can_access_route` helper introduced in #1673 went straight to `hasPermissionTo`. Spatie's `hasPermissionTo` does not consult `Gate::before`, so Super Admins without explicit permission assignments were treated as unauthorized and the SearchBar filtered every model out for them.
- Mirror the middleware bypass: when the authenticated user uses the `HasRoles` trait and holds the `Super Admin` role, return `true` immediately.
- Add a regression test that asserts a Super Admin sees a model in `searchModel` even when only the bare permission row exists in the database.

## Summary by Sourcery

Bypass standard permission checks for Super Admins in the route access helper and add a regression test to ensure SearchBar remains fully functional for them.

Bug Fixes:
- Ensure Super Admin users are always authorized by the user_can_access_route helper, matching the existing middleware behavior and preventing SearchBar from filtering out all models for them.

Tests:
- Add a regression test verifying that Super Admin users see searchable models in the SearchBar even when only the base permission exists in the database.