### PR TITLE
refactor(dunning): defer order level bump until reminder is actually sent

### DIFF
--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -1,0 +1,88 @@
+@use(Illuminate\Support\Number)
+
+<div>
+    <x-card :header="__('Payment Reminder Run')">
+        <x-slot:action>
+            <x-button
+                :text="__('Send all')"
+                color="primary"
+                icon="paper-airplane"
+                x-on:click="$wire.sendAll()"
+                x-bind:disabled="$wire.isEmpty"
+            />
+            <x-button
+                :text="__('Send selected')"
+                color="indigo"
+                icon="paper-airplane"
+                x-on:click="$wire.sendSelected()"
+                x-bind:disabled="!($wire.selected || []).length"
+            />
+        </x-slot:action>
+
+        @if ($this->isEmpty)
+            <div class="py-12 text-center text-sm text-secondary-500">
+                {{ __('No payment reminders are due today.') }}
+            </div>
+        @else
+            <div class="flex flex-col gap-3">
+                @foreach ($groups as $group)
+                    <x-card>
+                        <div class="flex items-start justify-between gap-3">
+                            <label
+                                class="flex flex-1 cursor-pointer items-start gap-3"
+                            >
+                                <input
+                                    type="checkbox"
+                                    wire:model.live="selected"
+                                    value="{{ $group['key'] }}"
+                                    class="mt-1"
+                                />
+                                <div class="flex flex-col gap-1">
+                                    <div class="font-medium">
+                                        {{ $group['contact_name'] ?? __('Unknown') }}
+                                    </div>
+                                    <div class="text-sm text-secondary-500">
+                                        {{ __('Reminder Level') }}:
+                                        {{ $group['next_level'] }}
+                                        &middot;
+                                        {{ $group['order_count'] }}
+                                        {{ __('invoice(s)') }}
+                                        &middot;
+                                        {{ $group['recipient_email'] ?? __('No email') }}
+                                    </div>
+                                </div>
+                            </label>
+                            <div class="flex items-center gap-2">
+                                <div class="text-right text-sm font-medium">
+                                    {{ Number::currency((float) $group['total_balance'], locale: app()->getLocale()) }}
+                                </div>
+                                <x-button
+                                    :text="__('Send')"
+                                    color="primary"
+                                    icon="paper-airplane"
+                                    size="sm"
+                                    wire:click="sendGroup('{{ $group['key'] }}')"
+                                />
+                            </div>
+                        </div>
+                        <div class="mt-3 flex flex-col gap-1 text-sm">
+                            @foreach ($group['orders'] as $order)
+                                <div
+                                    class="flex justify-between border-t border-secondary-100 py-1 dark:border-secondary-700"
+                                >
+                                    <span>{{ $order['invoice_number'] }}</span>
+                                    <span class="text-secondary-500">
+                                        {{ __('Due') }}: {{ $order['next_date'] }}
+                                    </span>
+                                    <span class="font-medium">
+                                        {{ Number::currency((float) $order['balance'], locale: app()->getLocale()) }}
+                                    </span>
+                                </div>
+                            @endforeach
+                        </div>
+                    </x-card>
+                @endforeach
+            </div>
+        @endif
+    </x-card>
+</div>

--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -31,11 +31,9 @@
                             <label
                                 class="flex flex-1 cursor-pointer items-start gap-3"
                             >
-                                <input
-                                    type="checkbox"
+                                <x-checkbox
                                     wire:model.live="selected"
                                     value="{{ $group['key'] }}"
-                                    class="mt-1"
                                 />
                                 <div class="flex flex-col gap-1">
                                     <div class="font-medium">

--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -19,13 +19,13 @@
             />
         </x-slot:action>
 
-        @if ($this->isEmpty)
-            <div class="py-12 text-center text-sm text-secondary-500">
+        @if($this->isEmpty)
+            <div class="text-secondary-500 py-12 text-center text-sm">
                 {{ __('No payment reminders are due today.') }}
             </div>
         @else
             <div class="flex flex-col gap-3">
-                @foreach ($groups as $group)
+                @foreach($groups as $group)
                     <x-card>
                         <div class="flex items-start justify-between gap-3">
                             <label
@@ -39,14 +39,8 @@
                                     <div class="font-medium">
                                         {{ $group['contact_name'] ?? __('Unknown') }}
                                     </div>
-                                    <div class="text-sm text-secondary-500">
-                                        {{ __('Reminder Level') }}:
-                                        {{ $group['next_level'] }}
-                                        &middot;
-                                        {{ $group['order_count'] }}
-                                        {{ __('invoice(s)') }}
-                                        &middot;
-                                        {{ $group['recipient_email'] ?? __('No email') }}
+                                    <div class="text-secondary-500 text-sm">
+                                        {{ __('Reminder Level') }}: {{ $group['next_level'] }} &middot; {{ $group['order_count'] }} {{ __('invoice(s)') }} &middot; {{ $group['recipient_email'] ?? __('No email') }}
                                     </div>
                                 </div>
                             </label>
@@ -64,9 +58,9 @@
                             </div>
                         </div>
                         <div class="mt-3 flex flex-col gap-1 text-sm">
-                            @foreach ($group['orders'] as $order)
+                            @foreach($group['orders'] as $order)
                                 <div
-                                    class="flex justify-between border-t border-secondary-100 py-1 dark:border-secondary-700"
+                                    class="border-secondary-100 dark:border-secondary-700 flex justify-between border-t py-1"
                                 >
                                     <span>{{ $order['invoice_number'] }}</span>
                                     <span class="text-secondary-500">

--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -19,13 +19,13 @@
             />
         </x-slot:action>
 
-        @if($this->isEmpty)
+        @if ($this->isEmpty)
             <div class="text-secondary-500 py-12 text-center text-sm">
                 {{ __('No payment reminders are due today.') }}
             </div>
         @else
             <div class="flex flex-col gap-3">
-                @foreach($groups as $group)
+                @foreach ($groups as $group)
                     <x-card>
                         <div class="flex items-start justify-between gap-3">
                             <label
@@ -58,7 +58,7 @@
                             </div>
                         </div>
                         <div class="mt-3 flex flex-col gap-1 text-sm">
-                            @foreach($group['orders'] as $order)
+                            @foreach ($group['orders'] as $order)
                                 <div
                                     class="border-secondary-100 dark:border-secondary-700 flex justify-between border-t py-1"
                                 >

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -12,6 +12,7 @@ use FluxErp\Livewire\AbsenceRequest\AbsenceRequest;
 use FluxErp\Livewire\Accounting\DirectDebit;
 use FluxErp\Livewire\Accounting\MoneyTransfer;
 use FluxErp\Livewire\Accounting\PaymentReminder;
+use FluxErp\Livewire\Accounting\PaymentReminderRun;
 use FluxErp\Livewire\Accounting\PaymentRunPreview;
 use FluxErp\Livewire\Accounting\TransactionAssignments;
 use FluxErp\Livewire\Accounting\TransactionList;
@@ -265,6 +266,7 @@ Route::middleware('web')
                     ->group(function (): void {
                         Route::get('/commissions', CommissionList::class)->name('commissions');
                         Route::get('/payment-reminders', PaymentReminder::class)->name('payment-reminders');
+                        Route::get('/payment-reminder-run', PaymentReminderRun::class)->name('payment-reminder-run');
                         Route::get('/purchase-invoices', PurchaseInvoiceList::class)->name('purchase-invoices');
                         Route::get('/transactions', TransactionList::class)->name('transactions');
                         Route::get('/transaction-assignments', TransactionAssignments::class)

--- a/src/Actions/PaymentReminder/BundlePaymentReminders.php
+++ b/src/Actions/PaymentReminder/BundlePaymentReminders.php
@@ -4,7 +4,6 @@ namespace FluxErp\Actions\PaymentReminder;
 
 use FluxErp\Actions\FluxAction;
 use FluxErp\Actions\MailMessage\SendMail;
-use FluxErp\Actions\Printing;
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentReminder;
 use FluxErp\Rulesets\PaymentReminder\BundlePaymentRemindersRuleset;
@@ -31,7 +30,7 @@ class BundlePaymentReminders extends FluxAction
             ->wherePaymentReminderEligible()
             ->get()
             ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
-                && $order->orderType->order_type_enum->multiplier() === 1
+                && bccomp($order->orderType->order_type_enum->multiplier(), '1') === 0
             );
 
         $groups = $orders->groupBy(
@@ -88,26 +87,11 @@ class BundlePaymentReminders extends FluxAction
         }
 
         foreach ($reminders as $reminder) {
-            $pdf = Printing::make([
+            $attachments[] = [
                 'model_type' => $reminder->getMorphClass(),
                 'model_id' => $reminder->getKey(),
                 'view' => 'payment-reminder',
-                'html' => false,
-                'preview' => false,
                 'attach_relation' => 'order',
-            ])
-                ->validate()
-                ->execute();
-
-            if (! $pdf) {
-                $this->abortGroup($reminders, $orders, 'PDF generation failed');
-
-                return null;
-            }
-
-            $attachments[] = [
-                'id' => $pdf->getKey(),
-                'name' => $pdf->file_name,
             ];
 
             if ($invoicePdf = $reminder->order->invoice()) {
@@ -184,7 +168,9 @@ class BundlePaymentReminders extends FluxAction
         ?string $reason,
         ?array $to = null,
     ): void {
-        $reminders->each(fn (PaymentReminder $reminder) => $reminder->forceDelete());
+        PaymentReminder::withoutEvents(function () use ($reminders): void {
+            $reminders->each(fn (PaymentReminder $reminder) => $reminder->forceDelete());
+        });
 
         $orders->each(function (Order $order) use ($reason, $to): void {
             activity()

--- a/src/Actions/PaymentReminder/BundlePaymentReminders.php
+++ b/src/Actions/PaymentReminder/BundlePaymentReminders.php
@@ -64,21 +64,27 @@ class BundlePaymentReminders extends FluxAction
 
         try {
             foreach ($orders as $order) {
-                $reminder = app(PaymentReminder::class, [
-                    'attributes' => ['order_id' => $order->getKey()],
-                ]);
-                $reminder->save();
+                $reminder = CreatePaymentReminder::make([
+                    'order_id' => $order->getKey(),
+                    'mark_as_sent' => false,
+                ])
+                    ->validate()
+                    ->execute();
                 $reminders->push($reminder);
             }
         } catch (Throwable $e) {
-            return $this->abortGroup($reminders, $orders, $e->getMessage());
+            $this->abortGroup($reminders, $orders, $e->getMessage());
+
+            return null;
         }
 
-        $attachments = collect();
+        $attachments = [];
         $reminderText = $reminders->first()?->getPaymentReminderText();
 
         if (! $reminderText?->emailTemplate) {
-            return $this->abortGroup($reminders, $orders, 'Missing payment reminder template');
+            $this->abortGroup($reminders, $orders, 'Missing payment reminder template');
+
+            return null;
         }
 
         foreach ($reminders as $reminder) {
@@ -94,19 +100,21 @@ class BundlePaymentReminders extends FluxAction
                 ->execute();
 
             if (! $pdf) {
-                return $this->abortGroup($reminders, $orders, 'PDF generation failed');
+                $this->abortGroup($reminders, $orders, 'PDF generation failed');
+
+                return null;
             }
 
-            $attachments->push([
+            $attachments[] = [
                 'id' => $pdf->getKey(),
                 'name' => $pdf->file_name,
-            ]);
+            ];
 
             if ($invoicePdf = $reminder->order->invoice()) {
-                $attachments->push([
+                $attachments[] = [
                     'id' => $invoicePdf->getKey(),
                     'name' => $invoicePdf->file_name,
-                ]);
+                ];
             }
         }
 
@@ -123,14 +131,16 @@ class BundlePaymentReminders extends FluxAction
         $cc = array_values(array_unique(array_filter($cc)));
 
         if (! $to) {
-            return $this->abortGroup($reminders, $orders, 'No recipient address');
+            $this->abortGroup($reminders, $orders, 'No recipient address');
+
+            return null;
         }
 
         $result = SendMail::make([
             'template_id' => $reminderText->email_template_id,
             'to' => $to,
             'cc' => $cc ?: null,
-            'attachments' => $attachments->all(),
+            'attachments' => $attachments,
             'blade_parameters' => [
                 'order' => $firstOrder,
                 'contact' => $firstOrder->contact,
@@ -138,21 +148,25 @@ class BundlePaymentReminders extends FluxAction
                 'paymentReminders' => $reminders,
                 'orders' => $orders,
             ],
-            'communicatables' => $orders->map(fn (Order $order) => [
-                'model_type' => $order->getMorphClass(),
-                'model_id' => $order->getKey(),
-            ])->all(),
+            'communicatables' => $orders
+                ->map(fn (Order $order) => [
+                    'model_type' => $order->getMorphClass(),
+                    'model_id' => $order->getKey(),
+                ])
+                ->all(),
         ])
             ->validate()
             ->execute();
 
         if (! data_get($result, 'success', false)) {
-            return $this->abortGroup(
+            $this->abortGroup(
                 $reminders,
                 $orders,
                 data_get($result, 'error') ?? data_get($result, 'message'),
                 $to,
             );
+
+            return null;
         }
 
         $reminders->each(function (PaymentReminder $reminder): void {
@@ -169,7 +183,7 @@ class BundlePaymentReminders extends FluxAction
         Collection $orders,
         ?string $reason,
         ?array $to = null,
-    ): ?Collection {
+    ): void {
         $reminders->each(fn (PaymentReminder $reminder) => $reminder->forceDelete());
 
         $orders->each(function (Order $order) use ($reason, $to): void {
@@ -183,7 +197,5 @@ class BundlePaymentReminders extends FluxAction
                 ]))
                 ->log('Payment reminder send failed');
         });
-
-        return null;
     }
 }

--- a/src/Actions/PaymentReminder/BundlePaymentReminders.php
+++ b/src/Actions/PaymentReminder/BundlePaymentReminders.php
@@ -28,10 +28,7 @@ class BundlePaymentReminders extends FluxAction
         $orders = resolve_static(Order::class, 'query')
             ->whereIntegerInRaw('id', $this->getData('order_ids'))
             ->with(['contact', 'orderType:id,order_type_enum'])
-            ->whereNotNull('invoice_number')
-            ->where('is_locked', true)
-            ->where('balance', '!=', 0)
-            ->whereHasMailablePaymentReminderAddress()
+            ->wherePaymentReminderEligible()
             ->get()
             ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
                 && $order->orderType->order_type_enum->multiplier() === 1

--- a/src/Actions/PaymentReminder/BundlePaymentReminders.php
+++ b/src/Actions/PaymentReminder/BundlePaymentReminders.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace FluxErp\Actions\PaymentReminder;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Actions\MailMessage\SendMail;
+use FluxErp\Actions\Printing;
+use FluxErp\Models\Order;
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Rulesets\PaymentReminder\BundlePaymentRemindersRuleset;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class BundlePaymentReminders extends FluxAction
+{
+    public static function models(): array
+    {
+        return [PaymentReminder::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return BundlePaymentRemindersRuleset::class;
+    }
+
+    public function performAction(): array
+    {
+        $orders = resolve_static(Order::class, 'query')
+            ->whereIntegerInRaw('id', $this->getData('order_ids'))
+            ->with(['contact', 'orderType:id,order_type_enum'])
+            ->whereNotNull('invoice_number')
+            ->where('is_locked', true)
+            ->where('balance', '!=', 0)
+            ->whereHasMailablePaymentReminderAddress()
+            ->get()
+            ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
+                && $order->orderType->order_type_enum->multiplier() === 1
+            );
+
+        $groups = $orders->groupBy(
+            fn (Order $order) => $order->contact_id . '-' . ((int) $order->payment_reminder_current_level + 1)
+        );
+
+        $results = [
+            'sent_groups' => 0,
+            'failed_groups' => 0,
+            'sent_reminders' => collect(),
+        ];
+
+        foreach ($groups as $group) {
+            $sent = $this->sendGroup($group);
+
+            if ($sent) {
+                $results['sent_groups']++;
+                $results['sent_reminders'] = $results['sent_reminders']->merge($sent);
+            } else {
+                $results['failed_groups']++;
+            }
+        }
+
+        return $results;
+    }
+
+    protected function sendGroup(Collection $orders): ?Collection
+    {
+        $reminders = collect();
+
+        try {
+            foreach ($orders as $order) {
+                $reminder = app(PaymentReminder::class, [
+                    'attributes' => ['order_id' => $order->getKey()],
+                ]);
+                $reminder->save();
+                $reminders->push($reminder);
+            }
+        } catch (Throwable $e) {
+            return $this->abortGroup($reminders, $orders, $e->getMessage());
+        }
+
+        $attachments = collect();
+        $reminderText = $reminders->first()?->getPaymentReminderText();
+
+        if (! $reminderText?->emailTemplate) {
+            return $this->abortGroup($reminders, $orders, 'Missing payment reminder template');
+        }
+
+        foreach ($reminders as $reminder) {
+            $pdf = Printing::make([
+                'model_type' => $reminder->getMorphClass(),
+                'model_id' => $reminder->getKey(),
+                'view' => 'payment-reminder',
+                'html' => false,
+                'preview' => false,
+                'attach_relation' => 'order',
+            ])
+                ->validate()
+                ->execute();
+
+            if (! $pdf) {
+                return $this->abortGroup($reminders, $orders, 'PDF generation failed');
+            }
+
+            $attachments->push([
+                'id' => $pdf->getKey(),
+                'name' => $pdf->file_name,
+            ]);
+
+            if ($invoicePdf = $reminder->order->invoice()) {
+                $attachments->push([
+                    'id' => $invoicePdf->getKey(),
+                    'name' => $invoicePdf->file_name,
+                ]);
+            }
+        }
+
+        $firstOrder = $orders->first();
+        $address = $firstOrder->resolveMailablePaymentReminderAddress();
+
+        $to = $reminderText->mail_to ?? [];
+        if ($email = $address?->email_primary) {
+            $to[] = $email;
+        }
+
+        $cc = $reminderText->mail_cc ?? [];
+        $to = array_values(array_unique(array_filter($to)));
+        $cc = array_values(array_unique(array_filter($cc)));
+
+        if (! $to) {
+            return $this->abortGroup($reminders, $orders, 'No recipient address');
+        }
+
+        $result = SendMail::make([
+            'template_id' => $reminderText->email_template_id,
+            'to' => $to,
+            'cc' => $cc ?: null,
+            'attachments' => $attachments->all(),
+            'blade_parameters' => [
+                'order' => $firstOrder,
+                'contact' => $firstOrder->contact,
+                'paymentReminder' => $reminders->first(),
+                'paymentReminders' => $reminders,
+                'orders' => $orders,
+            ],
+            'communicatables' => $orders->map(fn (Order $order) => [
+                'model_type' => $order->getMorphClass(),
+                'model_id' => $order->getKey(),
+            ])->all(),
+        ])
+            ->validate()
+            ->execute();
+
+        if (! data_get($result, 'success', false)) {
+            return $this->abortGroup(
+                $reminders,
+                $orders,
+                data_get($result, 'error') ?? data_get($result, 'message'),
+                $to,
+            );
+        }
+
+        $reminders->each(function (PaymentReminder $reminder): void {
+            MarkPaymentReminderSent::make(['id' => $reminder->getKey()])
+                ->validate()
+                ->execute();
+        });
+
+        return $reminders;
+    }
+
+    protected function abortGroup(
+        Collection $reminders,
+        Collection $orders,
+        ?string $reason,
+        ?array $to = null,
+    ): ?Collection {
+        $reminders->each(fn (PaymentReminder $reminder) => $reminder->forceDelete());
+
+        $orders->each(function (Order $order) use ($reason, $to): void {
+            activity()
+                ->event('payment_reminder_send_failed')
+                ->byAnonymous()
+                ->performedOn($order)
+                ->withProperties(array_filter([
+                    'error' => $reason,
+                    'to' => $to,
+                ]))
+                ->log('Payment reminder send failed');
+        });
+
+        return null;
+    }
+}

--- a/src/Actions/PaymentReminder/CreatePaymentReminder.php
+++ b/src/Actions/PaymentReminder/CreatePaymentReminder.php
@@ -7,6 +7,7 @@ use FluxErp\Models\Media;
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentReminder;
 use FluxErp\Rulesets\PaymentReminder\CreatePaymentReminderRuleset;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
 class CreatePaymentReminder extends FluxAction
@@ -23,11 +24,9 @@ class CreatePaymentReminder extends FluxAction
 
     public function performAction(): PaymentReminder
     {
-        $markAsSent = $this->getData('mark_as_sent') ?? true;
+        $markAsSent = Arr::pull($this->data, 'mark_as_sent') ?? true;
 
-        $paymentReminder = app(PaymentReminder::class, [
-            'attributes' => array_diff_key($this->data, ['mark_as_sent' => null]),
-        ]);
+        $paymentReminder = app(PaymentReminder::class, ['attributes' => $this->data]);
         $paymentReminder->save();
 
         if ($markAsSent) {

--- a/src/Actions/PaymentReminder/CreatePaymentReminder.php
+++ b/src/Actions/PaymentReminder/CreatePaymentReminder.php
@@ -26,6 +26,10 @@ class CreatePaymentReminder extends FluxAction
         $paymentReminder = app(PaymentReminder::class, ['attributes' => $this->data]);
         $paymentReminder->save();
 
+        MarkPaymentReminderSent::make(['id' => $paymentReminder->getKey()])
+            ->validate()
+            ->execute();
+
         return $paymentReminder->fresh();
     }
 

--- a/src/Actions/PaymentReminder/CreatePaymentReminder.php
+++ b/src/Actions/PaymentReminder/CreatePaymentReminder.php
@@ -23,12 +23,18 @@ class CreatePaymentReminder extends FluxAction
 
     public function performAction(): PaymentReminder
     {
-        $paymentReminder = app(PaymentReminder::class, ['attributes' => $this->data]);
+        $markAsSent = $this->getData('mark_as_sent') ?? true;
+
+        $paymentReminder = app(PaymentReminder::class, [
+            'attributes' => array_diff_key($this->data, ['mark_as_sent' => null]),
+        ]);
         $paymentReminder->save();
 
-        MarkPaymentReminderSent::make(['id' => $paymentReminder->getKey()])
-            ->validate()
-            ->execute();
+        if ($markAsSent) {
+            MarkPaymentReminderSent::make(['id' => $paymentReminder->getKey()])
+                ->validate()
+                ->execute();
+        }
 
         return $paymentReminder->fresh();
     }

--- a/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
+++ b/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
@@ -24,7 +24,7 @@ class MarkPaymentReminderSent extends FluxAction
         $paymentReminder = resolve_static(PaymentReminder::class, 'query')
             ->whereKey($this->getData('id'))
             ->with('order')
-            ->first();
+            ->firstOrFail();
 
         $order = $paymentReminder->order;
         $nextDateDays = $order->{'payment_reminder_days_' . ($paymentReminder->reminder_level + 1)}

--- a/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
+++ b/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
@@ -23,7 +23,7 @@ class MarkPaymentReminderSent extends FluxAction
     {
         $paymentReminder = resolve_static(PaymentReminder::class, 'query')
             ->whereKey($this->getData('id'))
-            ->with('order')
+            ->with('order:id,payment_reminder_days_1,payment_reminder_days_2,payment_reminder_days_3')
             ->firstOrFail();
 
         $order = $paymentReminder->order;

--- a/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
+++ b/src/Actions/PaymentReminder/MarkPaymentReminderSent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace FluxErp\Actions\PaymentReminder;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Actions\Order\UpdateLockedOrder;
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Rulesets\PaymentReminder\MarkPaymentReminderSentRuleset;
+
+class MarkPaymentReminderSent extends FluxAction
+{
+    public static function models(): array
+    {
+        return [PaymentReminder::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return MarkPaymentReminderSentRuleset::class;
+    }
+
+    public function performAction(): PaymentReminder
+    {
+        $paymentReminder = resolve_static(PaymentReminder::class, 'query')
+            ->whereKey($this->getData('id'))
+            ->with('order')
+            ->first();
+
+        $order = $paymentReminder->order;
+        $nextDateDays = $order->{'payment_reminder_days_' . ($paymentReminder->reminder_level + 1)}
+            ?? $order->payment_reminder_days_3
+            ?? 0;
+
+        UpdateLockedOrder::make([
+            'id' => $order->getKey(),
+            'payment_reminder_current_level' => $paymentReminder->reminder_level,
+            'payment_reminder_next_date' => $paymentReminder->created_at
+                ->addDays($nextDateDays)
+                ->toDateString(),
+        ])
+            ->validate()
+            ->execute();
+
+        return $paymentReminder->fresh();
+    }
+}

--- a/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
+++ b/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
@@ -3,13 +3,10 @@
 namespace FluxErp\Jobs\Accounting;
 
 use Cron\CronExpression;
-use FluxErp\Actions\MailMessage\SendMail;
-use FluxErp\Actions\PaymentReminder\CreatePaymentReminder;
-use FluxErp\Actions\Printing;
+use FluxErp\Actions\PaymentReminder\BundlePaymentReminders;
 use FluxErp\Console\Scheduling\Repeatable;
 use FluxErp\Enums\RepeatableTypeEnum;
 use FluxErp\Models\Order;
-use FluxErp\Models\PaymentReminder;
 use FluxErp\Settings\AccountingSettings;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -18,7 +15,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Str;
-use Throwable;
 
 class AutoSendPaymentRemindersJob implements Repeatable, ShouldQueue
 {
@@ -74,7 +70,7 @@ class AutoSendPaymentRemindersJob implements Repeatable, ShouldQueue
             return;
         }
 
-        resolve_static(Order::class, 'query')
+        $orderIds = resolve_static(Order::class, 'query')
             ->when($this->orderIds, fn (Builder $query) => $query->whereKey($this->orderIds))
             ->with(['orderType:id,order_type_enum'])
             ->whereNotNull('invoice_number')
@@ -82,132 +78,19 @@ class AutoSendPaymentRemindersJob implements Repeatable, ShouldQueue
             ->where('balance', '!=', 0)
             ->whereDate('payment_reminder_next_date', '<=', now()->toDateString())
             ->whereHasMailablePaymentReminderAddress()
-            ->cursor()
-            ->each(function (Order $order): void {
-                if ($order->orderType->order_type_enum->isPurchase()
-                    || $order->orderType->order_type_enum->multiplier() != 1
-                ) {
-                    return;
-                }
+            ->get(['id', 'order_type_id'])
+            ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
+                && $order->orderType->order_type_enum->multiplier() === 1
+            )
+            ->pluck('id')
+            ->all();
 
-                $this->processOrder($order);
-            });
-    }
-
-    protected function processOrder(Order $order): void
-    {
-        try {
-            $paymentReminder = CreatePaymentReminder::make([
-                'order_id' => $order->getKey(),
-            ])
-                ->validate()
-                ->execute();
-
-            $this->sendPaymentReminderEmail($paymentReminder);
-        } catch (Throwable $e) {
-            logger()->error('Failed to process payment reminder for order ' . $order->getKey(), [
-                'error' => $e->getMessage(),
-                'order_id' => $order->getKey(),
-            ]);
-        }
-    }
-
-    protected function sendPaymentReminderEmail(PaymentReminder $paymentReminder): void
-    {
-        /** @var Order $order */
-        $order = $paymentReminder->order;
-
-        if (! $order->contact) {
+        if (! $orderIds) {
             return;
         }
 
-        $paymentReminderText = $paymentReminder->getPaymentReminderText();
-
-        if (! $paymentReminderText?->emailTemplate) {
-            return;
-        }
-
-        $paymentReminderPdf = Printing::make([
-            'model_type' => $paymentReminder->getMorphClass(),
-            'model_id' => $paymentReminder->getKey(),
-            'view' => 'payment-reminder',
-            'html' => false,
-            'preview' => false,
-            'attach_relation' => 'order',
-        ])
+        BundlePaymentReminders::make(['order_ids' => $orderIds])
             ->validate()
             ->execute();
-
-        if (! $paymentReminderPdf) {
-            logger()->error('Failed to generate PDF for payment reminder ' . $paymentReminder->getKey());
-
-            return;
-        }
-
-        $invoicePdf = $order->invoice();
-
-        $address = $order->resolveMailablePaymentReminderAddress();
-
-        $to = $paymentReminderText->mail_to ?? [];
-
-        if ($email = $address?->email_primary) {
-            $to[] = $email;
-        }
-
-        $cc = $paymentReminderText->mail_cc ?? [];
-        $to = array_values(array_unique(array_filter($to)));
-        $cc = array_values(array_unique(array_filter($cc)));
-
-        if (! $to) {
-            return;
-        }
-
-        $attachments = [
-            [
-                'id' => $paymentReminderPdf->getKey(),
-                'name' => $paymentReminderPdf->file_name,
-            ],
-        ];
-
-        if ($invoicePdf) {
-            $attachments[] = [
-                'id' => $invoicePdf->getKey(),
-                'name' => $invoicePdf->file_name,
-            ];
-        }
-
-        $result = SendMail::make([
-            'template_id' => $paymentReminderText->email_template_id,
-            'to' => $to,
-            'cc' => $cc ?: null,
-            'attachments' => $attachments,
-            'blade_parameters' => [
-                'order' => $order,
-                'contact' => $order->contact,
-                'paymentReminder' => $paymentReminder,
-            ],
-            'communicatables' => [
-                [
-                    'model_type' => $order->getMorphClass(),
-                    'model_id' => $order->getKey(),
-                ],
-            ],
-        ])
-            ->validate()
-            ->execute();
-
-        if (! data_get($result, 'success', false)) {
-            activity()
-                ->event('payment_reminder_email_failed')
-                ->byAnonymous()
-                ->performedOn($order)
-                ->withProperties([
-                    'error' => data_get($result, 'error'),
-                    'message' => data_get($result, 'message'),
-                    'payment_reminder_id' => $paymentReminder->getKey(),
-                    'to' => $to,
-                ])
-                ->log('Payment reminder email failed');
-        }
     }
 }

--- a/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
+++ b/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
@@ -73,11 +73,7 @@ class AutoSendPaymentRemindersJob implements Repeatable, ShouldQueue
         $orderIds = resolve_static(Order::class, 'query')
             ->when($this->orderIds, fn (Builder $query) => $query->whereKey($this->orderIds))
             ->with(['orderType:id,order_type_enum'])
-            ->whereNotNull('invoice_number')
-            ->where('is_locked', true)
-            ->where('balance', '!=', 0)
-            ->whereDate('payment_reminder_next_date', '<=', now()->toDateString())
-            ->whereHasMailablePaymentReminderAddress()
+            ->wherePaymentReminderDue()
             ->get(['id', 'order_type_id'])
             ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
                 && $order->orderType->order_type_enum->multiplier() === 1

--- a/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
+++ b/src/Jobs/Accounting/AutoSendPaymentRemindersJob.php
@@ -76,7 +76,7 @@ class AutoSendPaymentRemindersJob implements Repeatable, ShouldQueue
             ->wherePaymentReminderDue()
             ->get(['id', 'order_type_id'])
             ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
-                && $order->orderType->order_type_enum->multiplier() === 1
+                && bccomp($order->orderType->order_type_enum->multiplier(), '1') === 0
             )
             ->pluck('id')
             ->all();

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -35,11 +35,7 @@ class PaymentReminderRun extends Component
     public function loadData(): void
     {
         $orders = resolve_static(Order::class, 'query')
-            ->whereNotNull('invoice_number')
-            ->where('is_locked', true)
-            ->where('balance', '!=', 0)
-            ->whereDate('payment_reminder_next_date', '<=', now()->toDateString())
-            ->whereHasMailablePaymentReminderAddress()
+            ->wherePaymentReminderDue()
             ->with(['contact:id,customer_number', 'orderType:id,order_type_enum'])
             ->get()
             ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -34,6 +34,8 @@ class PaymentReminderRun extends Component
 
     public function loadData(): void
     {
+        $this->selected = [];
+
         $orders = resolve_static(Order::class, 'query')
             ->wherePaymentReminderDue()
             ->with(['contact:id,customer_number', 'orderType:id,order_type_enum'])
@@ -45,15 +47,15 @@ class PaymentReminderRun extends Component
         $this->groups = $orders
             ->groupBy(fn (Order $order) => $order->contact_id . '-' . ((int) $order->payment_reminder_current_level + 1))
             ->map(function (Collection $group): array {
-                $first = $group->first();
-                $address = $first->resolveMailablePaymentReminderAddress();
+                $order = $group->first();
+                $address = $order->resolveMailablePaymentReminderAddress();
 
                 return [
-                    'key' => $first->contact_id . '-' . ((int) $first->payment_reminder_current_level + 1),
-                    'contact_id' => $first->contact_id,
-                    'contact_name' => $address?->getLabel() ?? $first->contact?->customer_number,
+                    'key' => $order->contact_id . '-' . ((int) $order->payment_reminder_current_level + 1),
+                    'contact_id' => $order->contact_id,
+                    'contact_name' => $address?->getLabel() ?? $order->contact?->customer_number,
                     'recipient_email' => $address?->email_primary,
-                    'next_level' => (int) $first->payment_reminder_current_level + 1,
+                    'next_level' => (int) $order->payment_reminder_current_level + 1,
                     'order_count' => $group->count(),
                     'total_balance' => $group->sum('balance'),
                     'orders' => $group
@@ -102,7 +104,6 @@ class PaymentReminderRun extends Component
             ->all();
 
         $this->sendBundle($orderIds);
-        $this->selected = [];
         $this->loadData();
     }
 

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace FluxErp\Livewire\Accounting;
+
+use FluxErp\Actions\PaymentReminder\BundlePaymentReminders;
+use FluxErp\Models\Order;
+use FluxErp\Traits\Livewire\Actions;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+
+class PaymentReminderRun extends Component
+{
+    use Actions;
+
+    #[Locked]
+    public array $groups = [];
+
+    public array $selected = [];
+
+    public function mount(): void
+    {
+        $this->loadData();
+    }
+
+    public function render(): View
+    {
+        return view('flux::livewire.accounting.payment-reminder-run');
+    }
+
+    public function loadData(): void
+    {
+        $orders = resolve_static(Order::class, 'query')
+            ->whereNotNull('invoice_number')
+            ->where('is_locked', true)
+            ->where('balance', '!=', 0)
+            ->whereDate('payment_reminder_next_date', '<=', now()->toDateString())
+            ->whereHasMailablePaymentReminderAddress()
+            ->with(['contact:id,customer_number', 'orderType:id,order_type_enum'])
+            ->get()
+            ->filter(fn (Order $order) => ! $order->orderType->order_type_enum->isPurchase()
+                && $order->orderType->order_type_enum->multiplier() === 1
+            );
+
+        $this->groups = $orders
+            ->groupBy(fn (Order $order) => $order->contact_id . '-' . ((int) $order->payment_reminder_current_level + 1))
+            ->map(function (Collection $group): array {
+                $first = $group->first();
+                $address = $first->resolveMailablePaymentReminderAddress();
+
+                return [
+                    'key' => $first->contact_id . '-' . ((int) $first->payment_reminder_current_level + 1),
+                    'contact_id' => $first->contact_id,
+                    'contact_name' => $address?->getLabel() ?? $first->contact?->customer_number,
+                    'recipient_email' => $address?->email_primary,
+                    'next_level' => (int) $first->payment_reminder_current_level + 1,
+                    'order_count' => $group->count(),
+                    'total_balance' => $group->sum('balance'),
+                    'orders' => $group
+                        ->map(fn (Order $order) => [
+                            'id' => $order->getKey(),
+                            'invoice_number' => $order->invoice_number,
+                            'invoice_date' => $order->invoice_date?->toDateString(),
+                            'balance' => $order->balance,
+                            'next_date' => $order->payment_reminder_next_date?->toDateString(),
+                        ])
+                        ->values()
+                        ->all(),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    #[Computed]
+    public function isEmpty(): bool
+    {
+        return blank($this->groups);
+    }
+
+    public function sendGroup(string $key): void
+    {
+        $group = collect($this->groups)->firstWhere('key', $key);
+
+        if (! $group) {
+            return;
+        }
+
+        $this->sendBundle(array_column($group['orders'], 'id'));
+        $this->loadData();
+    }
+
+    public function sendSelected(): void
+    {
+        if (! $this->selected) {
+            return;
+        }
+
+        $orderIds = collect($this->groups)
+            ->whereIn('key', $this->selected)
+            ->flatMap(fn (array $group) => array_column($group['orders'], 'id'))
+            ->all();
+
+        $this->sendBundle($orderIds);
+        $this->selected = [];
+        $this->loadData();
+    }
+
+    public function sendAll(): void
+    {
+        $orderIds = collect($this->groups)
+            ->flatMap(fn (array $group) => array_column($group['orders'], 'id'))
+            ->all();
+
+        $this->sendBundle($orderIds);
+        $this->loadData();
+    }
+
+    protected function sendBundle(array $orderIds): void
+    {
+        if (! $orderIds) {
+            return;
+        }
+
+        try {
+            $result = BundlePaymentReminders::make(['order_ids' => $orderIds])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $sent = (int) data_get($result, 'sent_groups', 0);
+        $failed = (int) data_get($result, 'failed_groups', 0);
+
+        if ($sent > 0) {
+            $this->toast()
+                ->success(__(':count payment reminder(s) sent', ['count' => $sent]))
+                ->send();
+        }
+
+        if ($failed > 0) {
+            $this->toast()
+                ->warning(__(':count payment reminder(s) failed', ['count' => $failed]))
+                ->send();
+        }
+    }
+}

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1438,6 +1438,22 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
             );
     }
 
+    protected function scopeWherePaymentReminderEligible(Builder $query): Builder
+    {
+        return $query
+            ->whereNotNull('invoice_number')
+            ->where('is_locked', true)
+            ->where('balance', '!=', 0)
+            ->whereHasMailablePaymentReminderAddress();
+    }
+
+    protected function scopeWherePaymentReminderDue(Builder $query): Builder
+    {
+        return $query
+            ->wherePaymentReminderEligible()
+            ->whereDate('payment_reminder_next_date', '<=', now()->toDateString());
+    }
+
     // Protected methods
     protected function makeAllSearchableUsing(Builder $query): Builder
     {

--- a/src/Models/PaymentReminder.php
+++ b/src/Models/PaymentReminder.php
@@ -2,7 +2,6 @@
 
 namespace FluxErp\Models;
 
-use FluxErp\Actions\Order\UpdateLockedOrder;
 use FluxErp\Contracts\HasMediaForeignKey;
 use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Traits\Model\HasPackageFactory;
@@ -25,21 +24,6 @@ class PaymentReminder extends FluxModel implements HasMediaForeignKey, OffersPri
             if (! $model->reminder_level) {
                 $model->reminder_level = $model->siblings()->max('reminder_level') + 1;
             }
-        });
-
-        static::created(function (PaymentReminder $model): void {
-            UpdateLockedOrder::make([
-                'id' => $model->order_id,
-                'payment_reminder_current_level' => $model->reminder_level,
-                'payment_reminder_next_date' => $model->created_at
-                    ->addDays(
-                        $model->order->{'payment_reminder_days_' . $model->reminder_level + 1}
-                            ?? $model->order->payment_reminder_days_3
-                    )
-                    ->toDateString(),
-            ])
-                ->validate()
-                ->execute();
         });
     }
 

--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -80,6 +80,7 @@ class MenuServiceProvider extends ServiceProvider
             closure: function (): void {
                 Menu::register(route: 'accounting.commissions');
                 Menu::register(route: 'accounting.payment-reminders');
+                Menu::register(route: 'accounting.payment-reminder-run');
                 Menu::register(route: 'accounting.purchase-invoices');
                 Menu::register(route: 'accounting.transactions');
                 Menu::register(route: 'accounting.transaction-assignments');

--- a/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
+++ b/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FluxErp\Rulesets\PaymentReminder;
+
+use FluxErp\Models\Order;
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rulesets\FluxRuleset;
+
+class BundlePaymentRemindersRuleset extends FluxRuleset
+{
+    protected static ?string $model = PaymentReminder::class;
+
+    public function rules(): array
+    {
+        return [
+            'order_ids' => 'required|array|min:1',
+            'order_ids.*' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => Order::class]),
+            ],
+        ];
+    }
+}

--- a/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
+++ b/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
@@ -18,7 +18,8 @@ class BundlePaymentRemindersRuleset extends FluxRuleset
             'order_ids.*' => [
                 'required',
                 'integer',
-                app(ModelExists::class, ['model' => Order::class])->wherePaymentReminderEligible(),
+                app(ModelExists::class, ['model' => Order::class])
+                    ->wherePaymentReminderEligible(),
             ],
         ];
     }

--- a/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
+++ b/src/Rulesets/PaymentReminder/BundlePaymentRemindersRuleset.php
@@ -18,7 +18,7 @@ class BundlePaymentRemindersRuleset extends FluxRuleset
             'order_ids.*' => [
                 'required',
                 'integer',
-                app(ModelExists::class, ['model' => Order::class]),
+                app(ModelExists::class, ['model' => Order::class])->wherePaymentReminderEligible(),
             ],
         ];
     }

--- a/src/Rulesets/PaymentReminder/CreatePaymentReminderRuleset.php
+++ b/src/Rulesets/PaymentReminder/CreatePaymentReminderRuleset.php
@@ -27,6 +27,7 @@ class CreatePaymentReminderRuleset extends FluxRuleset
                 app(ModelExists::class, ['model' => Media::class]),
             ],
             'reminder_level' => 'nullable|integer|min:1',
+            'mark_as_sent' => 'nullable|boolean',
         ];
     }
 }

--- a/src/Rulesets/PaymentReminder/MarkPaymentReminderSentRuleset.php
+++ b/src/Rulesets/PaymentReminder/MarkPaymentReminderSentRuleset.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FluxErp\Rulesets\PaymentReminder;
+
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rulesets\FluxRuleset;
+
+class MarkPaymentReminderSentRuleset extends FluxRuleset
+{
+    protected static ?string $model = PaymentReminder::class;
+
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => PaymentReminder::class]),
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
+++ b/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use FluxErp\Actions\PaymentReminder\BundlePaymentReminders;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use Spatie\Activitylog\Models\Activity;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-100',
+        'balance' => 100,
+        'payment_reminder_current_level' => 0,
+        'payment_reminder_next_date' => now()->subDay()->toDateString(),
+    ]);
+});
+
+test('bundle requires order_ids', function (): void {
+    BundlePaymentReminders::assertValidationErrors([], 'order_ids');
+});
+
+test('failed send leaves no reminder record and logs activity on order', function (): void {
+    $orderId = $this->order->getKey();
+    $originalLevel = $this->order->payment_reminder_current_level;
+    $originalNextDate = $this->order->payment_reminder_next_date?->toDateString();
+
+    BundlePaymentReminders::make(['order_ids' => [$orderId]])
+        ->validate()
+        ->execute();
+
+    expect(PaymentReminder::query()->where('order_id', $orderId)->count())->toBe(0);
+
+    $order = Order::query()->whereKey($orderId)->first();
+    expect($order->payment_reminder_current_level)->toBe($originalLevel);
+    expect($order->payment_reminder_next_date?->toDateString())->toBe($originalNextDate);
+
+    $failureLogged = Activity::query()
+        ->where('subject_type', morph_alias(Order::class))
+        ->where('subject_id', $orderId)
+        ->where('event', 'payment_reminder_send_failed')
+        ->exists();
+
+    expect($failureLogged)->toBeTrue();
+});

--- a/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
+++ b/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
@@ -43,6 +43,8 @@ beforeEach(function (): void {
         'payment_reminder_current_level' => 0,
         'payment_reminder_next_date' => now()->subDay()->toDateString(),
     ]);
+
+    $this->order->update(['balance' => 100]);
 });
 
 test('bundle requires order_ids', function (): void {

--- a/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
+++ b/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
@@ -5,16 +5,21 @@ use FluxErp\Jobs\Accounting\AutoSendPaymentRemindersJob;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
+use FluxErp\Models\EmailTemplate;
 use FluxErp\Models\Language;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\PaymentReminder;
+use FluxErp\Models\PaymentReminderText;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 use FluxErp\Settings\AccountingSettings;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
 beforeEach(function (): void {
+    Mail::fake();
+
     AccountingSettings::fake([
         'auto_send_reminders' => true,
         'auto_accept_secure_transaction_matches' => false,
@@ -40,6 +45,12 @@ beforeEach(function (): void {
             'order_type_enum' => OrderTypeEnum::Order,
             'is_active' => true,
         ]);
+
+    $emailTemplate = EmailTemplate::factory()->create();
+    PaymentReminderText::factory()->create([
+        'reminder_level' => 1,
+        'email_template_id' => $emailTemplate->getKey(),
+    ]);
 });
 
 test('sends payment reminders for overdue orders', function (): void {

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use FluxErp\Livewire\Accounting\PaymentReminderRun;
+use Livewire\Livewire;
+
+test('payment reminder run renders', function (): void {
+    Livewire::test(PaymentReminderRun::class)
+        ->assertOk();
+});


### PR DESCRIPTION
## Summary
- Move order level + next-date side effect out of `PaymentReminder::booted::created` into a new `MarkPaymentReminderSent` action so a failed mail can no longer leave the order in a wrong state
- Add `BundlePaymentReminders` action that groups due reminders per (contact, level), sends one mail per group with all reminder PDFs + invoice PDFs as attachments, and on any failure path force-deletes the freshly created reminders and logs an activity on each affected order
- Refactor `AutoSendPaymentRemindersJob` to use the bundler so the auto-send path now inherits the same fail-safe behavior
- Add `PaymentReminderRun` Livewire screen at `accounting.payment-reminder-run` showing today-due reminders grouped per contact with bulk send / per-group send

## Notes
- `CreatePaymentReminder` keeps its legacy contract by chaining `MarkPaymentReminderSent` at the end of `performAction`, so direct API callers still see the level bump on create
- Failure paths in `BundlePaymentReminders` go through a single `abortGroup()` helper that cleans up and logs once

## Summary by Sourcery

Refactor payment reminder processing to bundle reminders per contact/level, defer order reminder level updates until emails are successfully sent, and add a UI for managing and sending due reminder runs.

New Features:
- Introduce a BundlePaymentReminders action that groups due orders into reminder bundles per contact and reminder level and sends a single email with all related attachments.
- Add a PaymentReminderRun Livewire screen and route to review due payment reminder groups and trigger sending for all, selected, or individual groups.
- Add a MarkPaymentReminderSent action to update an order's payment reminder level and next reminder date once a reminder has been successfully sent.

Bug Fixes:
- Ensure failed payment reminder emails no longer leave orders with advanced reminder levels or updated next reminder dates by only applying these changes after successful send operations.
- Guarantee that failed bundled reminder sends remove newly created reminder records and log failure activities on affected orders.

Enhancements:
- Refactor AutoSendPaymentRemindersJob to delegate to the BundlePaymentReminders action, unifying auto-send behavior with the new bundled sending and failure handling.
- Remove the PaymentReminder model's created-hook side effect that eagerly updated the parent order, centralizing this logic in the new MarkPaymentReminderSent action.
- Add validation rulesets for bundling reminders and marking reminders as sent to enforce correct input and model existence.
- Register the new payment reminder run screen in navigation for easier access.

Tests:
- Add feature tests for BundlePaymentReminders to validate required parameters and ensure failed sends leave no reminders and log appropriate activities.
- Add a Livewire test to assert that the PaymentReminderRun component renders successfully.