### PR TITLE
Fix passkey bridge for Capacitor 7 listener API and ResponseHelper shape

### DIFF
--- a/resources/js/nuxbe-bridge.js
+++ b/resources/js/nuxbe-bridge.js
@@ -113,34 +113,36 @@ const initializeNativeBridge = async () => {
                         if (timer) clearTimeout(timer);
                     };
 
-                    App.addListener('appUrlOpen', (event) => {
-                        if (
-                            !event?.url ||
-                            !event.url.startsWith(PASSKEY_REDIRECT_URI)
-                        ) {
-                            return;
-                        }
-
-                        cleanup();
-                        try {
-                            const u = new URL(event.url);
-                            const error = u.searchParams.get('error');
-                            if (error) {
-                                reject(new Error(error));
+                    Promise.resolve(
+                        App.addListener('appUrlOpen', (event) => {
+                            if (
+                                !event?.url ||
+                                !event.url.startsWith(PASSKEY_REDIRECT_URI)
+                            ) {
                                 return;
                             }
 
-                            const code = u.searchParams.get('code');
-                            if (!code) {
-                                reject(new Error('missing_code'));
-                                return;
-                            }
+                            cleanup();
+                            try {
+                                const u = new URL(event.url);
+                                const error = u.searchParams.get('error');
+                                if (error) {
+                                    reject(new Error(error));
+                                    return;
+                                }
 
-                            resolve(code);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }).then((h) => {
+                                const code = u.searchParams.get('code');
+                                if (!code) {
+                                    reject(new Error('missing_code'));
+                                    return;
+                                }
+
+                                resolve(code);
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }),
+                    ).then((h) => {
                         handle = h;
                     });
 

--- a/resources/views/passkey-bridge/login.blade.php
+++ b/resources/views/passkey-bridge/login.blade.php
@@ -35,6 +35,9 @@
                         throw new Error(data.statusMessage || 'finish_failed');
                     }
                     const { data: { redirect } = {} } = await r.json();
+                    if (! redirect) {
+                        throw new Error('missing_redirect');
+                    }
                     window.location.href = redirect;
                 } catch (e) {
                     this.state = 'error';

--- a/resources/views/passkey-bridge/login.blade.php
+++ b/resources/views/passkey-bridge/login.blade.php
@@ -32,9 +32,9 @@
                     });
                     if (! r.ok) {
                         const data = await r.json().catch(() => ({}));
-                        throw new Error(data.error || 'finish_failed');
+                        throw new Error(data.statusMessage || 'finish_failed');
                     }
-                    const { redirect } = await r.json();
+                    const { data: { redirect } = {} } = await r.json();
                     window.location.href = redirect;
                 } catch (e) {
                     this.state = 'error';

--- a/resources/views/passkey-bridge/register.blade.php
+++ b/resources/views/passkey-bridge/register.blade.php
@@ -39,9 +39,9 @@
                     });
                     if (! r.ok) {
                         const data = await r.json().catch(() => ({}));
-                        throw new Error(data.error || 'finish_failed');
+                        throw new Error(data.statusMessage || 'finish_failed');
                     }
-                    const { redirect } = await r.json();
+                    const { data: { redirect } = {} } = await r.json();
                     window.location.href = redirect;
                 } catch (e) {
                     this.state = 'error';

--- a/resources/views/passkey-bridge/register.blade.php
+++ b/resources/views/passkey-bridge/register.blade.php
@@ -42,6 +42,9 @@
                         throw new Error(data.statusMessage || 'finish_failed');
                     }
                     const { data: { redirect } = {} } = await r.json();
+                    if (! redirect) {
+                        throw new Error('missing_redirect');
+                    }
                     window.location.href = redirect;
                 } catch (e) {
                     this.state = 'error';


### PR DESCRIPTION
## Summary

Two bugs that broke the passkey bridge end-to-end on a real iOS device:

1. **Capacitor 7 \`addListener\` returns the handle synchronously, not a Promise.**
   \`waitForCallback\` chained \`.then()\` on the result of \`App.addListener('appUrlOpen', ...)\`, which throws \`TypeError: ... .then is not a function\` under @capacitor/app v7. The redirect URL never gets received and the passkey flow stalls. Wrapping the call in \`Promise.resolve(...)\` keeps it backwards-compatible with v3-era plugins that did return a Promise.

2. **The login/register Blade pages still expected the old top-level \`{ redirect, error }\` shape.**
   PR #1697 already moved the controller to \`ResponseHelper::ok\` / \`ResponseHelper::unprocessableEntity\`, which nests the payload under \`data\` and uses \`statusMessage\` for errors. The Blade pages were never updated, so \`redirect\` was \`undefined\` after a successful WebAuthn ceremony — \`window.location.href = undefined\` then navigated the in-app browser to \`/auth/passkey-bridge/undefined\` (a 404) and the user stayed stuck on the bridge page.

## Summary by Sourcery

Fix passkey bridge behavior for Capacitor 7 app URL callbacks and align passkey bridge views with the current API response shape.

Bug Fixes:
- Ensure the app URL listener in the native passkey bridge works with both Promise- and synchronously-returning Capacitor addListener APIs so redirects are handled correctly.
- Update passkey bridge login and registration views to read redirect and error information from the nested ResponseHelper JSON structure instead of the legacy top-level fields.