### PR TITLE
Lower FilePond chunk threshold and gate chunked uploads on auth

### DIFF
--- a/resources/js/components/file-pond.js
+++ b/resources/js/components/file-pond.js
@@ -17,12 +17,19 @@ function loadLocale(lang) {
 
 // Files larger than this use the chunked upload endpoint to bypass
 // PHP's post_max_size / Octane FrankenPHP request body limits.
-const CHUNK_THRESHOLD = 4 * 1024 * 1024;
+// 1 MB stays well under the 2 MB upload_max_filesize default once Livewire's
+// base64 encoding inflates the payload by ~33%.
+const CHUNK_THRESHOLD = 1024 * 1024;
 const CHUNK_SIZE = 4 * 1024 * 1024;
 
 function csrfToken() {
     const meta = document.querySelector('meta[name="csrf-token"]');
     return meta ? meta.content : '';
+}
+
+function isAuthenticated() {
+    const meta = document.querySelector('meta[name="user-authenticated"]');
+    return meta?.content === 'true';
 }
 
 async function readJsonSafe(response) {
@@ -102,6 +109,7 @@ export default function (
     lang,
     modalTranslations,
     inputTranslation,
+    { chunked = true } = {},
 ) {
     return {
         tempFilesId: [],
@@ -112,6 +120,7 @@ export default function (
         fileCount: null,
         pond: null,
         multipleFileUpload: true,
+        chunkedEnabled: chunked && isAuthenticated(),
         async setCollection(collectionName, id = null) {
             if (collectionName !== null) {
                 //  on selected - check if collection is single file upload
@@ -213,7 +222,10 @@ export default function (
                         transfer,
                         options,
                     ) => {
-                        if (file.size > CHUNK_THRESHOLD) {
+                        if (
+                            this.chunkedEnabled &&
+                            file.size > CHUNK_THRESHOLD
+                        ) {
                             try {
                                 const signedPath = await chunkedUpload(
                                     file,

--- a/resources/views/components/layouts/head/head.blade.php
+++ b/resources/views/components/layouts/head/head.blade.php
@@ -7,6 +7,10 @@
 <meta name="mobile-web-app-capable" content="yes" />
 <link rel="manifest" href="{{ route('manifest') }}" />
 <meta name="csrf-token" content="{{ csrf_token() }}" />
+<meta
+    name="user-authenticated"
+    content="{{ auth()->check() ? 'true' : 'false' }}"
+/>
 <meta name="ws-key" content="{{ config('flux.vite.reverb_app_key') }}" />
 <meta
     name="ws-broadcaster"


### PR DESCRIPTION
## Summary

- Drops the chunked-upload threshold in \`file-pond.js\` from 4 MB to 1 MB so files between ~1.5 MB (Livewire's base64 inflation of the 2 MB \`upload_max_filesize\` default) and 4 MB no longer hit the regular Livewire upload path and bounce off PHP's limit.
- Skips chunked upload entirely for guests. The \`/file-pond/chunk\` route is behind \`auth:web\`, so unauthenticated users would get a 401 — they now stay on the regular Livewire upload pipeline so public forms keep working for small files.
- Adds a \`chunked\` opt-out flag to the \`filePond()\` Alpine factory. Pass \`{ chunked: false }\` as the sixth argument to force the classic upload path even for authenticated users.
- Surfaces auth state to the client via a new \`<meta name="user-authenticated">\` tag in the shared head component.

## Summary by Sourcery

Lower the file size threshold for using chunked uploads and gate the chunked upload flow based on user authentication state.

New Features:
- Expose an opt-out flag in the filePond Alpine factory to force non-chunked uploads.
- Surface user authentication state to the frontend via a new meta tag.

Enhancements:
- Reduce the chunked-upload threshold from 4 MB to 1 MB to avoid hitting PHP upload limits for mid-sized files.
- Disable chunked uploads for unauthenticated users so public forms continue using the standard Livewire upload path.