### PR TITLE
Null out agent_id when contact's agent has been soft-deleted

### DIFF
--- a/src/Actions/Order/CreateOrder.php
+++ b/src/Actions/Order/CreateOrder.php
@@ -13,6 +13,7 @@ use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
+use FluxErp\Models\User;
 use FluxErp\Rulesets\Order\CreateOrderRuleset;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -126,7 +127,12 @@ class CreateOrder extends FluxAction
             ->whereKey(data_get($this->data, 'payment_type_id'))
             ->first();
 
-        $this->data['agent_id'] = $this->data['agent_id'] ?? $contact->agent_id;
+        $contactAgentId = $contact->agent_id
+            && resolve_static(User::class, 'query')->whereKey($contact->agent_id)->exists()
+                ? $contact->agent_id
+                : null;
+
+        $this->data['agent_id'] ??= $contactAgentId;
         $this->data['approval_user_id'] ??= $contact->approval_user_id;
         $this->data['contact_bank_connection_id'] ??= $contact->contactBankConnections()->first()?->id;
         $this->data['payment_discount_target'] ??= $contact->discount_days

--- a/src/Actions/Order/CreateOrder.php
+++ b/src/Actions/Order/CreateOrder.php
@@ -127,12 +127,10 @@ class CreateOrder extends FluxAction
             ->whereKey(data_get($this->data, 'payment_type_id'))
             ->first();
 
-        $contactAgentId = $contact->agent_id
+        $this->data['agent_id'] ??= $contact->agent_id
             && resolve_static(User::class, 'query')->whereKey($contact->agent_id)->exists()
                 ? $contact->agent_id
                 : null;
-
-        $this->data['agent_id'] ??= $contactAgentId;
         $this->data['approval_user_id'] ??= $contact->approval_user_id;
         $this->data['contact_bank_connection_id'] ??= $contact->contactBankConnections()->first()?->id;
         $this->data['payment_discount_target'] ??= $contact->discount_days

--- a/tests/Feature/Actions/Order/ReplicateOrderTest.php
+++ b/tests/Feature/Actions/Order/ReplicateOrderTest.php
@@ -13,6 +13,7 @@ use FluxErp\Models\PaymentType;
 use FluxErp\Models\Price;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
+use FluxErp\Models\User;
 use FluxErp\Models\VatRate;
 use FluxErp\Models\Warehouse;
 use Illuminate\Support\Str;
@@ -1319,3 +1320,59 @@ test('replicate order preserves free text block parent-child structure', functio
         ->and($newChildren->pluck('name')->sort()->values()->all())
         ->toBe(['Child Position 1', 'Child Position 2']);
 });
+
+test('replicates with null agent_id when contact agent was deleted', function (OrderTypeEnum $targetEnum): void {
+    $deletedAgent = User::factory()->create([
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    $contact = Contact::factory()->create([
+        'has_delivery_lock' => false,
+        'credit_line' => null,
+        'agent_id' => $deletedAgent->getKey(),
+    ]);
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $orderOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+
+    $targetOrderType = OrderType::factory()->create([
+        'order_type_enum' => $targetEnum,
+        'is_active' => true,
+    ]);
+
+    $order = Order::factory()->create([
+        'address_invoice_id' => $address->getKey(),
+        'agent_id' => $deletedAgent->getKey(),
+        'contact_id' => $contact->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'order_type_id' => $orderOrderType->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'invoice_number' => $targetEnum === OrderTypeEnum::Retoure ? Str::random() : null,
+        'is_locked' => true,
+    ]);
+
+    $deletedAgent->delete();
+
+    $replicated = ReplicateOrder::make([
+        'id' => $order->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'order_type_id' => $targetOrderType->getKey(),
+    ])
+        ->validate()
+        ->execute();
+
+    expect($replicated->agent_id)->toBeNull();
+})->with([
+    'retoure' => OrderTypeEnum::Retoure,
+    'split order' => OrderTypeEnum::SplitOrder,
+]);


### PR DESCRIPTION
## Summary

- `CreateOrder` fell back to the contact's `agent_id` without verifying the referenced user still exists
- When a contact's stored agent was soft-deleted, replicating an order (Retoure / Split order) failed with `The selected Agent ID is invalid.`
- The fallback now null-resolves to `null` if the contact's agent no longer exists, so replicates succeed and the new order has no agent assigned (no commission for a deleted user)

## Summary by Sourcery

Ensure order replication handles contacts whose assigned agent user has been soft-deleted by nulling the agent assignment instead of failing validation.

Bug Fixes:
- Prevent order replication from failing when a contact’s stored agent user has been soft-deleted by resolving the agent_id to null in that case.

Tests:
- Add coverage to verify replicated Retoure and split orders receive a null agent_id when the original contact’s agent user has been deleted.