### PR TITLE
feat(folder-tree): enable search across name, file name and collection

### DIFF
--- a/resources/js/components/folders.js
+++ b/resources/js/components/folders.js
@@ -255,7 +255,10 @@ export default function folders(
 
                 // Check if the current node matches the search term (in the `nameAttribute`)
                 const matches = this.getSearchAttributes().some((attribute) => {
-                    return node[attribute]?.toLowerCase().includes(lowerSearch);
+                    return (
+                        node[attribute]?.toLowerCase().includes(lowerSearch) ??
+                        false
+                    );
                 });
 
                 // If the node matches, include it along with ALL its children

--- a/resources/js/components/folders.js
+++ b/resources/js/components/folders.js
@@ -255,7 +255,7 @@ export default function folders(
 
                 // Check if the current node matches the search term (in the `nameAttribute`)
                 const matches = this.getSearchAttributes().some((attribute) => {
-                    return node[attribute].toLowerCase().includes(lowerSearch);
+                    return node[attribute]?.toLowerCase().includes(lowerSearch);
                 });
 
                 // If the node matches, include it along with ALL its children

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -4,8 +4,10 @@
             <x-flux::checkbox-tree
                 tree="$wire.getTree()"
                 name-attribute="name"
+                :search-attributes="['name', 'file_name', 'collection_name']"
                 moved="$wire.moveItem(item, node, item.slug ?? item.collection_name ?? getNodePath(item, 'slug'), node.slug ?? node.collection_name ?? getNodePath(node, 'slug'))"
                 sortable
+                with-search
                 x-sort:item="childNode"
             >
                 <x-slot:beforeTree>


### PR DESCRIPTION
## Summary
- `<x-flux::checkbox-tree>` already supports search via `with-search` + `search-attributes`, but the FolderTree view never opted in
- Turn it on for every model that uses the FolderTree (Address, Order, Contact, Lead, Product, Ticket, Task, Employee, Project, SerialNumber)
- Search matches against `name`, `file_name` and `collection_name` so users find files by visible folder label, actual file name, or underlying spatie collection path
- Make the JS search null-safe so a missing attribute on a node (folders don't carry `file_name`, files don't carry deep `name`) no longer throws

## Summary by Sourcery

Enable search in the folder tree view and make folder node search handling null-safe.

New Features:
- Add search support to the folder tree checkbox component using name, file_name, and collection_name attributes.

Bug Fixes:
- Prevent errors during folder tree search when nodes are missing searchable attributes by making lookups null-safe.