### PR TITLE
fix(media-tree): preserve sibling branches when dotted collection names share a prefix

### DIFF
--- a/src/Traits/Model/InteractsWithMedia.php
+++ b/src/Traits/Model/InteractsWithMedia.php
@@ -81,31 +81,35 @@ trait InteractsWithMedia
         $undotted = [];
         foreach ($mediaCollections as $mediaCollection) {
             $slug = data_get($mediaCollection, 'slug') ?? '';
+
             if (
                 is_null(data_get($mediaCollection, 'id'))
                 && str_contains($slug, '.')
             ) {
-                $path = '';
+                $cursor = &$undotted;
                 $childSlug = '';
-                foreach (explode('.', $slug) as $index => $part) {
-                    if ($index === 0 && array_key_exists($part, $undotted)) {
-                        $path = $childSlug = $part;
 
-                        continue;
-                    }
+                foreach (explode('.', $slug) as $part) {
+                    $childSlug = $childSlug === '' ? $part : $childSlug . '.' . $part;
 
-                    $childSlug .= ($childSlug ? '.' : '') . $part;
-                    $path .= ($path ? '.children.' : '') . $part;
-
-                    Arr::set(
-                        $undotted,
-                        $path,
-                        [
+                    if (! isset($cursor[$part]) || ! is_array($cursor[$part])) {
+                        $cursor[$part] = [
                             'name' => Str::headline($part),
                             'slug' => $childSlug,
-                        ],
-                    );
+                        ];
+                    }
+
+                    if (
+                        ! isset($cursor[$part]['children'])
+                        || ! is_array($cursor[$part]['children'])
+                    ) {
+                        $cursor[$part]['children'] = [];
+                    }
+
+                    $cursor = &$cursor[$part]['children'];
                 }
+
+                unset($cursor);
             } else {
                 Arr::set($undotted, $slug, $mediaCollection);
             }

--- a/src/Traits/Model/InteractsWithMedia.php
+++ b/src/Traits/Model/InteractsWithMedia.php
@@ -92,7 +92,7 @@ trait InteractsWithMedia
                 foreach (explode('.', $slug) as $part) {
                     $childSlug = $childSlug === '' ? $part : $childSlug . '.' . $part;
 
-                    if (! isset($cursor[$part]) || ! is_array($cursor[$part])) {
+                    if (! array_key_exists($part, $cursor) || ! is_array($cursor[$part])) {
                         $cursor[$part] = [
                             'name' => Str::headline($part),
                             'slug' => $childSlug,
@@ -100,7 +100,7 @@ trait InteractsWithMedia
                     }
 
                     if (
-                        ! isset($cursor[$part]['children'])
+                        ! array_key_exists('children', $cursor[$part])
                         || ! is_array($cursor[$part]['children'])
                     ) {
                         $cursor[$part]['children'] = [];

--- a/tests/Feature/Traits/InteractsWithMediaTest.php
+++ b/tests/Feature/Traits/InteractsWithMediaTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Media;
+
+test('getMediaAsTree keeps all sibling branches under a shared dotted prefix', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+
+    foreach (
+        [
+            'Berater.Nextcloud.Alpha',
+            'Berater.Nextcloud.Beta',
+            'Berater.Nextcloud.Gamma',
+        ] as $collection
+    ) {
+        Media::factory()->create([
+            'model_type' => $address->getMorphClass(),
+            'model_id' => $address->getKey(),
+            'collection_name' => $collection,
+        ]);
+    }
+
+    $tree = $address->getMediaAsTree();
+
+    $berater = collect($tree)->firstWhere('slug', 'Berater');
+    expect($berater)->not->toBeNull();
+
+    $nextcloud = collect(data_get($berater, 'children'))->firstWhere('slug', 'Berater.Nextcloud');
+    expect($nextcloud)->not->toBeNull();
+
+    $childSlugs = collect(data_get($nextcloud, 'children'))
+        ->pluck('slug')
+        ->sort()
+        ->values()
+        ->all();
+
+    expect($childSlugs)->toBe([
+        'Berater.Nextcloud.Alpha',
+        'Berater.Nextcloud.Beta',
+        'Berater.Nextcloud.Gamma',
+    ]);
+});


### PR DESCRIPTION
## Summary
- The inner loop in InteractsWithMedia::getMediaAsTree built nested folders via Arr::set on a dotted path
- Arr::set replaces the array at the final path key, so each iteration that touched an intermediate node (e.g. \`Berater.children.Nextcloud\`) wiped any \`children\` already accumulated on it
- Sorted slug processing meant only the alphabetically last branch survived under any shared prefix; earlier siblings disappeared from the rendered tree even though the records existed in DB
- Real-world repro: address with media under \`Berater.Nextcloud.BRV\`, \`Berater.Nextcloud.Daten Darlehen\`, \`Berater.Nextcloud.PKV\`, … only \`PKV\` showed up

## Fix
- Walk the path by reference and initialise each level idempotently; never replace an existing node or its \`children\`
- Regression test attaches three media records sharing a prefix and asserts all three siblings survive on the parent

## Summary by Sourcery

Ensure media tree construction preserves all sibling branches for dotted collection names sharing a prefix.

Bug Fixes:
- Fix media tree building logic so intermediate nodes created from dotted slugs no longer overwrite existing siblings, preventing branches from disappearing in the rendered tree.

Tests:
- Add a feature test that asserts multiple media collections with a shared dotted prefix all appear as distinct sibling branches in the resulting media tree.