### PR TITLE
Fix passkey auth losing options across intermediate requests

### DIFF
--- a/src/Actions/Passkey/GeneratePasskeyAuthenticationOptionsAction.php
+++ b/src/Actions/Passkey/GeneratePasskeyAuthenticationOptionsAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FluxErp\Actions\Passkey;
+
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
+use Spatie\LaravelPasskeys\Actions\GeneratePasskeyAuthenticationOptionsAction as BaseGeneratePasskeyAuthenticationOptionsAction;
+use Spatie\LaravelPasskeys\Support\Config;
+use Spatie\LaravelPasskeys\Support\Serializer;
+use Webauthn\PublicKeyCredentialRequestOptions;
+
+class GeneratePasskeyAuthenticationOptionsAction extends BaseGeneratePasskeyAuthenticationOptionsAction
+{
+    public function execute(): string
+    {
+        $options = new PublicKeyCredentialRequestOptions(
+            challenge: Str::random(),
+            rpId: Config::getRelyingPartyId(),
+            allowCredentials: [],
+        );
+
+        $options = Serializer::make()->toJson($options);
+
+        // put() instead of the parent's flash(): flash data is aged out
+        // after one subsequent request, so any intermediate Livewire poll
+        // or asset load consumes it before the authenticate POST arrives.
+        // The controller pulls() the value to preserve single-use semantics.
+        Session::put('passkey-authentication-options', $options);
+
+        return $options;
+    }
+}

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp;
 
+use FluxErp\Actions\Passkey\GeneratePasskeyAuthenticationOptionsAction;
 use FluxErp\Actions\Passkey\StorePasskeyAction;
 use FluxErp\Assets\AssetManager;
 use FluxErp\Facades\ProductType;
@@ -249,6 +250,7 @@ class FluxServiceProvider extends ServiceProvider
             config(['two-factor.recovery.enabled' => false]);
             config(['passkeys.models.authenticatable' => resolve_static(User::class, 'class')]);
             config(['passkeys.actions.store_passkey' => resolve_static(StorePasskeyAction::class, 'class')]);
+            config(['passkeys.actions.generate_passkey_authentication_options' => resolve_static(GeneratePasskeyAuthenticationOptionsAction::class, 'class')]);
         });
         $this->mergeConfigFrom(__DIR__ . '/../config/flux.php', 'flux');
         $this->mergeConfigFrom(__DIR__ . '/../config/notifications.php', 'notifications');

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -250,7 +250,12 @@ class FluxServiceProvider extends ServiceProvider
             config(['two-factor.recovery.enabled' => false]);
             config(['passkeys.models.authenticatable' => resolve_static(User::class, 'class')]);
             config(['passkeys.actions.store_passkey' => resolve_static(StorePasskeyAction::class, 'class')]);
-            config(['passkeys.actions.generate_passkey_authentication_options' => resolve_static(GeneratePasskeyAuthenticationOptionsAction::class, 'class')]);
+            config([
+                'passkeys.actions.generate_passkey_authentication_options' => resolve_static(
+                    GeneratePasskeyAuthenticationOptionsAction::class,
+                    'class'
+                ),
+            ]);
         });
         $this->mergeConfigFrom(__DIR__ . '/../config/flux.php', 'flux');
         $this->mergeConfigFrom(__DIR__ . '/../config/notifications.php', 'notifications');

--- a/src/Http/Controllers/AuthenticateUsingPasskeyController.php
+++ b/src/Http/Controllers/AuthenticateUsingPasskeyController.php
@@ -2,13 +2,56 @@
 
 namespace FluxErp\Http\Controllers;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
+use Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction;
 use Spatie\LaravelPasskeys\Http\Controllers\AuthenticateUsingPasskeyController as BaseAuthenticateUsingPasskeyController;
+use Spatie\LaravelPasskeys\Http\Requests\AuthenticateUsingPasskeysRequest;
+use Spatie\LaravelPasskeys\Support\Config;
 
 class AuthenticateUsingPasskeyController extends BaseAuthenticateUsingPasskeyController
 {
+    public function __invoke(AuthenticateUsingPasskeysRequest $request)
+    {
+        // pull() instead of get(): atomic read-and-delete keeps the
+        // single-use guarantee that the package's flash() relied on,
+        // independent of Laravel's flash lifecycle.
+        $passkeyOptions = Session::pull('passkey-authentication-options');
+
+        if (blank($passkeyOptions)) {
+            return $this->invalidPasskeyResponse();
+        }
+
+        $findAuthenticatableUsingPasskey = Config::getAction(
+            'find_passkey',
+            FindPasskeyToAuthenticateAction::class,
+        );
+
+        $passkey = $findAuthenticatableUsingPasskey->execute(
+            $request->input('start_authentication_response'),
+            $passkeyOptions,
+        );
+
+        if (! $passkey) {
+            return $this->invalidPasskeyResponse();
+        }
+
+        /** @var Authenticatable $authenticatable */
+        $authenticatable = $passkey->authenticatable;
+
+        if (! $authenticatable) {
+            return $this->invalidPasskeyResponse();
+        }
+
+        $this->logInAuthenticatable($authenticatable, $request->boolean('remember'));
+
+        $this->firePasskeyEvent($passkey, $request);
+
+        return $this->validPasskeyResponse($request);
+    }
+
     protected function validPasskeyResponse(Request $request): RedirectResponse
     {
         if (Session::has('passkeys.redirect')) {

--- a/tests/Feature/Actions/Passkey/GeneratePasskeyAuthenticationOptionsActionTest.php
+++ b/tests/Feature/Actions/Passkey/GeneratePasskeyAuthenticationOptionsActionTest.php
@@ -3,6 +3,13 @@
 use FluxErp\Actions\Passkey\GeneratePasskeyAuthenticationOptionsAction;
 use Illuminate\Support\Facades\Session;
 
+beforeEach(function (): void {
+    config([
+        'passkeys.relying_party.id' => 'localhost',
+        'passkeys.relying_party.name' => 'Flux Test',
+    ]);
+});
+
 test('options are persisted with put so they survive aged flash data', function (): void {
     Session::start();
 

--- a/tests/Feature/Actions/Passkey/GeneratePasskeyAuthenticationOptionsActionTest.php
+++ b/tests/Feature/Actions/Passkey/GeneratePasskeyAuthenticationOptionsActionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use FluxErp\Actions\Passkey\GeneratePasskeyAuthenticationOptionsAction;
+use Illuminate\Support\Facades\Session;
+
+test('options are persisted with put so they survive aged flash data', function (): void {
+    Session::start();
+
+    $options = resolve(GeneratePasskeyAuthenticationOptionsAction::class)->execute();
+
+    // Simulate the session middleware running between the generate and the
+    // authenticate request: any flashed data is aged out and forgotten.
+    Session::ageFlashData();
+    Session::ageFlashData();
+
+    expect(Session::get('passkey-authentication-options'))->toBe($options);
+});
+
+test('pull removes the value so a replay returns null', function (): void {
+    Session::start();
+
+    resolve(GeneratePasskeyAuthenticationOptionsAction::class)->execute();
+
+    Session::pull('passkey-authentication-options');
+
+    expect(Session::get('passkey-authentication-options'))->toBeNull();
+});


### PR DESCRIPTION
## Summary

Spatie's `GeneratePasskeyAuthenticationOptionsAction` stores the WebAuthn challenge via `Session::flash`, which only survives one subsequent request. Any intermediate Livewire poll, asset load, or background fetch ages the flash out before the user's authenticate POST arrives, so the controller passes `null` into `FindPasskeyToAuthenticateAction` and the action throws a `TypeError` on its non-nullable `string $passkeyOptionsJson` argument.

```
Spatie\LaravelPasskeys\Actions\FindPasskeyToAuthenticateAction::execute():
Argument #2 ($passkeyOptionsJson) must be of type string, null given
```

## Fix

- Override the action to persist the options with `Session::put` instead of `Session::flash`.
- Override the controller to read them with `Session::pull`.

The atomic read-and-delete preserves the same single-use guarantee that the package's flash-based flow relied on, but no longer depends on Laravel's flash lifecycle, so the value survives any number of intermediate requests until the user authenticates.

## Security note

`pull()` is read-and-delete in one step. After a successful or failed authenticate request the challenge is gone from the session, so the same WebAuthn response cannot be replayed. This matches the security posture of the original `flash()` based flow.

## Summary by Sourcery

Ensure passkey authentication options persist across intermediate requests while retaining single-use semantics.

New Features:
- Add a custom GeneratePasskeyAuthenticationOptionsAction that stores WebAuthn authentication options in the session using persistent storage.

Bug Fixes:
- Prevent passkey authentication failures caused by flashed WebAuthn options expiring after intermediate requests by switching to persistent session storage with atomic retrieval.

Enhancements:
- Override the passkey authentication controller to atomically read and delete stored authentication options and handle missing or invalid options more robustly.

Tests:
- Add feature tests to verify that authentication options survive aged flash data and are removed from the session after being pulled to prevent replay.