### PR TITLE
Add null-safety to edit-mail Alpine group getters

### DIFF
--- a/resources/views/livewire/edit-mail.blade.php
+++ b/resources/views/livewire/edit-mail.blade.php
@@ -57,7 +57,12 @@
                         <span x-text="$wire.currentGroupRecipientCount"></span> {{ __('recipient(s)') }}
                     </span>
                     <span class="text-gray-400">·</span>
-                    <span class="text-gray-500" x-text="'{{ __('Group') }} ' + (($wire.currentGroupIndex ?? 0) + 1) + '/' + ($wire.groupKeys?.length ?? 0)"></span>
+                    <span
+                        class="text-gray-500"
+                        x-text="$wire.groupKeys?.length > 0
+                            ? '{{ __('Group') }} ' + (($wire.currentGroupIndex ?? 0) + 1) + '/' + $wire.groupKeys.length
+                            : '-'"
+                    ></span>
                 </div>
             </div>
 

--- a/resources/views/livewire/edit-mail.blade.php
+++ b/resources/views/livewire/edit-mail.blade.php
@@ -24,13 +24,13 @@
             }
         },
         get isMultiGroup() {
-            return $wire.groupKeys.length > 1
+            return ($wire.groupKeys?.length ?? 0) > 1
         },
         get isLastGroup() {
-            return $wire.currentGroupIndex >= $wire.groupKeys.length - 1
+            return ($wire.currentGroupIndex ?? 0) >= ($wire.groupKeys?.length ?? 0) - 1
         },
         get isFirstGroup() {
-            return $wire.currentGroupIndex <= 0
+            return ($wire.currentGroupIndex ?? 0) <= 0
         },
     }"
 >
@@ -57,7 +57,7 @@
                         <span x-text="$wire.currentGroupRecipientCount"></span> {{ __('recipient(s)') }}
                     </span>
                     <span class="text-gray-400">·</span>
-                    <span class="text-gray-500" x-text="'{{ __('Group') }} ' + ($wire.currentGroupIndex + 1) + '/' + $wire.groupKeys.length"></span>
+                    <span class="text-gray-500" x-text="'{{ __('Group') }} ' + (($wire.currentGroupIndex ?? 0) + 1) + '/' + ($wire.groupKeys?.length ?? 0)"></span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

The Alpine getters `isMultiGroup`, `isLastGroup` and `isFirstGroup` on the outer `x-data` of `edit-mail.blade.php` read `$wire.groupKeys.length` and `$wire.currentGroupIndex` directly. Because the component is mounted as `<livewire:edit-mail lazy />` in the global layout and the TallStackUI `<x-modal>` teleports its content to `body`, these getters can be evaluated before `$wire` is fully hydrated. In production this surfaces as `isMultiGroup is not defined` (and the same for the other two) when a user opens the global mail modal.

The visible group indicator on line 60 had the same direct read of `$wire.currentGroupIndex` and `$wire.groupKeys.length` and is hardened the same way.

## Changes

- Coerce `$wire.groupKeys?.length` and `$wire.currentGroupIndex` to `0` in the three Alpine getters so they remain safe during any hydration phase.
- Apply the same fallback to the inline group-index/total label so its `x-text` evaluation cannot throw while the surrounding `x-show` is still resolving.

## Summary by Sourcery

Bug Fixes:
- Prevent runtime errors in the edit-mail modal when Alpine getters access Livewire properties before $wire is hydrated.