### PR TITLE
Drop bare x-transition from editor toolbar to fix alpine effect heap leak

### DIFF
--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -50,7 +50,6 @@
     >
         <div
             x-cloak
-            x-transition
             x-show="proxy && proxy.isEditable"
             x-ref="controlPanel-{{ $id }}"
             id="controlPanel"


### PR DESCRIPTION
## Summary

- Removes `x-transition` (bare, no modifiers) from the editor toolbar control panel
- The control panel is shown once when the editor initializes and stays visible — the transition fires extremely rarely in normal use, but accumulates Alpine reactive effect cleanups every time the surrounding `x-show` is re-evaluated
- This was a major heap leak when the editor is inside a modal that gets opened/closed repeatedly (e.g. mail compose flow on the orders list)

## Heap profile evidence (isolated modal open/close × 3, identical environment)

| Before fix | After fix |
|---|---|
| +25,796 `cleanup2` closures | +18 `cleanup2` closures |
| +34.1 MB heap | +0.1 MB heap |

The control panel toolbar appears once on editor init and remains visible until the editor is destroyed — no functional regression from removing the transition.

## Summary by Sourcery

Bug Fixes:
- Fix an Alpine.js reactive effect heap leak caused by a bare x-transition on the editor toolbar control panel that re-triggered on repeated modal open/close cycles.