### PR TITLE
Init Alpine on tiptap toolbar after editor is ready

### DIFF
--- a/resources/js/components/tiptap.js
+++ b/resources/js/components/tiptap.js
@@ -252,6 +252,10 @@ export default function (
 
                 this.proxy = Alpine.raw(_editor);
 
+                if (!showTooltipDropdown) {
+                    Alpine.initTree(controlPanel);
+                }
+
                 element.dataset.tiptapInitialized = 'true';
 
                 this.$watch('editable', (editable) => {


### PR DESCRIPTION
## Summary
- Cloned `<template>` button commands inside the tiptap controlPanel were no longer auto-initialized by Alpine after the bump to alpinejs 3.15.12, leaving dropdown buttons (Table, Headings, etc.) inert with `x-data` and `x-on:click.prevent="onClick"` unwired.
- Initializing right at the `appendChild` site blew up because each button's `x-bind:class` evaluates `editor().isActive(...)`, and the closure-captured `_editor` is still `null` at that point — every button threw `cannot read properties of undefined (reading isActive)` on init, which inflated `assertNoSmoke` retry loops in CI past the 300s budget.
- Run `Alpine.initTree(controlPanel)` after `this.proxy = Alpine.raw(_editor)`, guarded by `!showTooltipDropdown` so the floating tooltip variant keeps using its own `initTree` at the floatingElement insertion site.

## Summary by Sourcery

Bug Fixes:
- Restore functionality of Alpine-based dropdown buttons in the tiptap control panel by initializing Alpine after the editor instance is available.