### PR TITLE
Init Alpine on tiptap toolbar after appending button commands

### DIFF
--- a/resources/js/components/tiptap.js
+++ b/resources/js/components/tiptap.js
@@ -252,6 +252,10 @@ export default function (
 
                 this.proxy = Alpine.raw(_editor);
 
+                if (!showTooltipDropdown) {
+                    Alpine.initTree(controlPanel);
+                }
+
                 element.dataset.tiptapInitialized = 'true';
 
                 this.$watch('editable', (editable) => {


### PR DESCRIPTION
## Summary
- Cloned `<template>` button commands inside the tiptap controlPanel were no longer auto-initialized by Alpine after the bump to alpinejs 3.15.12, leaving dropdown buttons (Table, Headings, etc.) inert with `x-data` and `x-on:click.prevent="onClick"` unwired.
- Call `Alpine.initTree(controlPanel)` right after appending the cloned commands, mirroring the existing pattern used on the floating tooltip variant a few lines down.

## Summary by Sourcery

Bug Fixes:
- Restore Alpine.js initialization for cloned tiptap toolbar button commands so dropdown controls respond to clicks as expected.