### PR TITLE
Fix notification toast lookup across TallStackUI slide teleport

### DIFF
--- a/resources/views/livewire/features/notifications.blade.php
+++ b/resources/views/livewire/features/notifications.blade.php
@@ -1,16 +1,5 @@
 <div
-    x-data="{
-        addToast(event) {
-            Alpine.$data(
-                $el.querySelector('#toasts').querySelector('[x-data]'),
-            ).add(event);
-        },
-        removeAll() {
-            Alpine.$data(
-                $el.querySelector('#toasts').querySelector('[x-data]'),
-            ).toasts = [];
-        },
-    }"
+    x-data
     x-init.once="
         window.Echo.private(
             '{{ auth()->user()->receivesBroadcastNotificationsOn() }}',
@@ -40,17 +29,27 @@
             scope="notifications"
             x-on:close="$wire.closeNotifications()"
         >
-            <div class="flex h-full flex-col justify-between">
-                <div
-                    x-on:ts-ui:toast-list.window="addToast($event)"
-                    x-on:ts-ui:toast.window="event.stopPropagation()"
-                >
-                    <div class="space-y-3 p-0" id="toasts">
-                        <x-toast scope="relative" />
-                        <div
-                            x-intersect="show && $wire.showNotifications()"
-                        ></div>
-                    </div>
+            <div
+                x-data="{
+                    addToast(event) {
+                        Alpine.$data(
+                            $refs.toasts.querySelector('[x-data]'),
+                        ).add(event);
+                    },
+                    removeAll() {
+                        Alpine.$data(
+                            $refs.toasts.querySelector('[x-data]'),
+                        ).toasts = [];
+                    },
+                }"
+                class="flex h-full flex-col justify-between"
+                x-on:ts-ui:toast-list.window="addToast($event)"
+                x-on:ts-ui:toast.window="event.stopPropagation()"
+                x-on:notifications:clear.window="removeAll()"
+            >
+                <div class="space-y-3 p-0" x-ref="toasts">
+                    <x-toast scope="relative" />
+                    <div x-intersect="show && $wire.showNotifications()"></div>
                 </div>
             </div>
             <x-slot:footer>
@@ -60,7 +59,9 @@
                         class="w-full"
                         :text="__('Mark all as read')"
                         x-on:click.prevent="
-                            $wire.markAllAsRead().then(() => removeAll())
+                            $wire
+                                .markAllAsRead()
+                                .then(() => $dispatch('notifications:clear'))
                         "
                     />
                 </div>


### PR DESCRIPTION
## Summary
- Notification panel was throwing `Cannot read properties of null (reading 'querySelector')` from `addToast`. Since TallStackUI 3.2.1 the slide overlay wraps its content in `<template x-teleport="body">`, so the outer `x-data` wrapper in `notifications.blade.php` no longer contains `#toasts` and `$el.querySelector('#toasts')` returns `null`.
- Move `addToast` / `removeAll` into an `x-data` scope inside the slide and reference the toast list via `x-ref="toasts"` so the lookup is scope-local and survives the teleport.
- The "Mark all as read" button now dispatches a `notifications:clear` window event the inner scope listens for, since the footer slot lives in a sibling DOM branch after the teleport.

## Summary by Sourcery

Fix notification toast handling to work with TallStackUI's teleported slide content and ensure bulk-clear actions function correctly.

Bug Fixes:
- Prevent notification toast handling from throwing errors when the toast list is teleported outside the outer Alpine scope.
- Ensure the 'Mark all as read' action reliably clears all toasts even when the footer resides in a separate DOM branch due to teleporting.