### PR TITLE
fix: escape slug in MediaFolder descendant slug update

### DIFF
--- a/src/Models/MediaFolder.php
+++ b/src/Models/MediaFolder.php
@@ -57,11 +57,11 @@ class MediaFolder extends FluxModel implements HasMedia
         static::saved(function (MediaFolder $model): void {
             if ($model->wasChanged(['parent_id', 'slug'])) {
                 $original = $model->getRawOriginal('slug');
-                $replace = $model->slug;
+                $quotedSlug = $model->getConnection()->getPdo()->quote($model->slug);
                 $model->getAllDescendantsQuery()
                     ->update([
-                        'slug' => DB::raw('CONCAT(\'' . $replace
-                            . '\', SUBSTRING(slug, ' . strlen($original) + 1 . '))'
+                        'slug' => DB::raw('CONCAT(' . $quotedSlug
+                            . ', SUBSTRING(slug, ' . (strlen($original) + 1) . '))'
                         ),
                     ]);
             }

--- a/src/Models/MediaFolder.php
+++ b/src/Models/MediaFolder.php
@@ -58,6 +58,11 @@ class MediaFolder extends FluxModel implements HasMedia
             if ($model->wasChanged(['parent_id', 'slug'])) {
                 $original = $model->getRawOriginal('slug');
                 $quotedSlug = $model->getConnection()->getPdo()->quote($model->slug);
+
+                if ($quotedSlug === false) {
+                    $quotedSlug = "'" . addslashes($model->slug) . "'";
+                }
+
                 $model->getAllDescendantsQuery()
                     ->update([
                         'slug' => DB::raw('CONCAT(' . $quotedSlug

--- a/src/Models/MediaFolder.php
+++ b/src/Models/MediaFolder.php
@@ -60,7 +60,7 @@ class MediaFolder extends FluxModel implements HasMedia
                 $quotedSlug = $model->getConnection()->getPdo()->quote($model->slug);
 
                 if ($quotedSlug === false) {
-                    $quotedSlug = "'" . addslashes($model->slug) . "'";
+                    $quotedSlug = '\'' . addslashes($model->slug) . '\'';
                 }
 
                 $model->getAllDescendantsQuery()

--- a/tests/Feature/Actions/MediaFolder/MediaFolderActionTest.php
+++ b/tests/Feature/Actions/MediaFolder/MediaFolderActionTest.php
@@ -43,3 +43,28 @@ test('delete media folder', function (): void {
     expect(DeleteMediaFolder::make(['id' => $folder->getKey()])
         ->validate()->execute())->toBeTrue();
 });
+
+test('renaming media folder with apostrophe in name does not break descendant slug update', function (): void {
+    $contact = FluxErp\Models\Contact::factory()->create();
+
+    $parent = CreateMediaFolder::make([
+        'name' => "Zusatzinfo's",
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => $contact->getKey(),
+    ])->validate()->execute();
+
+    $child = CreateMediaFolder::make([
+        'parent_id' => $parent->getKey(),
+        'name' => 'Sub',
+        'model_type' => morph_alias(FluxErp\Models\Contact::class),
+        'model_id' => $contact->getKey(),
+    ])->validate()->execute();
+
+    UpdateMediaFolder::make([
+        'id' => $parent->getKey(),
+        'name' => "Zusatzinfo's renamed",
+    ])->validate()->execute();
+
+    expect($child->fresh()->slug)
+        ->toBe("zusatzinfo's_renamed|{$parent->getKey()}.sub|{$child->getKey()}");
+});


### PR DESCRIPTION
## Summary
The `saved` hook on `MediaFolder` rebuilds descendant slugs via a raw `UPDATE … SET slug = CONCAT('<slug>', SUBSTRING(slug, X))`. The slug was concatenated into the SQL string without escaping, so any folder whose name contained a single quote (e.g. real-world data like `Zusatzinfo's`) produced a 1064 syntax error and the rename/move silently failed for the whole descendant tree.

Now the new slug is passed through the model's connection PDO `quote()` so it is properly escaped. Also wraps `strlen($original) + 1` in parentheses to make operator precedence explicit (the previous expression worked by coincidence).

## Regression test
Renaming `Zusatzinfo's` to `Zusatzinfo's renamed` while it has a descendant must keep the descendant slug consistent and must not throw. Pinned with `toBe()` so future changes to the slug strategy stay deterministic.

## Summary by Sourcery

Escape media folder slugs when updating descendant records to prevent SQL errors with apostrophes and add a regression test for renaming folders containing apostrophes.

Bug Fixes:
- Fix descendant slug update for media folders whose names contain apostrophes by quoting the new slug in the raw SQL update.

Tests:
- Add a regression test ensuring renaming a media folder with an apostrophe keeps descendant slugs consistent and does not throw.