### PR TITLE
Make leaflet.markercluster import static so window.L is patched in time

### DIFF
--- a/resources/js/components/address-map.js
+++ b/resources/js/components/address-map.js
@@ -1,12 +1,16 @@
+// leaflet's UMD exports itself on window.L; importing it first guarantees
+// the global is set before leaflet.markercluster's IIFE — which references
+// `L` as a free variable — evaluates. Keeping markercluster as a static
+// import eliminates the chunk-load race that broke L.markerClusterGroup()
+// in production.
 import leaflet from 'leaflet';
+import 'leaflet.markercluster';
 import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
 import markerIcon from 'leaflet/dist/images/marker-icon.png';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
-// Set global L before anything else — markercluster and all map code
-// must use the same L instance to avoid instanceof failures.
 window.L = leaflet;
-const L = window.L;
+const L = leaflet;
 
 // remove default icon - take what vite generated
 delete L.Icon.Default.prototype._getIconUrl;
@@ -16,9 +20,6 @@ L.Icon.Default.mergeOptions({
     iconUrl: markerIcon,
     shadowUrl: markerShadow,
 });
-
-// leaflet.markercluster registers itself on window.L
-const markerClusterReady = import('leaflet.markercluster');
 
 export default function (
     $wire,
@@ -30,8 +31,6 @@ export default function (
     return {
         zoom: zoom,
         async init() {
-            await markerClusterReady;
-
             if (autoload) {
                 this.$nextTick(() => {
                     this.addMarkers();
@@ -49,13 +48,7 @@ export default function (
                 );
             }
         },
-        async _initMap() {
-            if (this.map) {
-                return;
-            }
-
-            await markerClusterReady;
-
+        _initMap() {
             if (this.map) {
                 return;
             }


### PR DESCRIPTION
## Summary

`leaflet.markercluster` is a UMD plugin whose IIFE references the global `L` variable as a free identifier. The previous setup loaded it via dynamic `import('leaflet.markercluster')` and tried to compensate by setting `window.L = leaflet` before the dynamic load. With Vite's chunk-graph that arrangement could still produce one of two failure modes on the contact address tab:

1. The plugin chunk evaluated before downstream consumers had captured the same `L` reference.
2. The plugin chunk's IIFE ran with a different `L` than the one the rest of the app used.

In production the symptom is `L.markerClusterGroup is not a constructor` / `L.MarkerClusterGroup is not a constructor` while opening any contact address.

## Changes

- Promote `leaflet.markercluster` to a static side-effect import. ES module evaluation order resolves `leaflet` first — leaflet's UMD self-assigns `window.L` during its own evaluation — so by the time the plugin's IIFE looks up the free `L` identifier, the global is already populated and points at the same module instance as the rest of `address-map.js`.
- Drop the now-unused `markerClusterReady` promise and the `await markerClusterReady` calls in `init()` and `_initMap()`. `_initMap()` no longer needs to be async; its `await`-using callers continue to work.

## Summary by Sourcery

Make the Leaflet marker cluster plugin a static side-effect import so it is initialized in a consistent order with Leaflet and simplify the address map initialization accordingly.

Bug Fixes:
- Resolve a race condition where leaflet.markercluster could load with a different or uninitialized global L, causing markerClusterGroup constructors to fail at runtime.

Enhancements:
- Simplify the address map setup by removing the markerClusterReady promise and making map initialization synchronous now that markercluster is always loaded statically.