### PR TITLE
fix(media): stream downloads through a dedicated disk-agnostic route

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -376,7 +376,8 @@ Route::middleware('web')
         Route::middleware('signed')->group(function (): void {
             Route::get('/media-private/{media}/{filename}', function (Media $media) {
                 return $media;
-            })->name('media.private');
+            })
+                ->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {
                 $disposition = HeaderUtils::makeDisposition(
@@ -404,7 +405,8 @@ Route::middleware('web')
                     $media->file_name,
                     ['Content-Disposition' => $disposition],
                 );
-            })->name('media.show');
+            })
+                ->name('media.show');
 
             Route::get('/media-collection-download/{token}', function (string $token) {
                 $payload = Crypt::decrypt($token);

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -127,6 +127,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use TeamNiftyGmbH\DataTable\Controllers\IconController;
 
 /*
@@ -378,8 +379,12 @@ Route::middleware('web')
             })->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {
-                $disposition = (request()->boolean('download') ? 'attachment' : 'inline')
-                    . '; filename="' . $media->file_name . '"';
+                $disposition = HeaderUtils::makeDisposition(
+                    request()->boolean('download')
+                        ? HeaderUtils::DISPOSITION_ATTACHMENT
+                        : HeaderUtils::DISPOSITION_INLINE,
+                    $media->file_name,
+                );
 
                 $disk = Storage::disk($media->disk);
                 $path = $media->getPathRelativeToRoot();

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -377,6 +377,30 @@ Route::middleware('web')
                 return $media;
             })->name('media.private');
 
+            Route::get('/media/{media}', function (Media $media) {
+                $disposition = (request()->boolean('download') ? 'attachment' : 'inline')
+                    . '; filename="' . $media->file_name . '"';
+
+                $disk = Storage::disk($media->disk);
+                $path = $media->getPathRelativeToRoot();
+
+                if ($disk->providesTemporaryUrls()) {
+                    return redirect()->away(
+                        $disk->temporaryUrl(
+                            $path,
+                            now()->addMinutes(5),
+                            ['ResponseContentDisposition' => $disposition],
+                        )
+                    );
+                }
+
+                return $disk->response(
+                    $path,
+                    $media->file_name,
+                    ['Content-Disposition' => $disposition],
+                );
+            })->name('media.show');
+
             Route::get('/media-collection-download/{token}', function (string $token) {
                 $payload = Crypt::decrypt($token);
 

--- a/src/Traits/Livewire/SupportsFileDownloads.php
+++ b/src/Traits/Livewire/SupportsFileDownloads.php
@@ -10,12 +10,14 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 
 trait SupportsFileDownloads
 {
     use EnsureUsedInLivewire;
 
+    #[Renderless]
     public function download(Media $media): void
     {
         if (! file_exists($media->getPath())) {
@@ -27,9 +29,7 @@ trait SupportsFileDownloads
         }
 
         try {
-            DownloadMedia::make([
-                'id' => $media->getKey(),
-            ])
+            DownloadMedia::make(['id' => $media->getKey()])
                 ->checkPermission()
                 ->validate();
         } catch (ValidationException|UnauthorizedException $e) {
@@ -38,9 +38,14 @@ trait SupportsFileDownloads
             return;
         }
 
-        $this->redirect($media->getUrl());
+        $this->redirect(URL::temporarySignedRoute(
+            'media.show',
+            now()->addMinutes(5),
+            ['media' => $media->getKey(), 'download' => 1],
+        ));
     }
 
+    #[Renderless]
     public function downloadCollection(int|string $id, array|string $collection): void
     {
         // If $id is an integer we assume it's a media folder

--- a/src/Traits/Livewire/SupportsFileDownloads.php
+++ b/src/Traits/Livewire/SupportsFileDownloads.php
@@ -29,7 +29,9 @@ trait SupportsFileDownloads
         }
 
         try {
-            DownloadMedia::make(['id' => $media->getKey()])
+            DownloadMedia::make([
+                'id' => $media->getKey(),
+            ])
                 ->checkPermission()
                 ->validate();
         } catch (ValidationException|UnauthorizedException $e) {


### PR DESCRIPTION
## Summary
- `SupportsFileDownloads::download` redirected to the media URL. On the public disk that URL has no `Content-Disposition` header, so browsers rendered images and PDFs inline instead of downloading them
- Returning a `BinaryFileResponse` straight from the Livewire action would have forced the download but Livewire base64-encodes the whole response body for transport, which blows up memory on large files
- Add a signed `media.show` route that uses `Storage::disk(...)` so it adapts to whichever driver the media lives on:
  - local/public disks stream the file with a conditional `Content-Disposition` header (inline by default, attachment when `?download=1` is set)
  - S3-style disks (`providesTemporaryUrls`) redirect to a presigned URL with `ResponseContentDisposition` so the client downloads directly from the bucket without proxying through us
- Mark `download()` and `downloadCollection()` `#[Renderless]` so the component template is not re-rendered on a redirect