### PR TITLE
Load OpenCV via classic script tag for mobile WebView compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build && cp node_modules/@techstark/opencv-js/dist/opencv.js dist/opencv.js",
+        "build": "vite build && node scripts/copy-opencv.mjs",
         "format": "prettier --write ."
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "vite build && cp node_modules/@techstark/opencv-js/dist/opencv.js dist/opencv.js",
         "format": "prettier --write ."
     },
     "devDependencies": {

--- a/resources/js/components/document-scanner.js
+++ b/resources/js/components/document-scanner.js
@@ -222,13 +222,55 @@ export default ($wire) => ({
             return;
         }
 
-        if (window.cv?.Mat) {
+        if (window.cv?.HEAPU8) {
             this.openCvReady = true;
 
             return;
         }
 
-        await import('@techstark/opencv-js');
+        // OpenCV ships as a ~10 MB UMD bundle. iOS WKWebView's ESM /
+        // dynamic-import pipeline hangs indefinitely on a chunk that size,
+        // so we load it via classic <script> tag — the HTML-parser path
+        // streams large scripts reliably across mobile WebViews. Cache the
+        // promise on window so a second mount of the modal reuses it.
+        if (!window.__fluxOpenCvLoading) {
+            window.__fluxOpenCvLoading = new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = '/flux/opencv.js';
+                script.onload = () => {
+                    if (!window.cv) {
+                        reject(
+                            new Error(
+                                'opencv.js executed but window.cv is missing',
+                            ),
+                        );
+
+                        return;
+                    }
+                    if (window.cv.HEAPU8) {
+                        resolve();
+
+                        return;
+                    }
+                    const previous = window.cv.onRuntimeInitialized;
+                    window.cv.onRuntimeInitialized = () => {
+                        if (typeof previous === 'function') {
+                            try {
+                                previous();
+                            } catch (e) {
+                                // never let a previous handler block readiness
+                            }
+                        }
+                        resolve();
+                    };
+                };
+                script.onerror = () =>
+                    reject(new Error('opencv.js script load failed'));
+                document.head.appendChild(script);
+            });
+        }
+
+        await window.__fluxOpenCvLoading;
         this.openCvReady = true;
     },
 
@@ -285,7 +327,7 @@ export default ($wire) => ({
             await this.loadOpenCv();
             openCvLoaded = true;
         } catch (error) {
-            // OpenCV is optional — scanner falls back to manual corner selection
+            // OpenCV is optional — scanner falls back to manual corner selection.
             console.error('OpenCV load failed:', error);
         }
 
@@ -294,23 +336,30 @@ export default ($wire) => ({
             let corners = null;
 
             if (openCvLoaded) {
-                const mat = cv.imread(img);
-                const contour = findPaperContour(mat);
+                let mat = null;
+                let contour = null;
+                try {
+                    mat = cv.imread(img);
+                    contour = findPaperContour(mat);
 
-                if (contour) {
-                    const detected = getCornerPoints(contour);
-                    if (
-                        detected.topLeftCorner &&
-                        detected.topRightCorner &&
-                        detected.bottomLeftCorner &&
-                        detected.bottomRightCorner
-                    ) {
-                        corners = detected;
+                    if (contour) {
+                        const detected = getCornerPoints(contour);
+                        if (
+                            detected.topLeftCorner &&
+                            detected.topRightCorner &&
+                            detected.bottomLeftCorner &&
+                            detected.bottomRightCorner
+                        ) {
+                            corners = detected;
+                        }
                     }
-                    contour.delete();
+                } catch (error) {
+                    // Detection failure must not freeze the spinner — fall back to manual corners.
+                    console.error('OpenCV detection failed:', error);
+                } finally {
+                    contour?.delete();
+                    mat?.delete();
                 }
-
-                mat.delete();
             }
 
             if (!corners) {
@@ -323,6 +372,7 @@ export default ($wire) => ({
             this.$nextTick(() => this.drawCorners());
         };
         img.onerror = () => {
+            this.isProcessing = false;
             this.closeEditor();
         };
         img.src = imageSrc;

--- a/resources/js/components/document-scanner.js
+++ b/resources/js/components/document-scanner.js
@@ -234,12 +234,29 @@ export default ($wire) => ({
         // streams large scripts reliably across mobile WebViews. Cache the
         // promise on window so a second mount of the modal reuses it.
         if (!window.__fluxOpenCvLoading) {
+            const TIMEOUT_MS = 30_000;
             window.__fluxOpenCvLoading = new Promise((resolve, reject) => {
+                let timeoutId = null;
+                const succeed = () => {
+                    window.clearTimeout(timeoutId);
+                    resolve();
+                };
+                const fail = (error) => {
+                    window.clearTimeout(timeoutId);
+                    delete window.__fluxOpenCvLoading;
+                    reject(error);
+                };
+
+                timeoutId = window.setTimeout(
+                    () => fail(new Error('Timed out loading opencv.js')),
+                    TIMEOUT_MS,
+                );
+
                 const script = document.createElement('script');
                 script.src = '/flux/opencv.js';
                 script.onload = () => {
                     if (!window.cv) {
-                        reject(
+                        fail(
                             new Error(
                                 'opencv.js executed but window.cv is missing',
                             ),
@@ -248,7 +265,7 @@ export default ($wire) => ({
                         return;
                     }
                     if (window.cv.HEAPU8) {
-                        resolve();
+                        succeed();
 
                         return;
                     }
@@ -261,11 +278,11 @@ export default ($wire) => ({
                                 // never let a previous handler block readiness
                             }
                         }
-                        resolve();
+                        succeed();
                     };
                 };
                 script.onerror = () =>
-                    reject(new Error('opencv.js script load failed'));
+                    fail(new Error('opencv.js script load failed'));
                 document.head.appendChild(script);
             });
         }

--- a/scripts/copy-opencv.mjs
+++ b/scripts/copy-opencv.mjs
@@ -1,0 +1,8 @@
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const src = 'node_modules/@techstark/opencv-js/dist/opencv.js';
+const dest = 'dist/opencv.js';
+
+mkdirSync(dirname(dest), { recursive: true });
+copyFileSync(src, dest);

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -316,6 +316,19 @@ class FrontendAssets
 
     protected function pretendResponseIsFile(string $path, string $contentType)
     {
-        return Utils::pretendResponseIsFile($path, $contentType);
+        $response = Utils::pretendResponseIsFile($path, $contentType);
+
+        // FrankenPHP / Caddy `encode zstd br gzip` mis-frames brotli responses
+        // for PHP-generated bodies (HEAD returns content-length: 1, GET drops
+        // it entirely). Some clients — notably iOS WKWebView used by Capacitor
+        // — hang the import indefinitely. `no-transform` tells the encoder and
+        // any intermediary to leave the body untouched.
+        $existing = $response->headers->get('Cache-Control', '');
+        $response->headers->set(
+            'Cache-Control',
+            $existing === '' ? 'no-transform' : $existing . ', no-transform',
+        );
+
+        return $response;
     }
 }


### PR DESCRIPTION
## Summary

- `loadOpenCv()` now injects a classic `<script src="/flux/opencv.js">` tag and waits for `cv.onRuntimeInitialized` instead of `await import('@techstark/opencv-js')`. Dynamic import of the 10 MB UMD bundle hangs indefinitely on iOS WKWebView (Capacitor mobile app) — fetch completes, parse/instantiate never resolves and never throws. The HTML-parser path streams large scripts reliably across mobile WebViews.
- `npm run build` now copies `node_modules/@techstark/opencv-js/dist/opencv.js` to `dist/opencv.js` so `FrontendAssets`' `/flux/{file}` route can serve it.
- `FrontendAssets::pretendResponseIsFile()` appends `no-transform` to the cache-control header. FrankenPHP / Caddy's `encode zstd br gzip` mis-frames brotli responses for PHP-generated bodies (HEAD returns `content-length: 1`, GET drops it entirely) which iOS WKWebView then refuses to consume. `no-transform` tells the encoder to leave the body alone.
- `processImage` now wraps `cv.imread` / `findPaperContour` in `try/catch/finally` and resets `isProcessing` on `img.onerror`, so a detection failure or load error no longer freezes the spinner forever.

## Summary by Sourcery

Load OpenCV via a classic script tag and hard-copied bundle to improve mobile WebView compatibility and ensure scanner UI recovers gracefully from loading and detection failures.

New Features:
- Serve a bundled opencv.js file via the existing /flux asset route and load it through a classic script tag instead of dynamic import.

Bug Fixes:
- Prevent iOS WKWebView from hanging on large OpenCV bundles by avoiding dynamic import and relying on script tag loading with runtime initialization.
- Ensure document scanning failures or image load errors reset processing state so the UI spinner does not remain stuck.
- Avoid broken brotli-encoded responses in FrankenPHP / Caddy by appending no-transform to cache-control for pseudo-file responses, preventing WebView hangs.

Build:
- Extend the build script to copy the OpenCV UMD bundle into the dist directory for serving by the frontend assets mechanism.