### PR TITLE
refactor(tallstackui-select): delegate setOptions to $tsui.select when available

### DIFF
--- a/resources/js/components/tallstackui/select.js
+++ b/resources/js/components/tallstackui/select.js
@@ -41,6 +41,12 @@ class TallstackUISelect {
     }
 
     setOptions(params) {
+        if (window.$tsui?.select) {
+            window.$tsui.select(this.id).setOptions(params);
+
+            return;
+        }
+
         const encoded = btoa(JSON.stringify(params));
 
         this.alpineComponent.$refs.options.innerText = `JSON.parse(atob('${encoded}'))`;


### PR DESCRIPTION
## Summary

Forward-compat for the new `$tsui.select(name).setOptions(array)` API proposed at https://github.com/tallstackui/tallstackui/pull/1290.

When `window.$tsui.select` is available (TallStackUI version that includes the upstream fix), our `$tallstackuiSelect(id).setOptions(...)` helper delegates to it. The upstream API:

- Writes the inner template element using the same `JSON.parse(atob('...'))` envelope as before.
- Does **not** call `sync()` manually — the patched select component now picks up `innerText = ...` changes automatically via a `MutationObserver` with `childList: true`.
- Is the recommended way to populate options programmatically going forward.

When the user is on an older TallStackUI version (no `$tsui.select`), the original code path is used as a fallback. No behavior change for existing installs.

## Why this matters

The original setOptions path triggers an infinite loop in TallStackUI's `Form/Select/Styled` `sync()` method that allocates tens of thousands of Alpine reactive effect cleanup closures per modal interaction. In the order-list → bulk mail send flow this causes JS heap growth of 100+ MB per send. Details and heap-profile evidence are in the upstream PR.

This PR alone does not fix the leak — it routes through the new upstream API once available, so once the TallStackUI fix lands and is bumped we will be on the leak-free path without further code changes here.

## Summary by Sourcery

Enhancements:
- Add conditional delegation from the local `TallstackUISelect.setOptions` helper to `window.$tsui.select(id).setOptions` for forward compatibility with newer TallStackUI releases while preserving existing behavior as a fallback.