### PR TITLE
Backfill null tasks.state values to default open state

### DIFF
--- a/database/migrations/2026_05_06_000001_backfill_null_task_states.php
+++ b/database/migrations/2026_05_06_000001_backfill_null_task_states.php
@@ -1,0 +1,30 @@
+<?php
+
+use FluxErp\States\Task\Open;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        // tasks.state is `string('state')->default('open')` and therefore
+        // declared NOT NULL with default 'open'. Some customer databases
+        // still carry rows with state IS NULL from before the state column
+        // was introduced or from manual SQL fixes that bypassed the
+        // default. Hydrating such a row into FluxErp\Livewire\Forms\TaskForm
+        // raises "Cannot assign null to property of type string".
+        //
+        // Backfill those rows to the default state so the form (and every
+        // other consumer that reasonably assumes a non-null state) works
+        // again.
+        DB::table('tasks')
+            ->whereNull('state')
+            ->update(['state' => Open::$name]);
+    }
+
+    public function down(): void
+    {
+        // Lossy: we cannot recover which rows previously held NULL.
+    }
+};


### PR DESCRIPTION
## Summary

`tasks.state` is declared with `string('state')->default('open')`, i.e. NOT NULL with default `'open'`. A handful of customer databases still hold rows where the value is literally NULL — most likely from before the state column was introduced, or from manual SQL fixes that bypassed the default. Whenever such a row is hydrated into `FluxErp\Livewire\Forms\TaskForm` via Livewire's `FormObjectSynth`, the typed `string $state` property rejects the null value:

```
Cannot assign null to property FluxErp\Livewire\Forms\TaskForm::$state of type string
```

## Changes

- New migration `2026_05_06_000001_backfill_null_task_states` that updates every `tasks` row where `state IS NULL` to `Open::$name` ('open').

## Why fix the data, not the type

Widening the property to `?string $state` would silence the exception but leave the underlying invariant violated — there is no "null state" in the state machine, every Task is supposed to have one. The right fix is to align the data with the schema's declared constraint.

## Summary by Sourcery

Enhancements:
- Add a migration to update tasks with a null state to use the default open state value.