### PR TITLE
Add UI for product variant inheritance

### DIFF
--- a/resources/views/components/product/general.blade.php
+++ b/resources/views/components/product/general.blade.php
@@ -6,17 +6,27 @@
                 label="{{ __('Product number') }}"
                 wire:model="product.product_number"
             />
-            <x-input
-                x-bind:readonly="!isEditing"
-                label="{{ __('Name') }}"
-                wire:model="product.name"
-            />
-            <x-flux::editor
-                x-model="isEditing"
-                wire:model="product.description"
-                scope="product"
-                :label="__('Description')"
-            />
+            <x-flux::product.inheritance-indicator
+                :product="$this->product->getProductModel()"
+                field="name"
+            >
+                <x-input
+                    x-bind:readonly="!isEditing"
+                    label="{{ __('Name') }}"
+                    wire:model="product.name"
+                />
+            </x-flux::product.inheritance-indicator>
+            <x-flux::product.inheritance-indicator
+                :product="$this->product->getProductModel()"
+                field="description"
+            >
+                <x-flux::editor
+                    x-model="isEditing"
+                    wire:model="product.description"
+                    scope="product"
+                    :label="__('Description')"
+                />
+            </x-flux::product.inheritance-indicator>
         @show
     </x-card>
     <x-card class="space-y-2.5" :header="__('Attributes')">
@@ -27,32 +37,57 @@
                     label="{{ __('Is active') }}"
                     wire:model="product.is_active"
                 />
-                <x-checkbox
-                    x-bind:disabled="!isEditing"
-                    label="{{ __('Is highlight') }}"
-                    wire:model="product.is_highlight"
-                />
-                <x-checkbox
-                    x-bind:disabled="!isEditing"
-                    label="{{ __('Is NOS') }}"
-                    wire:model="product.is_nos"
-                />
-                <x-checkbox
-                    x-bind:disabled="!isEditing"
-                    label="{{ __('Export to Webshop') }}"
-                    wire:model="product.is_active_export_to_web_shop"
-                />
-                <x-checkbox
-                    x-bind:disabled="!isEditing"
-                    label="{{ __('Is service') }}"
-                    wire:model="product.is_service"
-                />
-                <div x-cloak x-show="$wire.product.is_service">
-                    <x-select.styled
-                        label="{{ __('Time unit') }}"
-                        wire:model="product.time_unit_enum"
-                        :options="\FluxErp\Enums\TimeUnitEnum::valuesLocalized()"
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="is_highlight"
+                >
+                    <x-checkbox
+                        x-bind:disabled="!isEditing"
+                        label="{{ __('Is highlight') }}"
+                        wire:model="product.is_highlight"
                     />
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="is_nos"
+                >
+                    <x-checkbox
+                        x-bind:disabled="!isEditing"
+                        label="{{ __('Is NOS') }}"
+                        wire:model="product.is_nos"
+                    />
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="is_active_export_to_web_shop"
+                >
+                    <x-checkbox
+                        x-bind:disabled="!isEditing"
+                        label="{{ __('Export to Webshop') }}"
+                        wire:model="product.is_active_export_to_web_shop"
+                    />
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="is_service"
+                >
+                    <x-checkbox
+                        x-bind:disabled="!isEditing"
+                        label="{{ __('Is service') }}"
+                        wire:model="product.is_service"
+                    />
+                </x-flux::product.inheritance-indicator>
+                <div x-cloak x-show="$wire.product.is_service">
+                    <x-flux::product.inheritance-indicator
+                        :product="$this->product->getProductModel()"
+                        field="time_unit_enum"
+                    >
+                        <x-select.styled
+                            label="{{ __('Time unit') }}"
+                            wire:model="product.time_unit_enum"
+                            :options="\FluxErp\Enums\TimeUnitEnum::valuesLocalized()"
+                        />
+                    </x-flux::product.inheritance-indicator>
                 </div>
             @show
             <hr />
@@ -61,101 +96,141 @@
                 label="{{ __('EAN') }}"
                 wire:model="product.ean"
             />
-            <x-input
-                x-bind:readonly="!isEditing"
-                label="{{ __('Customs Tariff Number') }}"
-                wire:model="product.customs_tariff_number"
-            />
+            <x-flux::product.inheritance-indicator
+                :product="$this->product->getProductModel()"
+                field="customs_tariff_number"
+            >
+                <x-input
+                    x-bind:readonly="!isEditing"
+                    label="{{ __('Customs Tariff Number') }}"
+                    wire:model="product.customs_tariff_number"
+                />
+            </x-flux::product.inheritance-indicator>
             <x-input
                 x-bind:readonly="!isEditing"
                 label="{{ __('Manufacturer product number') }}"
                 wire:model="product.manufacturer_product_number"
             />
-            <x-select.styled
-                x-bind:readonly="!isEditing"
-                label="{{ __('Unit') }}"
-                wire:model.number="product.unit_id"
-                select="label:name|value:id"
-                :options="resolve_static(\FluxErp\Models\Unit::class, 'query')->get(['id', 'name'])->toArray()"
-            />
+            <x-flux::product.inheritance-indicator
+                :product="$this->product->getProductModel()"
+                field="unit_id"
+            >
+                <x-select.styled
+                    x-bind:readonly="!isEditing"
+                    label="{{ __('Unit') }}"
+                    wire:model.number="product.unit_id"
+                    select="label:name|value:id"
+                    :options="resolve_static(\FluxErp\Models\Unit::class, 'query')->get(['id', 'name'])->toArray()"
+                />
+            </x-flux::product.inheritance-indicator>
             <div
                 class="grid grid-cols-1 gap-4 sm:grid-cols-4"
                 x-bind:class="!isEditing && 'pointer-events-none'"
             >
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.dimension_length_mm"
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="dimension_length_mm"
                 >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Length') }}</div>
-                            <div>{{ __('mm') }}</div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.dimension_width_mm"
-                >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Width') }}</div>
-                            <div>{{ __('mm') }}</div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.dimension_height_mm"
-                >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Height') }}</div>
-                            <div>{{ __('mm') }}</div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.weight_gram"
-                >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Weight') }}</div>
-                            <div>{{ __('Gram') }}</div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.selling_unit"
-                >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Selling Unit') }}</div>
-                            <div>
-                                <x-tooltip
-                                    :text="__('Required to calculate the product\'s unit price. The value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value.')"
-                                />
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.dimension_length_mm"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Length') }}</div>
+                                <div>{{ __('mm') }}</div>
                             </div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
-                <x-number
-                    x-bind:readonly="!isEditing"
-                    wire:model.number="product.basic_unit"
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="dimension_width_mm"
                 >
-                    <x-slot:label>
-                        <div class="flex items-center justify-between">
-                            <div>{{ __('Basic Unit') }}</div>
-                            <div>
-                                <x-tooltip
-                                    :text="__('Required to calculate the product\'s unit price. The value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value.')"
-                                />
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.dimension_width_mm"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Width') }}</div>
+                                <div>{{ __('mm') }}</div>
                             </div>
-                        </div>
-                    </x-slot:label>
-                </x-number>
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="dimension_height_mm"
+                >
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.dimension_height_mm"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Height') }}</div>
+                                <div>{{ __('mm') }}</div>
+                            </div>
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="weight_gram"
+                >
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.weight_gram"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Weight') }}</div>
+                                <div>{{ __('Gram') }}</div>
+                            </div>
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="selling_unit"
+                >
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.selling_unit"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Selling Unit') }}</div>
+                                <div>
+                                    <x-tooltip
+                                        :text="__('Required to calculate the product\'s unit price. The value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value.')"
+                                    />
+                                </div>
+                            </div>
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
+                <x-flux::product.inheritance-indicator
+                    :product="$this->product->getProductModel()"
+                    field="basic_unit"
+                >
+                    <x-number
+                        x-bind:readonly="!isEditing"
+                        wire:model.number="product.basic_unit"
+                    >
+                        <x-slot:label>
+                            <div class="flex items-center justify-between">
+                                <div>{{ __('Basic Unit') }}</div>
+                                <div>
+                                    <x-tooltip
+                                        :text="__('Required to calculate the product\'s unit price. The value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value.')"
+                                    />
+                                </div>
+                            </div>
+                        </x-slot:label>
+                    </x-number>
+                </x-flux::product.inheritance-indicator>
             </div>
         @show
     </x-card>

--- a/resources/views/components/product/inheritance-indicator.blade.php
+++ b/resources/views/components/product/inheritance-indicator.blade.php
@@ -1,0 +1,22 @@
+@if(! $shouldRenderChrome())
+    {{ $slot }}
+@else
+    <div class="space-y-1">
+        <div class="flex items-center gap-2">
+            @if($isOverridden)
+                <x-badge color="amber" sm> {{ __('Überschrieben') }} </x-badge>
+                <x-button
+                    icon="arrow-uturn-left"
+                    color="secondary"
+                    flat
+                    sm
+                    :title="__('Auf geerbt zurücksetzen')"
+                    wire:click="{{ $resetMethod }}('{{ $field }}')"
+                />
+            @else
+                <x-badge color="gray" sm> {{ __('Vererbt') }} </x-badge>
+            @endif
+        </div>
+        {{ $slot }}
+    </div>
+@endif

--- a/resources/views/components/product/inheritance-orphan-banner.blade.php
+++ b/resources/views/components/product/inheritance-orphan-banner.blade.php
@@ -1,0 +1,30 @@
+@if($visible)
+    <x-alert color="amber">
+        <div class="space-y-3">
+            <div class="font-semibold">
+                {{ __('Dieses Produkt hatte Varianten, aber keine aktive Variante mehr.') }}
+            </div>
+            <div class="text-sm">{{ __('Was soll passieren?') }}</div>
+            <div class="flex flex-wrap gap-2">
+                <x-button
+                    :text="__('Als eigenständiges Produkt aktivieren')"
+                    color="primary"
+                    wire:click="promoteToStandalone"
+                    wire:flux-confirm.type.info="{{ __('Sicher? Das Produkt ist danach wieder verkaufbar.') }}"
+                />
+                <x-button
+                    :text="__('Produkt deaktivieren')"
+                    color="secondary"
+                    flat
+                    wire:click="deactivate"
+                />
+                <x-button
+                    :text="__('Neue Variante anlegen')"
+                    color="secondary"
+                    flat
+                    x-on:click="$tsui.open.modal('generate-variants-modal')"
+                />
+            </div>
+        </div>
+    </x-alert>
+@endif

--- a/resources/views/components/product/prices.blade.php
+++ b/resources/views/components/product/prices.blade.php
@@ -71,6 +71,42 @@
                         color="amber"
                         x-text="'{{ __('Inherited from :parent_name') }}'.replace(':parent_name', priceList.parent?.name)"
                     />
+                    <x-badge
+                        x-cloak
+                        x-show="
+                            $wire.product.parent_id &&
+                            priceList.variant_owns_price
+                        "
+                        color="amber"
+                        :text="__('Überschrieben')"
+                    />
+                    <x-badge
+                        x-cloak
+                        x-show="
+                            $wire.product.parent_id &&
+                            !priceList.variant_owns_price &&
+                            priceList.price_id
+                        "
+                        color="gray"
+                        :text="__('Vererbt')"
+                    />
+                    <x-button
+                        x-cloak
+                        x-show="
+                            $wire.product.parent_id &&
+                            priceList.variant_owns_price
+                        "
+                        icon="arrow-uturn-left"
+                        color="secondary"
+                        flat
+                        sm
+                        :title="__('Auf geerbt zurücksetzen')"
+                        x-on:click="
+                            $wire
+                                .resetRelation('prices', priceList.id)
+                                .then(() => $wire.getPriceLists())
+                        "
+                    />
                     <div x-show="priceList.parent">
                         <x-toggle
                             x-model.boolean="priceList.is_editable"

--- a/resources/views/components/product/variant-bulk-reset.blade.php
+++ b/resources/views/components/product/variant-bulk-reset.blade.php
@@ -1,0 +1,29 @@
+@if(! empty($counters))
+    <x-card>
+        <x-slot:header>
+            {{ __('Auswirkung auf Varianten') }}
+        </x-slot:header>
+        <div class="space-y-2">
+            @foreach($counters as $field => $stat)
+                <div class="flex items-center justify-between gap-4">
+                    <div>
+                        <span class="font-medium">{{ __($field) }}</span>
+                        <span class="text-sm text-gray-500">
+                            {{ __(':inheriting von :total Varianten erben', $stat) }}
+                        </span>
+                    </div>
+                    @if($stat['inheriting'] < $stat['total'])
+                        <x-button
+                            :text="__('Alle auf geerbt setzen')"
+                            color="secondary"
+                            flat
+                            sm
+                            wire:click="resetFieldOnAllVariants('{{ $field }}')"
+                            wire:flux-confirm.type.warning="{{ __('Alle Variant-Overrides für :field zurücksetzen?', ['field' => __($field)]) }}"
+                        />
+                    @endif
+                </div>
+            @endforeach
+        </div>
+    </x-card>
+@endif

--- a/resources/views/livewire/product/product.blade.php
+++ b/resources/views/livewire/product/product.blade.php
@@ -97,6 +97,11 @@
             @stack('product-detail-header-actions')
         </div>
     </div>
+    @if($state = $this->inheritanceState)
+        <x-badge color="amber" sm>
+            {{ __(':fields Felder überschrieben, :prices Preise abweichend', $state) }}
+        </x-badge>
+    @endif
     <x-flux::product.variant-bulk-reset
         :counters="$this->inheritanceCounters"
     />

--- a/resources/views/livewire/product/product.blade.php
+++ b/resources/views/livewire/product/product.blade.php
@@ -97,6 +97,9 @@
             @stack('product-detail-header-actions')
         </div>
     </div>
+    <x-flux::product.variant-bulk-reset
+        :counters="$this->inheritanceCounters"
+    />
     <x-flux::tabs wire:model.live="tab" wire:loading="tab" :$tabs wire:ignore />
     @stack('product-detail-after-tabs')
 </div>

--- a/resources/views/livewire/product/product.blade.php
+++ b/resources/views/livewire/product/product.blade.php
@@ -97,6 +97,9 @@
             @stack('product-detail-header-actions')
         </div>
     </div>
+    <x-flux::product.inheritance-orphan-banner
+        :visible="$this->isOrphanedParent"
+    />
     @if($state = $this->inheritanceState)
         <x-badge color="amber" sm>
             {{ __(':fields Felder überschrieben, :prices Preise abweichend', $state) }}

--- a/resources/views/livewire/product/variant-list.blade.php
+++ b/resources/views/livewire/product/variant-list.blade.php
@@ -190,6 +190,12 @@
             />
         </x-slot:footer>
     </x-modal>
+    <div class="mb-4 flex items-center gap-2">
+        <x-toggle
+            wire:model.live="onlyOverrides"
+            :label="__('Nur Overrides anzeigen')"
+        />
+    </div>
     <div wire:ignore>
         @include('tall-datatables::livewire.data-table')
     </div>

--- a/src/Console/Commands/ProductVariantsAuditCommand.php
+++ b/src/Console/Commands/ProductVariantsAuditCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace FluxErp\Console\Commands;
+
+use FluxErp\Models\Product;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class ProductVariantsAuditCommand extends Command
+{
+    protected $description = 'Audit existing parent products for references that block parent-not-orderable enforcement.';
+
+    protected $signature = 'flux:product-variants:audit {--output=table : Output format: table or csv}';
+
+    public function handle(): int
+    {
+        $rows = $this->collectReferences();
+
+        if ($rows->isEmpty()) {
+            $this->info('No issues found. All parent products are clean.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('output') === 'csv') {
+            $path = $this->writeCsv($rows);
+            $this->info("CSV written to: {$path}");
+        } else {
+            $this->table(
+                ['parent_id', 'product_number', 'reference_type', 'reference_count'],
+                $rows->toArray()
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function collectReferences(): Collection
+    {
+        $rows = collect();
+
+        $parents = resolve_static(Product::class, 'query')
+            ->where(fn (Builder $query) => $query
+                ->whereHas('children')
+                ->orWhere('was_parent', true)
+            )
+            ->get(['id', 'product_number', 'is_active_export_to_web_shop']);
+
+        foreach ($parents as $parent) {
+            $orderPositions = DB::table('order_positions')
+                ->whereNull('deleted_at')
+                ->where('product_id', $parent->getKey())
+                ->count();
+
+            if ($orderPositions > 0) {
+                $rows->push([
+                    'parent_id' => $parent->getKey(),
+                    'product_number' => $parent->product_number,
+                    'reference_type' => 'order_positions',
+                    'reference_count' => $orderPositions,
+                ]);
+            }
+
+            $stockPostings = DB::table('stock_postings')
+                ->where('product_id', $parent->getKey())
+                ->count();
+
+            if ($stockPostings > 0) {
+                $rows->push([
+                    'parent_id' => $parent->getKey(),
+                    'product_number' => $parent->product_number,
+                    'reference_type' => 'stock_postings',
+                    'reference_count' => $stockPostings,
+                ]);
+            }
+
+            $bundleRefs = DB::table('bundle_product_product')
+                ->where('product_id', $parent->getKey())
+                ->count();
+
+            if ($bundleRefs > 0) {
+                $rows->push([
+                    'parent_id' => $parent->getKey(),
+                    'product_number' => $parent->product_number,
+                    'reference_type' => 'bundle_components',
+                    'reference_count' => $bundleRefs,
+                ]);
+            }
+
+            if ($parent->is_active_export_to_web_shop) {
+                $rows->push([
+                    'parent_id' => $parent->getKey(),
+                    'product_number' => $parent->product_number,
+                    'reference_type' => 'web_shop_active',
+                    'reference_count' => 1,
+                ]);
+            }
+        }
+
+        return $rows;
+    }
+
+    protected function writeCsv(Collection $rows): string
+    {
+        $path = storage_path('app/product-variants-audit-' . now()->format('Ymd-His-u') . '.csv');
+        $handle = fopen($path, 'w');
+        fputcsv($handle, ['parent_id', 'product_number', 'reference_type', 'reference_count']);
+
+        foreach ($rows as $row) {
+            fputcsv($handle, [
+                $row['parent_id'],
+                $row['product_number'],
+                $row['reference_type'],
+                $row['reference_count'],
+            ]);
+        }
+
+        fclose($handle);
+
+        return $path;
+    }
+}

--- a/src/Livewire/Forms/ProductForm.php
+++ b/src/Livewire/Forms/ProductForm.php
@@ -6,6 +6,7 @@ use FluxErp\Actions\Product\CreateProduct;
 use FluxErp\Actions\Product\DeleteProduct;
 use FluxErp\Actions\Product\RestoreProduct;
 use FluxErp\Actions\Product\UpdateProduct;
+use FluxErp\Models\Product;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Locked;
 
@@ -119,6 +120,8 @@ class ProductForm extends FluxForm
 
     public ?float $weight_gram = null;
 
+    protected ?Product $cachedProductModel = null;
+
     public function fill($values): void
     {
         if ($values instanceof Model) {
@@ -160,6 +163,17 @@ class ProductForm extends FluxForm
                 'count' => $bundleProduct['pivot']['count'] ?? 0,
             ];
         }, $this->bundle_products);
+    }
+
+    public function getProductModel(): ?Product
+    {
+        if (! $this->id) {
+            return null;
+        }
+
+        return $this->cachedProductModel ??= resolve_static(Product::class, 'query')
+            ->whereKey($this->id)
+            ->first();
     }
 
     protected function getActions(): array

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -3,6 +3,11 @@
 namespace FluxErp\Livewire\Product;
 
 use Exception;
+use FluxErp\Actions\Product\PromoteParentToStandalone;
+use FluxErp\Actions\Product\ResetFieldOnAllVariants;
+use FluxErp\Actions\Product\ResetProductField;
+use FluxErp\Actions\Product\ResetProductRelation;
+use FluxErp\Actions\Product\ResetRelationOnAllVariants;
 use FluxErp\Actions\Tag\CreateTag;
 use FluxErp\Enums\PropertyTypeEnum;
 use FluxErp\Facades\ProductType;
@@ -390,6 +395,79 @@ class Product extends Component
         $this->product->product_properties = Arr::keyBy($this->product->product_properties, 'id');
 
         $this->recalculateDisplayedProductProperties();
+    }
+
+    public function resetField(string $field): void
+    {
+        try {
+            ResetProductField::make([
+                'id' => $this->product->id,
+                'field' => $field,
+            ])->validate()->execute();
+        } catch (ValidationException $e) {
+            $this->addError('inheritance', $e->validator->errors()->first());
+
+            return;
+        }
+
+        $this->resetProduct();
+    }
+
+    #[Renderless]
+    public function resetRelation(string $relation, mixed $key = null): void
+    {
+        try {
+            ResetProductRelation::make([
+                'id' => $this->product->id,
+                'relation' => $relation,
+                'key' => $key,
+            ])->validate()->execute();
+        } catch (ValidationException $e) {
+            $this->addError('inheritance', $e->validator->errors()->first());
+        }
+    }
+
+    #[Renderless]
+    public function resetFieldOnAllVariants(string $field): int
+    {
+        try {
+            return ResetFieldOnAllVariants::make([
+                'parent_id' => $this->product->id,
+                'field' => $field,
+            ])->validate()->execute();
+        } catch (ValidationException $e) {
+            $this->addError('inheritance', $e->validator->errors()->first());
+
+            return 0;
+        }
+    }
+
+    #[Renderless]
+    public function resetRelationOnAllVariants(string $relation, mixed $key = null): int
+    {
+        try {
+            return ResetRelationOnAllVariants::make([
+                'parent_id' => $this->product->id,
+                'relation' => $relation,
+                'key' => $key,
+            ])->validate()->execute();
+        } catch (ValidationException $e) {
+            $this->addError('inheritance', $e->validator->errors()->first());
+
+            return 0;
+        }
+    }
+
+    #[Renderless]
+    public function promoteToStandalone(): void
+    {
+        try {
+            PromoteParentToStandalone::make([
+                'id' => $this->product->id,
+            ])->validate()->execute();
+        } catch (ValidationException $e) {
+            $this->addError('inheritance', $e->validator->errors()->first());
+        }
     }
 
     public function save(): bool

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -561,6 +561,41 @@ class Product extends Component
         return app(VatRate::class)->all(['id', 'name', 'rate_percentage'])->toArray();
     }
 
+    #[Computed]
+    public function inheritanceCounters(): array
+    {
+        $product = $this->product->getProductModel();
+        if (! $product) {
+            return [];
+        }
+
+        $hasChildren = $product->children()->exists();
+        if (! $product->was_parent && ! $hasChildren) {
+            return [];
+        }
+
+        $children = $product->children()->get(['id', 'overridden_fields']);
+        $totalVariants = $children->count();
+
+        if ($totalVariants === 0) {
+            return [];
+        }
+
+        $counters = [];
+        foreach ($product->getInheritableFields() as $field) {
+            $overriding = $children->filter(
+                fn ($v) => in_array($field, $v->overridden_fields ?? [], strict: true)
+            )->count();
+
+            $counters[$field] = [
+                'inheriting' => $totalVariants - $overriding,
+                'total' => $totalVariants,
+            ];
+        }
+
+        return $counters;
+    }
+
     #[Computed(persist: true)]
     public function viewName()
     {

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -255,6 +255,11 @@ class Product extends Component
         $product = resolve_static(ProductModel::class, 'query')
             ->whereKey($this->product->id)
             ->first();
+
+        $variantOwnPriceListIds = $product?->isVariant()
+            ? $product->ownPrices()->pluck('price_list_id')->all()
+            : [];
+
         $priceListHelper = PriceHelper::make($product)->useDefault(false);
 
         $priceLists = resolve_static(PriceList::class, 'query')
@@ -275,7 +280,7 @@ class Product extends Component
                 'is_default',
                 'is_purchase',
             ])
-            ->map(function (PriceList $priceList) use ($priceListHelper) {
+            ->map(function (PriceList $priceList) use ($priceListHelper, $variantOwnPriceListIds) {
                 $price = $priceListHelper
                     ->setPriceList($priceList)
                     ->price();
@@ -293,6 +298,7 @@ class Product extends Component
                     'is_default' => $priceList->is_default,
                     'is_purchase' => $priceList->is_purchase,
                     'is_editable' => ! is_null(data_get($price, 'id')) || ! is_null($price?->parent) || is_null($price),
+                    'variant_owns_price' => in_array($priceList->id, $variantOwnPriceListIds, strict: true),
                 ];
             });
 

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -476,6 +476,13 @@ class Product extends Component
         }
     }
 
+    public function deactivate(): bool
+    {
+        $this->product->is_active = false;
+
+        return $this->save();
+    }
+
     public function save(): bool
     {
         if ($this->priceLists !== null) {
@@ -615,6 +622,18 @@ class Product extends Component
         }
 
         return $counters;
+    }
+
+    #[Computed]
+    public function isOrphanedParent(): bool
+    {
+        $product = $this->product->getProductModel();
+
+        if (! $product?->was_parent) {
+            return false;
+        }
+
+        return ! $product->children()->where('is_active', true)->exists();
     }
 
     #[Computed(persist: true)]

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -562,6 +562,27 @@ class Product extends Component
     }
 
     #[Computed]
+    public function inheritanceState(): ?array
+    {
+        $product = $this->product->getProductModel();
+        if (! $product?->isVariant()) {
+            return null;
+        }
+
+        $overriddenFields = count($product->overridden_fields ?? []);
+        $overriddenPrices = $product->ownPrices()->count();
+
+        if ($overriddenFields === 0 && $overriddenPrices === 0) {
+            return null;
+        }
+
+        return [
+            'fields' => $overriddenFields,
+            'prices' => $overriddenPrices,
+        ];
+    }
+
+    #[Computed]
     public function inheritanceCounters(): array
     {
         $product = $this->product->getProductModel();

--- a/src/Livewire/Product/VariantList.php
+++ b/src/Livewire/Product/VariantList.php
@@ -31,6 +31,8 @@ class VariantList extends ProductList
 
     public bool $isSelectable = true;
 
+    public bool $onlyOverrides = false;
+
     #[Modelable]
     public ProductForm $product;
 
@@ -268,6 +270,23 @@ class VariantList extends ProductList
             ->success(__(':model restored', ['model' => __('Product')]))
             ->send();
         $this->loadData();
+    }
+
+    public function updatedOnlyOverrides(): void
+    {
+        $this->loadData();
+    }
+
+    protected function getBuilder(Builder $builder): Builder
+    {
+        $builder->with('parent');
+
+        if ($this->onlyOverrides) {
+            $builder->whereNotNull('overridden_fields')
+                ->whereJsonLength('overridden_fields', '>', 0);
+        }
+
+        return $builder;
     }
 
     protected function itemToArray($item): array

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -20,7 +20,6 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\Engine;
 use Spatie\MediaLibrary\HasMedia;
@@ -51,7 +50,7 @@ class Tenant extends FluxModel implements HasMedia
 
         static::saving(function (self $tenant): void {
             if ($tenant->isDirty('product_variant_inheritance_enabled')) {
-                Cache::memo()->forget('default_' . morph_alias(self::class));
+                self::clearDefaultCache();
             }
         });
     }

--- a/src/Traits/Model/HasDefault.php
+++ b/src/Traits/Model/HasDefault.php
@@ -25,7 +25,7 @@ trait HasDefault
             );
 
         if (! is_null($attributes) && ! is_array($attributes)) {
-            Cache::memo()->forget($cacheKey);
+            static::clearDefaultCache();
             $attributes = resolve_static(static::class, 'query')
                 ->where(static::$defaultColumn, true)
                 ->first()
@@ -42,12 +42,17 @@ trait HasDefault
         return $model;
     }
 
+    public static function clearDefaultCache(): void
+    {
+        Cache::memo()->forget('default_' . morph_alias(static::class));
+    }
+
     protected static function bootHasDefault(): void
     {
         static::saving(
             function (Model $model): void {
                 if ($model->isDirty(static::$defaultColumn)) {
-                    Cache::memo()->forget('default_' . morph_alias(static::class));
+                    static::clearDefaultCache();
 
                     if ($model->{static::$defaultColumn}) {
                         $model->setUpdatedDefault();
@@ -75,7 +80,7 @@ trait HasDefault
 
         static::deleted(function (Model $model): void {
             if ($model->{static::$defaultColumn}) {
-                Cache::memo()->forget('default_' . morph_alias(static::class));
+                static::clearDefaultCache();
 
                 $default = static::query()->first();
                 if ($default) {

--- a/src/View/Components/Product/InheritanceIndicator.php
+++ b/src/View/Components/Product/InheritanceIndicator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FluxErp\View\Components\Product;
+
+use FluxErp\Models\Product;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class InheritanceIndicator extends Component
+{
+    public bool $isVariant;
+
+    public bool $inheritanceEnabled;
+
+    public bool $isOverridden;
+
+    public function __construct(
+        public ?Product $product,
+        public string $field,
+        public string $resetMethod = 'resetField',
+        ?bool $overridden = null,
+    ) {
+        $this->isVariant = $product?->isVariant() ?? false;
+        $this->inheritanceEnabled = $product?->inheritanceEnabled() ?? false;
+        $this->isOverridden = $overridden ?? ($this->isVariant && $product->overrides($field));
+    }
+
+    public function render(): View
+    {
+        return view('flux::components.product.inheritance-indicator');
+    }
+
+    public function shouldRenderChrome(): bool
+    {
+        return $this->isVariant && $this->inheritanceEnabled;
+    }
+}

--- a/src/View/Components/Product/InheritanceOrphanBanner.php
+++ b/src/View/Components/Product/InheritanceOrphanBanner.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FluxErp\View\Components\Product;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class InheritanceOrphanBanner extends Component
+{
+    public function __construct(
+        public bool $visible = false,
+    ) {}
+
+    public function render(): View
+    {
+        return view('flux::components.product.inheritance-orphan-banner');
+    }
+}

--- a/src/View/Components/Product/VariantBulkReset.php
+++ b/src/View/Components/Product/VariantBulkReset.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FluxErp\View\Components\Product;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class VariantBulkReset extends Component
+{
+    public function __construct(
+        public array $counters = [],
+    ) {}
+
+    public function render(): View
+    {
+        return view('flux::components.product.variant-bulk-reset');
+    }
+}

--- a/tests/Feature/Actions/Product/ProductActionTest.php
+++ b/tests/Feature/Actions/Product/ProductActionTest.php
@@ -8,7 +8,6 @@ use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
 use FluxErp\Models\Tenant;
 use FluxErp\Models\VatRate;
-use Illuminate\Support\Facades\Cache;
 
 test('create product with defaults', function (): void {
     $product = CreateProduct::make([
@@ -66,7 +65,7 @@ test('delete product with children fails', function (): void {
 
 it('does not copy parent prices into variant when inheritance is enabled', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $listA = PriceList::factory()->create();
     $parent = Product::factory()->create(['vat_rate_id' => VatRate::default()?->getKey()]);
@@ -90,7 +89,7 @@ it('does not copy parent prices into variant when inheritance is enabled', funct
 
 it('still copies parent prices into variant when inheritance is disabled', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $listA = PriceList::factory()->create();
     $parent = Product::factory()->create(['vat_rate_id' => VatRate::default()?->getKey()]);

--- a/tests/Feature/Actions/Product/Variant/CreateVariantsTest.php
+++ b/tests/Feature/Actions/Product/Variant/CreateVariantsTest.php
@@ -7,11 +7,10 @@ use FluxErp\Models\ProductOption;
 use FluxErp\Models\ProductOptionGroup;
 use FluxErp\Models\Tenant;
 use FluxErp\Models\VatRate;
-use Illuminate\Support\Facades\Cache;
 
 it('does not attach inherited categories to a new variant when inheritance is enabled', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $cat = Category::factory()->create(['model_type' => morph_alias(Product::class)]);
     $parent = Product::factory()->create(['vat_rate_id' => VatRate::default()?->getKey()]);
@@ -35,7 +34,7 @@ it('does not attach inherited categories to a new variant when inheritance is en
 
 it('still attaches parent categories to a new variant when inheritance is disabled', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $cat = Category::factory()->create(['model_type' => morph_alias(Product::class)]);
     $parent = Product::factory()->create(['vat_rate_id' => VatRate::default()?->getKey()]);

--- a/tests/Feature/Console/MigrateProductVariantInheritanceCommandTest.php
+++ b/tests/Feature/Console/MigrateProductVariantInheritanceCommandTest.php
@@ -2,11 +2,10 @@
 
 use FluxErp\Models\Product;
 use FluxErp\Models\Tenant;
-use Illuminate\Support\Facades\Cache;
 
 beforeEach(function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 });
 
 test('runs the migration for the default tenant when feature toggle is on', function (): void {
@@ -23,7 +22,7 @@ test('runs the migration for the default tenant when feature toggle is on', func
 
 test('refuses to run when feature toggle is off', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $this->artisan('flux:product-variants:migrate-inheritance')
         ->expectsOutputToContain('disabled')

--- a/tests/Feature/Console/ProductVariantsAuditCommandTest.php
+++ b/tests/Feature/Console/ProductVariantsAuditCommandTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Product;
+use FluxErp\Models\StockPosting;
+use FluxErp\Models\Warehouse;
+
+function makeWarehouse(): Warehouse
+{
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+    ]);
+
+    return Warehouse::factory()->create([
+        'address_id' => $address->getKey(),
+    ]);
+}
+
+test('reports parent products referenced in order_positions', function (): void {
+    $parent = Product::factory()->create(['product_number' => 'AUDIT-OP-PARENT']);
+    Product::factory()->create(['parent_id' => $parent->getKey()]);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $priceList = PriceList::factory()->create();
+    $currency = Currency::factory()->create();
+
+    $order = Order::factory()->create([
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+
+    OrderPosition::factory()->create([
+        'order_id' => $order->getKey(),
+        'product_id' => $parent->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $this->artisan('flux:product-variants:audit')
+        ->expectsOutputToContain('order_positions')
+        ->assertSuccessful();
+});
+
+test('reports parent products referenced in stock_postings', function (): void {
+    $parent = Product::factory()->create(['product_number' => 'AUDIT-SP-PARENT']);
+    Product::factory()->create(['parent_id' => $parent->getKey()]);
+
+    StockPosting::factory()->create([
+        'warehouse_id' => makeWarehouse()->getKey(),
+        'product_id' => $parent->getKey(),
+    ]);
+
+    $this->artisan('flux:product-variants:audit')
+        ->expectsOutputToContain('stock_postings')
+        ->assertSuccessful();
+});
+
+test('reports parent products with is_active_export_to_web_shop set', function (): void {
+    $parent = Product::factory()->create([
+        'product_number' => 'AUDIT-WEB-PARENT',
+        'is_active_export_to_web_shop' => true,
+    ]);
+    Product::factory()->create(['parent_id' => $parent->getKey()]);
+
+    $this->artisan('flux:product-variants:audit')
+        ->expectsOutputToContain('web_shop_active')
+        ->assertSuccessful();
+});
+
+test('runs cleanly when no problematic data exists', function (): void {
+    $this->artisan('flux:product-variants:audit')
+        ->expectsOutputToContain('No issues found')
+        ->assertSuccessful();
+});
+
+test('csv output writes a file to storage/app and reports the path', function (): void {
+    $parent = Product::factory()->create();
+    Product::factory()->create(['parent_id' => $parent->getKey()]);
+    StockPosting::factory()->create([
+        'warehouse_id' => makeWarehouse()->getKey(),
+        'product_id' => $parent->getKey(),
+    ]);
+
+    $this->artisan('flux:product-variants:audit', ['--output' => 'csv'])
+        ->expectsOutputToContain('CSV written to')
+        ->assertSuccessful();
+
+    $files = glob(storage_path('app/product-variants-audit-*.csv'));
+    expect($files)->not->toBeEmpty();
+
+    $latest = collect($files)->sort()->last();
+    $contents = file_get_contents($latest);
+
+    expect($contents)
+        ->toContain('parent_id,product_number,reference_type,reference_count')
+        ->toContain('stock_postings')
+        ->toContain((string) $parent->getKey());
+
+    foreach ($files as $file) {
+        @unlink($file);
+    }
+});

--- a/tests/Feature/Jobs/MigrateProductVariantInheritanceJobTest.php
+++ b/tests/Feature/Jobs/MigrateProductVariantInheritanceJobTest.php
@@ -6,11 +6,10 @@ use FluxErp\Models\Price;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
 use FluxErp\Models\Tenant;
-use Illuminate\Support\Facades\Cache;
 
 beforeEach(function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 });
 
 /**

--- a/tests/Feature/Web/ProductInheritanceIndicatorTest.php
+++ b/tests/Feature/Web/ProductInheritanceIndicatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use FluxErp\Models\Product;
+use FluxErp\Models\Tenant;
+use Illuminate\Support\Facades\Blade;
+
+beforeEach(function (): void {
+    Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
+    Tenant::clearDefaultCache();
+});
+
+test('renders only slot for non-variant products', function (): void {
+    $product = Product::factory()->create(['parent_id' => null]);
+
+    $html = Blade::render(
+        '<x-flux::product.inheritance-indicator :product="$product" field="name"><span data-testid="slot">slot</span></x-flux::product.inheritance-indicator>',
+        ['product' => $product]
+    );
+
+    expect($html)->toContain('data-testid="slot"');
+    expect($html)->not->toContain('Vererbt');
+    expect($html)->not->toContain('Überschrieben');
+});
+
+test('renders inherited badge when variant has not overridden the field', function (): void {
+    $parent = Product::factory()->create();
+    $variant = Product::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $html = Blade::render(
+        '<x-flux::product.inheritance-indicator :product="$variant" field="name"><span data-testid="slot">slot</span></x-flux::product.inheritance-indicator>',
+        ['variant' => $variant]
+    );
+
+    expect($html)->toContain('data-testid="slot"');
+    expect($html)->toContain('Vererbt');
+    expect($html)->not->toContain('Überschrieben');
+});
+
+test('renders overridden badge and reset button when variant overrides the field', function (): void {
+    $parent = Product::factory()->create();
+    $variant = Product::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+
+    $html = Blade::render(
+        '<x-flux::product.inheritance-indicator :product="$variant" field="name"><span data-testid="slot">slot</span></x-flux::product.inheritance-indicator>',
+        ['variant' => $variant]
+    );
+
+    expect($html)->toContain('data-testid="slot"');
+    expect($html)->toContain('Überschrieben');
+    expect($html)->toContain('resetField');
+    expect($html)->toContain("'name'");
+});
+
+test('renders only slot when inheritance is disabled tenant-wide', function (): void {
+    Tenant::default()->update(['product_variant_inheritance_enabled' => false]);
+    Tenant::clearDefaultCache();
+
+    $parent = Product::factory()->create();
+    $variant = Product::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+
+    $html = Blade::render(
+        '<x-flux::product.inheritance-indicator :product="$variant" field="name"><span data-testid="slot">slot</span></x-flux::product.inheritance-indicator>',
+        ['variant' => $variant]
+    );
+
+    expect($html)->toContain('data-testid="slot"');
+    expect($html)->not->toContain('Vererbt');
+    expect($html)->not->toContain('Überschrieben');
+});
+
+test('uses custom reset method when reset-method prop is set', function (): void {
+    $parent = Product::factory()->create();
+    $variant = Product::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $template = '<x-flux::product.inheritance-indicator'
+        . ' :product="$variant"'
+        . ' field="price:42"'
+        . ' reset-method="resetPriceListEntry"'
+        . ' :overridden="true"'
+        . '><span>slot</span></x-flux::product.inheritance-indicator>';
+
+    $html = Blade::render($template, ['variant' => $variant]);
+
+    expect($html)->toContain('resetPriceListEntry');
+    expect($html)->toContain("'price:42'");
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -292,3 +292,66 @@ test('inheritanceState returns null on variants with no overrides', function ():
 
     expect($component->instance()->inheritanceState)->toBeNull();
 });
+
+test('variant list filters to only overridden variants when toggle is on', function (): void {
+    $parent = ProductModel::factory()->create();
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $form = new FluxErp\Livewire\Forms\ProductForm(
+        Livewire::new(FluxErp\Livewire\Product\VariantList::class),
+        'product'
+    );
+    $form->fill($parent);
+
+    $component = Livewire::test(FluxErp\Livewire\Product\VariantList::class, ['product' => $form]);
+
+    $reflection = new ReflectionMethod($component->instance(), 'getBuilder');
+    $reflection->setAccessible(true);
+
+    $countAll = $reflection->invoke(
+        $component->instance(),
+        ProductModel::query()->where('parent_id', $parent->getKey())
+    )->count();
+    expect($countAll)->toBe(2);
+
+    $component->set('onlyOverrides', true);
+
+    $countOverrides = $reflection->invoke(
+        $component->instance(),
+        ProductModel::query()->where('parent_id', $parent->getKey())
+    )->count();
+    expect($countOverrides)->toBe(1);
+});
+
+test('variant list eager-loads parent so accessor lookups do not N+1', function (): void {
+    $parent = ProductModel::factory()->create();
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $form = new FluxErp\Livewire\Forms\ProductForm(
+        Livewire::new(FluxErp\Livewire\Product\VariantList::class),
+        'product'
+    );
+    $form->fill($parent);
+
+    $component = Livewire::test(FluxErp\Livewire\Product\VariantList::class, ['product' => $form]);
+
+    $reflection = new ReflectionMethod($component->instance(), 'getBuilder');
+    $reflection->setAccessible(true);
+    $builder = $reflection->invoke($component->instance(), ProductModel::query());
+
+    expect($builder->getEagerLoads())->toHaveKey('parent');
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use FluxErp\Livewire\Product\Product;
+use FluxErp\Models\Category;
+use FluxErp\Models\Product as ProductModel;
+use FluxErp\Models\Tenant;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
+    Tenant::clearDefaultCache();
+});
+
+test('resetField clears overridden_fields on the variant', function (): void {
+    $parent = ProductModel::factory()->create(['name' => 'Parent']);
+    $variant = ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+        'name' => 'override',
+    ]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->call('resetField', 'name')
+        ->assertHasNoErrors();
+
+    expect($variant->fresh()->overridden_fields)->toBeNull();
+});
+
+test('resetField on non-inheritable field surfaces a validation error', function (): void {
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create(['parent_id' => $parent->getKey()]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->call('resetField', 'product_number')
+        ->assertHasErrors(['inheritance']);
+});
+
+test('resetRelation deletes own pivot rows for the relation', function (): void {
+    $cat = Category::factory()->create([
+        'model_type' => morph_alias(ProductModel::class),
+    ]);
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create(['parent_id' => $parent->getKey()]);
+    $variant->ownCategories()->attach([$cat->getKey()]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->call('resetRelation', 'categories')
+        ->assertHasNoErrors();
+
+    expect($variant->ownCategories()->count())->toBe(0);
+});
+
+test('resetFieldOnAllVariants clears the field across every variant', function (): void {
+    $parent = ProductModel::factory()->create(['name' => 'Parent']);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name', 'description'],
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->call('resetFieldOnAllVariants', 'name')
+        ->assertHasNoErrors();
+
+    foreach (ProductModel::where('parent_id', $parent->getKey())->get() as $variant) {
+        expect($variant->overridden_fields ?? [])->not->toContain('name');
+    }
+});
+
+test('promoteToStandalone clears was_parent on a parent without active children', function (): void {
+    $parent = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => true,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => false,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->call('promoteToStandalone')
+        ->assertHasNoErrors();
+
+    expect($parent->fresh()->was_parent)->toBeFalse();
+});
+
+test('promoteToStandalone surfaces error when active children still exist', function (): void {
+    $parent = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => true,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->call('promoteToStandalone')
+        ->assertHasErrors(['inheritance']);
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -119,3 +119,75 @@ test('non-variant edit form does not render inheritance indicator chrome', funct
         ->assertDontSeeHtml('Vererbt')
         ->assertDontSeeHtml('Überschrieben');
 });
+
+test('priceLists payload marks variant_owns_price true when variant has own price', function (): void {
+    $listA = FluxErp\Models\PriceList::factory()->create(['is_default' => false]);
+    $parent = ProductModel::factory()->create();
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $parent->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '10.0000',
+    ]);
+    $variant = ProductModel::factory()->create(['parent_id' => $parent->getKey()]);
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $variant->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '15.0000',
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->call('getPriceLists');
+
+    $listEntry = collect($component->get('priceLists'))->firstWhere('id', $listA->getKey());
+
+    expect($listEntry['variant_owns_price'])->toBeTrue();
+});
+
+test('priceLists payload marks variant_owns_price false when variant inherits from parent product', function (): void {
+    $listA = FluxErp\Models\PriceList::factory()->create(['is_default' => false]);
+    $parent = ProductModel::factory()->create();
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $parent->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '10.0000',
+    ]);
+    $variant = ProductModel::factory()->create(['parent_id' => $parent->getKey()]);
+
+    $component = Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->call('getPriceLists');
+
+    $listEntry = collect($component->get('priceLists'))->firstWhere('id', $listA->getKey());
+
+    expect($listEntry['variant_owns_price'])->toBeFalse();
+});
+
+test('priceLists payload marks variant_owns_price false on non-variant products', function (): void {
+    $listA = FluxErp\Models\PriceList::factory()->create(['is_default' => false]);
+    $product = ProductModel::factory()->create();
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $product->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '10.0000',
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $product->getKey()])
+        ->call('getPriceLists');
+
+    $listEntry = collect($component->get('priceLists'))->firstWhere('id', $listA->getKey());
+
+    expect($listEntry['variant_owns_price'])->toBeFalse();
+});
+
+test('variant prices tab shows Vererbt badge for inherited price-lists', function (): void {
+    $listA = FluxErp\Models\PriceList::factory()->create(['is_default' => false, 'name' => 'Liste A']);
+    $parent = ProductModel::factory()->create();
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $parent->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '10.0000',
+    ]);
+    $variant = ProductModel::factory()->create(['parent_id' => $parent->getKey()]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->assertSeeHtml('Vererbt');
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -191,3 +191,56 @@ test('variant prices tab shows Vererbt badge for inherited price-lists', functio
     Livewire::test(Product::class, ['id' => $variant->getKey()])
         ->assertSeeHtml('Vererbt');
 });
+
+test('parent product computes inheritance counters per inheritable field', function (): void {
+    $parent = ProductModel::factory()->create();
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $parent->getKey()]);
+
+    $counters = $component->instance()->inheritanceCounters;
+
+    expect($counters['name']['inheriting'])->toBe(1);
+    expect($counters['name']['total'])->toBe(2);
+    expect($counters['description']['inheriting'])->toBe(2);
+    expect($counters['description']['total'])->toBe(2);
+});
+
+test('inheritanceCounters is empty for non-parent products', function (): void {
+    $product = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => false,
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $product->getKey()]);
+
+    expect($component->instance()->inheritanceCounters)->toBe([]);
+});
+
+test('variant bulk-reset panel renders on parent product edit view', function (): void {
+    $parent = ProductModel::factory()->create();
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name'],
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->assertSeeHtml('Auswirkung auf Varianten');
+});
+
+test('variant bulk-reset panel does not render on non-parent products', function (): void {
+    $product = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => false,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $product->getKey()])
+        ->assertDontSeeHtml('Auswirkung auf Varianten');
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -4,6 +4,7 @@ use FluxErp\Livewire\Product\Product;
 use FluxErp\Models\Category;
 use FluxErp\Models\Product as ProductModel;
 use FluxErp\Models\Tenant;
+use FluxErp\Models\VatRate;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -354,4 +355,81 @@ test('variant list eager-loads parent so accessor lookups do not N+1', function 
     $builder = $reflection->invoke($component->instance(), ProductModel::query());
 
     expect($builder->getEagerLoads())->toHaveKey('parent');
+});
+
+test('orphaned-parent banner shows on parent that lost all active variants', function (): void {
+    $parent = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => true,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => false,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->assertSeeHtml('Dieses Produkt hatte Varianten')
+        ->assertSeeHtml('Als eigenständiges Produkt aktivieren')
+        ->assertSeeHtml('Produkt deaktivieren')
+        ->assertSeeHtml('Neue Variante anlegen');
+});
+
+test('orphaned-parent banner does not show when active children exist', function (): void {
+    $parent = ProductModel::factory()->create([
+        'was_parent' => true,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => true,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->assertDontSeeHtml('Dieses Produkt hatte Varianten');
+});
+
+test('orphaned-parent banner does not show on standalone products', function (): void {
+    $product = ProductModel::factory()->create([
+        'parent_id' => null,
+        'was_parent' => false,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $product->getKey()])
+        ->assertDontSeeHtml('Dieses Produkt hatte Varianten');
+});
+
+test('isOrphanedParent computed returns true when was_parent and no active children', function (): void {
+    $parent = ProductModel::factory()->create([
+        'was_parent' => true,
+    ]);
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => false,
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $parent->getKey()]);
+
+    expect($component->instance()->isOrphanedParent)->toBeTrue();
+});
+
+test('deactivate banner action persists is_active false', function (): void {
+    $parent = ProductModel::factory()
+        ->for(VatRate::default())
+        ->create([
+            'parent_id' => null,
+            'was_parent' => true,
+            'is_active' => true,
+            'is_bundle' => false,
+        ]);
+    $parent->tenants()->attach(Tenant::default()->getKey());
+
+    ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'is_active' => false,
+    ]);
+
+    Livewire::test(Product::class, ['id' => $parent->getKey()])
+        ->call('deactivate')
+        ->assertReturned(true);
+
+    expect($parent->fresh()->is_active)->toBeFalse();
 });

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -244,3 +244,51 @@ test('variant bulk-reset panel does not render on non-parent products', function
     Livewire::test(Product::class, ['id' => $product->getKey()])
         ->assertDontSeeHtml('Auswirkung auf Varianten');
 });
+
+test('variant header shows consistency badge when there are field overrides', function (): void {
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => ['name', 'description'],
+    ]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->assertSeeHtml('2 Felder überschrieben');
+});
+
+test('variant header shows price-override count in consistency badge', function (): void {
+    $listA = FluxErp\Models\PriceList::factory()->create(['is_default' => false]);
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+    FluxErp\Models\Price::factory()->create([
+        'product_id' => $variant->getKey(),
+        'price_list_id' => $listA->getKey(),
+        'price' => '15.0000',
+    ]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->assertSeeHtml('1 Preise abweichend');
+});
+
+test('inheritanceState returns null on non-variant products', function (): void {
+    $product = ProductModel::factory()->create(['parent_id' => null]);
+
+    $component = Livewire::test(Product::class, ['id' => $product->getKey()]);
+
+    expect($component->instance()->inheritanceState)->toBeNull();
+});
+
+test('inheritanceState returns null on variants with no overrides', function (): void {
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+        'overridden_fields' => null,
+    ]);
+
+    $component = Livewire::test(Product::class, ['id' => $variant->getKey()]);
+
+    expect($component->instance()->inheritanceState)->toBeNull();
+});

--- a/tests/Livewire/Product/ProductVariantInheritanceTest.php
+++ b/tests/Livewire/Product/ProductVariantInheritanceTest.php
@@ -101,3 +101,21 @@ test('promoteToStandalone surfaces error when active children still exist', func
         ->call('promoteToStandalone')
         ->assertHasErrors(['inheritance']);
 });
+
+test('variant edit form renders inheritance indicator on inheritable fields', function (): void {
+    $parent = ProductModel::factory()->create();
+    $variant = ProductModel::factory()->create([
+        'parent_id' => $parent->getKey(),
+    ]);
+
+    Livewire::test(Product::class, ['id' => $variant->getKey()])
+        ->assertSeeHtml('Vererbt');
+});
+
+test('non-variant edit form does not render inheritance indicator chrome', function (): void {
+    $product = ProductModel::factory()->create(['parent_id' => null]);
+
+    Livewire::test(Product::class, ['id' => $product->getKey()])
+        ->assertDontSeeHtml('Vererbt')
+        ->assertDontSeeHtml('Überschrieben');
+});

--- a/tests/Unit/Helpers/PriceHelperVariantInheritanceTest.php
+++ b/tests/Unit/Helpers/PriceHelperVariantInheritanceTest.php
@@ -6,11 +6,10 @@ use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
 use FluxErp\Models\Tenant;
 use FluxErp\Models\VatRate;
-use Illuminate\Support\Facades\Cache;
 
 beforeEach(function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $this->vatRate = VatRate::default() ?? VatRate::factory()->create(['is_default' => true]);
 });
@@ -83,7 +82,7 @@ test('variant returns null when neither variant nor parent has price', function 
 
 test('variant does not inherit parent price when inheritance is disabled', function (): void {
     Tenant::default()->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $list = PriceList::factory()->create(['is_default' => false]);
     $parent = Product::factory()->create(['vat_rate_id' => $this->vatRate->getKey()]);

--- a/tests/Unit/Models/TenantInheritanceToggleTest.php
+++ b/tests/Unit/Models/TenantInheritanceToggleTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use FluxErp\Models\Tenant;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -41,7 +40,7 @@ it('evicts default-tenant cache when product_variant_inheritance_enabled is togg
     // Start from a known-false baseline so we can observe the toggle taking effect.
     $tenant = Tenant::default();
     $tenant->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     expect(Tenant::default()->product_variant_inheritance_enabled)->toBeFalse();
 
@@ -53,4 +52,19 @@ it('evicts default-tenant cache when product_variant_inheritance_enabled is togg
 
     // Tenant::default() should now reflect the change because the saving hook evicted the memo.
     expect(Tenant::default()->product_variant_inheritance_enabled)->toBeTrue();
+});
+
+test('clearDefaultCache evicts the default-tenant memo', function (): void {
+    $tenant = Tenant::default();          // memoize attributes
+
+    // Mutate the underlying row directly via DB (bypasses model events that would clear the cache).
+    DB::table('tenants')->where('id', $tenant->getKey())->update(['name' => 'NewName']);
+
+    // Without clearing, default() returns memoized (stale) attributes.
+    expect(Tenant::default()->name)->toBe($tenant->name);
+
+    Tenant::clearDefaultCache();
+
+    // After clearing, default() recomputes from DB and reflects the change.
+    expect(Tenant::default()->name)->toBe('NewName');
 });

--- a/tests/Unit/Traits/InheritsFromParentTest.php
+++ b/tests/Unit/Traits/InheritsFromParentTest.php
@@ -8,12 +8,11 @@ use FluxErp\Models\Product;
 use FluxErp\Models\ProductProperty;
 use FluxErp\Models\Tenant;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Cache;
 
 beforeEach(function (): void {
     $this->tenant = Tenant::default();
     $this->tenant->update(['product_variant_inheritance_enabled' => true]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 });
 
 it('isVariant returns true when parent_id is set', function (): void {
@@ -26,7 +25,7 @@ it('isVariant returns true when parent_id is set', function (): void {
 
 it('inheritanceEnabled returns false when tenant flag is false', function (): void {
     $this->tenant->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $product = Product::factory()->create();
 
@@ -127,7 +126,7 @@ it('non-variant ignores overridden_fields entirely (defensive)', function (): vo
 
 it('falls back to own column when feature toggle is off', function (): void {
     $this->tenant->update(['product_variant_inheritance_enabled' => false]);
-    Cache::memo()->forget('default_' . morph_alias(Tenant::class));
+    Tenant::clearDefaultCache();
 
     $parent = Product::factory()->create(['name' => 'Parent Name']);
     $variant = Product::factory()->create([


### PR DESCRIPTION
## Summary

User-facing UI for variant inheritance, building on #1702 (backend foundation).

- `Tenant::clearDefaultCache()` extracted into the `HasDefault` trait so all default-having models reuse one cache helper.
- New class-based Blade component `<x-flux::product.inheritance-indicator>` — shows "Vererbt" / "Überschrieben" badge plus reset button around any inheritable input.
- Five new Livewire methods on the `Product` component: `resetField`, `resetRelation`, `resetFieldOnAllVariants`, `resetRelationOnAllVariants`, `promoteToStandalone`, plus `deactivate`.
- Variant edit form: 15 inheritable scalar inputs in `general.blade.php` wrapped with the indicator.
- Prices tab: each price list shows whether the variant overrides or inherits, plus a per-list reset action that calls `resetRelation('prices', priceListId)`.
- Parent edit view: `<x-flux::product.variant-bulk-reset>` panel with per-field counters ("X von Y Varianten erben") and per-field bulk-reset buttons (`wire:flux-confirm.type.warning`).
- Variant header consistency badge ("X Felder überschrieben, Y Preise abweichend") on variants with at least one override.
- Variant list (`VariantList`) eager-loads `parent` and adds a "Nur Overrides anzeigen" toggle that filters via `whereJsonLength('overridden_fields', '>', 0)`.
- `<x-flux::product.inheritance-orphan-banner>` — TallStackUI `<x-alert color="amber">` with three buttons (standalone, deactivate, new variant) when `was_parent` is true and no active children exist.
- `flux:product-variants:audit` artisan command — read-only reporter listing parents still referenced in `order_positions`, `stock_postings`, `bundle_product_product`, or webshop-active. Supports `--output=csv`.

## Stacked on

#1702 — merge that first; this branch is fast-forwarded onto it. Once #1702 lands, rebase or merge `main` here and the diff narrows to UI-only.