### PR TITLE
Coerce folder tree checked argument to array

### DIFF
--- a/resources/js/components/folders.js
+++ b/resources/js/components/folders.js
@@ -23,7 +23,7 @@ export default function folders(
     searchAttributes = null,
 ) {
     return {
-        checked: Array.isArray(checked) ? checked : [],
+        checked: checked ?? [],
         selected: null,
         openFolders: [],
         tree: [],

--- a/resources/js/components/folders.js
+++ b/resources/js/components/folders.js
@@ -23,7 +23,7 @@ export default function folders(
     searchAttributes = null,
 ) {
     return {
-        checked: checked,
+        checked: Array.isArray(checked) ? checked : [],
         selected: null,
         openFolders: [],
         tree: [],


### PR DESCRIPTION
## Summary

`<x-checkbox-tree>` resolves the `checked` argument of the Alpine `folder_tree` factory from a `wire:model` / `x-model` expression. When the bound Livewire property has not been hydrated yet — for example on a contact detail page that opens the address tab before `$wire.somethingFolderIds` is populated — the expression evaluates to `null`. JavaScript default parameters only apply for `undefined`, so the factory keeps `null` as the value of `this.checked` and every downstream method (`isChecked`, `isIndeterminate`, `toggleCheck`, `check`, `unCheck`) throws on `null.includes` / `null.filter` / `null.push`.

The reproducible report in production: `Cannot read properties of null (reading 'includes')` raised from `Proxy.isChecked` while `<x-checkbox>` evaluates `x-bind:checked="isChecked(node)"`.

## Changes

- Coerce the `checked` constructor argument in `resources/js/components/folders.js` via `Array.isArray(checked) ? checked : []` so `this.checked` is always an array regardless of what the caller passes.

## Summary by Sourcery

Bug Fixes:
- Prevent runtime errors in the folders checkbox tree when the checked model evaluates to null by defaulting the checked collection to an empty array.