### PR TITLE
Stop dehydrating media downloads through Livewire's response payload

### DIFF
--- a/src/Livewire/DataTables/MediaList.php
+++ b/src/Livewire/DataTables/MediaList.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class MediaList extends BaseDataTable
@@ -64,7 +63,8 @@ class MediaList extends BaseDataTable
         ];
     }
 
-    public function downloadMedia(Media $media): false|BinaryFileResponse
+    #[Renderless]
+    public function downloadMedia(Media $media): bool
     {
         if (! file_exists($media->getPath())) {
             $this->toast()
@@ -74,7 +74,9 @@ class MediaList extends BaseDataTable
             return false;
         }
 
-        return response()->download($media->getPath(), $media->file_name);
+        $this->js('window.location.href = ' . json_encode($media->getUrl()));
+
+        return true;
     }
 
     #[Renderless]

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -27,7 +27,6 @@ use Illuminate\View\ComponentAttributeBag;
 use Livewire\Attributes\Renderless;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Spatie\Permission\Exceptions\UnauthorizedException;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class PurchaseInvoiceList extends BaseDataTable
@@ -109,7 +108,7 @@ class PurchaseInvoiceList extends BaseDataTable
     }
 
     #[Renderless]
-    public function downloadMedia(Media $media): false|BinaryFileResponse
+    public function downloadMedia(Media $media): bool
     {
         if (! file_exists($media->getPath())) {
             $this->toast()
@@ -119,7 +118,9 @@ class PurchaseInvoiceList extends BaseDataTable
             return false;
         }
 
-        return response()->download($media->getPath(), $media->file_name);
+        $this->js('window.location.href = ' . json_encode($media->getUrl()));
+
+        return true;
     }
 
     #[Renderless]

--- a/src/Livewire/EditMail.php
+++ b/src/Livewire/EditMail.php
@@ -19,7 +19,6 @@ use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
 class EditMail extends Component
@@ -348,9 +347,9 @@ class EditMail extends Component
     }
 
     #[Renderless]
-    public function downloadAttachment(Media $media): BinaryFileResponse
+    public function downloadAttachment(Media $media): void
     {
-        return response()->download($media->getPath());
+        $this->js('window.location.href = ' . json_encode($media->getUrl()));
     }
 
     #[Renderless]

--- a/src/Livewire/Mail/Mail.php
+++ b/src/Livewire/Mail/Mail.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class Mail extends CommunicationList
 {
@@ -126,7 +125,7 @@ class Mail extends CommunicationList
         JS);
     }
 
-    public function download(Media $mediaItem): false|BinaryFileResponse
+    public function download(Media $mediaItem): bool
     {
         if (! file_exists($mediaItem->getPath())) {
             if (method_exists($this, 'notification')) {
@@ -138,7 +137,9 @@ class Mail extends CommunicationList
             return false;
         }
 
-        return response()->download($mediaItem->getPath(), $mediaItem->file_name);
+        $this->js('window.location.href = ' . json_encode($mediaItem->getUrl()));
+
+        return true;
     }
 
     public function getNewMessages(): void

--- a/src/Traits/Livewire/WithFileUploads.php
+++ b/src/Traits/Livewire/WithFileUploads.php
@@ -14,7 +14,6 @@ use Illuminate\Validation\ValidationException;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads as WithFileUploadsBase;
 use Spatie\Permission\Exceptions\UnauthorizedException;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 trait WithFileUploads
@@ -27,20 +26,23 @@ trait WithFileUploads
 
     public bool $filesArrayDirty = false;
 
-    public function download(Media $media): ?BinaryFileResponse
+    public function download(Media $media): void
     {
         try {
-            return DownloadMedia::make([
+            $url = DownloadMedia::make([
                 'id' => $media->getKey(),
+                'as' => 'url',
             ])
                 ->checkPermission()
                 ->validate()
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);
+
+            return;
         }
 
-        return null;
+        $this->js('window.location.href = ' . json_encode($url));
     }
 
     public function downloadCollection(int|string $id, array|string $collection): ?StreamedResponse

--- a/tests/Livewire/DataTables/MediaListTest.php
+++ b/tests/Livewire/DataTables/MediaListTest.php
@@ -1,9 +1,44 @@
 <?php
 
 use FluxErp\Livewire\DataTables\MediaList;
+use FluxErp\Models\Media;
+use FluxErp\Models\Task;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(MediaList::class)
         ->assertOk();
+});
+
+test('downloadMedia triggers a client-side redirect and never dehydrates the file content', function (): void {
+    Storage::fake('local');
+
+    $task = Task::factory()->create([
+        'responsible_user_id' => $this->user->getKey(),
+    ]);
+
+    /** @var Media $media */
+    $media = Media::factory()->create([
+        'model_type' => $task->getMorphClass(),
+        'model_id' => $task->getKey(),
+        'disk' => 'local',
+    ]);
+    Storage::disk('local')->put($media->getPathRelativeToRoot(), 'mock-pdf-bytes');
+
+    $component = Livewire::actingAs($this->user)
+        ->test(MediaList::class)
+        ->call('downloadMedia', $media->getKey())
+        ->assertReturned(true);
+
+    // SupportFileDownloads dehydrates BinaryFileResponse return values into
+    // the response payload as base64. Asserting the absence of the 'download'
+    // effect and the presence of an 'xjs' window.location.href is the
+    // observable proof that a 70 MB attachment will not exhaust 128 MB of
+    // request memory.
+    expect($component->effects)->not->toHaveKey('download');
+    expect($component->effects['xjs'] ?? [])
+        ->toHaveCount(1)
+        ->and($component->effects['xjs'][0]['expression'])
+        ->toStartWith('window.location.href = ');
 });


### PR DESCRIPTION
## Summary

`Livewire\Features\SupportFileDownloads` intercepts every `BinaryFileResponse` / `StreamedResponse` returned from a component, calls `sendContent()` inside `ob_start()` to capture the full body, then base64-encodes it into the response payload. For a 70 MB attachment that costs ~93 MB of base64 on top of the 70 MB output buffer, which is enough to exhaust the customer's 128 MB `memory_limit` on `/projects/{id}` (Comments tab) and other pages that load media via Livewire actions.

## Changes

Every Livewire component download method that previously returned a file response now triggers a client-side redirect to the existing streamed media route. `window.location.href = signed-url` issues a separate HTTP request served by Spatie's `StreamedResponse`, which is chunked and never buffers the body.

Affected entry points:

- `FluxErp\Livewire\DataTables\MediaList::downloadMedia`
- `FluxErp\Livewire\DataTables\PurchaseInvoiceList::downloadMedia`
- `FluxErp\Livewire\EditMail::downloadAttachment`
- `FluxErp\Livewire\Mail\Mail::download`
- `FluxErp\Traits\Livewire\WithFileUploads::download` (used by Comments, MediaUploadForm, FolderTree, EmailTemplates and every other consumer of the trait)

`WithFileUploads::download` reuses the existing `DownloadMedia` action by passing `as => 'url'` so the URL generation (signed `media.private` for non-public disks, public URL otherwise) keeps living in one place.

A regression test on `MediaList::downloadMedia` asserts the response carries an `xjs` effect (the redirect) and never the `download` effect that `SupportFileDownloads` injects when it dehydrates a file response.

## Summary by Sourcery

Avoid returning file responses from Livewire components by triggering client-side redirects to media URLs instead, preventing Livewire from dehydrating large downloads into the response payload.

Bug Fixes:
- Prevent out-of-memory errors caused by Livewire dehydrating large media downloads into base64-encoded response payloads.

Enhancements:
- Standardize media downloads across Livewire components to use JS redirects to existing streamed media routes, reusing the central DownloadMedia action for URL generation.

Tests:
- Add a regression test for MediaList::downloadMedia to ensure downloads trigger a client-side redirect and no Livewire file-download effect is generated.