### PR TITLE
Honor intended URL on passkey login

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -8,6 +8,7 @@ use FluxErp\Facades\ProductType;
 use FluxErp\Helpers\Composer;
 use FluxErp\Helpers\Livewire\Features\SupportFormObjects;
 use FluxErp\Helpers\MediaLibraryDownloader;
+use FluxErp\Http\Controllers\AuthenticateUsingPasskeyController;
 use FluxErp\Http\Middleware\AuthContextMiddleware;
 use FluxErp\Http\Middleware\EnsureTwoFactorSetup;
 use FluxErp\Http\Middleware\Localization;
@@ -52,6 +53,7 @@ use Illuminate\Support\Number;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController as BaseAuthenticateUsingPasskeyController;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 use Symfony\Component\Finder\Finder;
@@ -120,6 +122,7 @@ class FluxServiceProvider extends ServiceProvider
 
         app('livewire')->componentHook(SupportFormObjects::class);
         $this->app->bind(DatabaseNotification::class, Notification::class);
+        $this->app->bind(BaseAuthenticateUsingPasskeyController::class, AuthenticateUsingPasskeyController::class);
 
         $this->app->singleton(AssetManager::class);
         $this->app->singleton(ProductTypeManager::class);

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController as BaseAuthenticateUsingPasskeyController;
+
+class AuthenticateUsingPasskeyController extends BaseAuthenticateUsingPasskeyController
+{
+    protected function validPasskeyResponse(Request $request): RedirectResponse
+    {
+        if (Session::has('passkeys.redirect')) {
+            return redirect(Session::pull('passkeys.redirect'));
+        }
+
+        return redirect(Session::get('url.intended', route('dashboard')));
+    }
+}


### PR DESCRIPTION
## Summary
- Spatie's `AuthenticateUsingPasskeyController` falls back to `config('passkeys.redirect_to_after_login')` — a hardcoded `/dashboard` URL string — which made passkey login inconsistent with the regular `Login` Livewire component. The latter redirects to `Session::get('url.intended', route('dashboard'))` so a user that landed on the login page via a protected route ends up where they wanted to go.
- Add a Flux subclass `FluxErp\Http\Controllers\AuthenticateUsingPasskeyController` that overrides `validPasskeyResponse` to mirror `Login.php`. Spatie's `passkeys.redirect` session key (used by their guest registration flow) is preserved.
- Bind the subclass in the container so Spatie's `Route::passkeys()` macro resolves the Flux controller without re-registering routes.

## Summary by Sourcery

Align passkey-based authentication redirects with existing login behavior so users are sent to their originally intended destination or dashboard consistently.

Enhancements:
- Introduce a custom AuthenticateUsingPasskeyController that preserves Spatie's passkeys.redirect behavior while falling back to the application's intended URL or dashboard route.
- Bind the Spatie base passkey authentication controller interface to the custom controller in the service container so existing passkey routes automatically use the new redirect behavior.