### PR TITLE
Stop leaking Alpine cleanups on every commit from validation-errors

### DIFF
--- a/resources/js/components/validation-errors.js
+++ b/resources/js/components/validation-errors.js
@@ -9,6 +9,14 @@ const ERROR_RING = [
     'dark:focus-within:ring-red-500',
 ];
 
+// Property extraction patterns for TallStackUI's form/error.blade.php span,
+// which carries `x-show="...$errors.has('prop')..."` and
+// `x-text="...$errors.first('prop')..."`. Other $errors helpers
+// (count/any/get) are intentionally not handled — we only ship the
+// has/first shape today.
+const ERROR_PROPERTY_FROM_HAS = /has\(['"]([^'"]+)['"]\)/;
+const ERROR_PROPERTY_FROM_FIRST = /first\(['"]([^'"]+)['"]\)/;
+
 function toggleRing(wrapper, add) {
     if (!wrapper) return;
 
@@ -34,6 +42,14 @@ function getWireModel(el) {
     }
 
     return null;
+}
+
+function getErrorProperty(node) {
+    return (
+        node.getAttribute('x-show')?.match(ERROR_PROPERTY_FROM_HAS)?.[1] ||
+        node.getAttribute('x-text')?.match(ERROR_PROPERTY_FROM_FIRST)?.[1] ||
+        null
+    );
 }
 
 function isVisible(el) {
@@ -129,31 +145,32 @@ function processComponent(component) {
         },
     );
 
-    // Force Alpine to re-evaluate x-show/x-text for vendor-rendered error
-    // spans inside teleported subtrees, where reactive bindings on
-    // $wire.$errors don't trigger automatically.
+    // Update vendor-rendered error spans inside teleported subtrees, where
+    // reactive bindings on $wire.$errors don't trigger automatically.
+    // We read the bound property name out of the directive and consult the
+    // commit's errors map directly instead of invoking Alpine.evaluate —
+    // every Alpine.evaluate call goes through getUtilities which pushes a
+    // cleanup onto el._x_cleanups that never runs while the element stays
+    // mounted, leaking closures on every commit. matched.add() only fires
+    // for the x-show branch to mirror the old behaviour: spans that were
+    // shown count as "matched" so the toast fallback below skips them.
     queryAllScoped(roots, '[x-show*="$errors"], [x-text*="$errors"]').forEach(
         (node) => {
-            try {
-                const xshow = node.getAttribute('x-show');
-                const xtext = node.getAttribute('x-text');
+            const prop = getErrorProperty(node);
 
-                if (xshow) {
-                    const visible = Alpine.evaluate(node, xshow);
-                    node.style.display = visible ? '' : 'none';
+            if (!prop) return;
 
-                    if (visible) {
-                        const prop = xshow.match(/has\('([^']+)'\)/)?.[1];
+            const messages = errors[prop];
+            const visible = messages?.length > 0;
 
-                        if (prop) matched.add(prop);
-                    }
-                }
+            if (node.hasAttribute('x-show')) {
+                node.style.display = visible ? '' : 'none';
 
-                if (xtext) {
-                    node.textContent = Alpine.evaluate(node, xtext) || '';
-                }
-            } catch (e) {
-                console.warn('[validation-errors]', e);
+                if (visible) matched.add(prop);
+            }
+
+            if (node.hasAttribute('x-text')) {
+                node.textContent = visible ? messages[0] : '';
             }
         },
     );


### PR DESCRIPTION
## Summary

The commit hook in `validation-errors.js` walked every form error span and called `Alpine.evaluate(node, xshow)` / `Alpine.evaluate(node, xtext)` to drive the x-show/x-text bindings inside teleported modal/slide-over subtrees. Each evaluate goes through Livewire's `getUtilities()`, which unconditionally pushes a fresh `cleanup` closure into `el._x_cleanups`. The cleanups never run while the element stays mounted, so every commit leaked several closures per visible error span. Profiling on `/tickets` showed ~1 MB heap growth per 20 `loadData()` calls and unbounded `el._x_cleanups` arrays on the long-lived datatable head / modal-form spans (424 cleanups on a single span in one session).

This change reads the bound property name out of the directive text (`has('prop')` / `first('prop')`) and consults the commit's errors map directly, so no Alpine evaluation runs. Also:

- regex literals moved to module-level constants
- new `getErrorProperty(node)` helper to mirror the `getWireModel(input)` / `Alpine.$data(select)?.property` shape used by the loops above
- `messages?.length` instead of `Array.isArray(...) && length > 0`

After the fix: cleanup count stays flat over 200 `loadData()` calls (was hundreds per 100 calls), heap per `loadData` dropped from ~330 KB to ~180 KB on `/tickets`.

## Summary by Sourcery

Prevent memory leaks and excessive Alpine cleanup registrations when updating validation error spans in teleported subtrees by avoiding Alpine-driven re-evaluation of error bindings.

Bug Fixes:
- Eliminate accumulation of unused Alpine cleanup handlers on error spans during repeated Livewire commits by replacing Alpine.evaluate-based updates with direct error map lookups.

Enhancements:
- Add helpers and regex patterns to extract error property names from x-show/x-text directives and drive visibility/text directly from the current errors payload.