### PR TITLE
Bump tallstackui to ^3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "spatie/laravel-settings": "^3.4",
         "spatie/laravel-tags": "^4.3",
         "spatie/pdf-to-image": "^3.0",
-        "tallstackui/tallstackui": "^3.4.1",
+        "tallstackui/tallstackui": "^3.5",
         "team-nifty-gmbh/tall-datatables": "^2.4.10",
         "webklex/laravel-imap": "^6.1"
     },

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -156,7 +156,7 @@
                 <x-tab.items :tab="__('All')" />
                 <x-tab.items :tab="__('Assignment suggestions')">
                     <x-slot:right>
-                        <x-badge round="full">
+                        <x-badge round>
                             <x-slot:text>
                                 <span
                                     x-text="$wire.suggestionCount ?? 0"
@@ -167,7 +167,7 @@
                 </x-tab.items>
                 <x-tab.items :tab="__('Open transactions')">
                     <x-slot:right>
-                        <x-badge round="full">
+                        <x-badge round>
                             <x-slot:text>
                                 <span
                                     x-text="$wire.unassignedCount ?? 0"

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -96,7 +96,7 @@ class ViewServiceProvider extends ServiceProvider
             ->scope('calendar')
             ->dropdown()
             ->block('wrapper.second', 'relative inline-block text-left w-full')
-            ->block('floating.class', 'w-full');
+            ->block('floating.widths.md', 'w-full');
 
         TallStackUi::customize()
             ->badge()


### PR DESCRIPTION
## Summary
- Bumps `tallstackui/tallstackui` constraint from `^3.4.1` to `^3.5`.
- Migrates the calendar-scoped dropdown customization from the removed `floating.class` block to `floating.widths.md`, which replaces the single class hook in tallstackui 3.5.

The previous customization broke at boot with:

```
Component [dropdown.main] does not have the block [floating.class] to be customized.
Allowed: wrapper.first, wrapper.second, header.wrapper, slot.wrapper, floating.default,
floating.widths.xxs, floating.widths.xs, floating.widths.sm, floating.widths.md,
floating.widths.lg, floating.widths.xl, floating.widths.2xl, action.wrapper, action.text,
action.icon, action.icon-rotated
```

## Summary by Sourcery

Bump tallstackui/tallstackui dependency to ^3.5 and update calendar dropdown customization to use the new floating width block.

Enhancements:
- Adjust calendar-scoped dropdown customization to target the floating.widths.md block for full-width behavior with tallstackui 3.5.

Build:
- Update composer dependency constraint for tallstackui/tallstackui from ^3.4.1 to ^3.5.