### PR TITLE
fix morphTo eager loading with customization

### DIFF
--- a/src/Models/FluxModel.php
+++ b/src/Models/FluxModel.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Models;
 
+use FluxErp\Support\Relations\MorphTo;
 use FluxErp\Traits\Model\BroadcastsEvents;
 use FluxErp\Traits\Model\HasModelPermission;
 use FluxErp\Traits\Model\ResolvesRelationsThroughContainer;
@@ -48,5 +49,20 @@ abstract class FluxModel extends Model
         }
 
         return parent::resolveCollectionFromAttribute();
+    }
+
+    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation): MorphTo
+    {
+        return app(
+            MorphTo::class,
+            [
+                'query' => $query,
+                'parent' => $parent,
+                'foreignKey' => $foreignKey,
+                'ownerKey' => $ownerKey,
+                'type' => $type,
+                'relation' => $relation,
+            ]
+        );
     }
 }

--- a/src/Support/Relations/MorphTo.php
+++ b/src/Support/Relations/MorphTo.php
@@ -11,7 +11,7 @@ class MorphTo extends EloquentMorphTo
     {
         $class = resolve_static(Model::getActualClassNameForMorph($type), 'class');
 
-        return tap(new $class(), function ($instance) {
+        return tap(new $class(), function ($instance): void {
             if (! $instance->getConnectionName()) {
                 $instance->setConnection($this->getConnection()->getName());
             }

--- a/src/Support/Relations/MorphTo.php
+++ b/src/Support/Relations/MorphTo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FluxErp\Support\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
+
+class MorphTo extends EloquentMorphTo
+{
+    public function createModelByType($type): Model
+    {
+        $class = resolve_static(Model::getActualClassNameForMorph($type), 'class');
+
+        return tap(new $class(), function ($instance) {
+            if (! $instance->getConnectionName()) {
+                $instance->setConnection($this->getConnection()->getName());
+            }
+        });
+    }
+}

--- a/tests/Feature/Customization/ModelTest.php
+++ b/tests/Feature/Customization/ModelTest.php
@@ -1,12 +1,15 @@
 <?php
 
+use FluxErp\Models\Comment;
 use FluxErp\Models\Language;
+use FluxErp\Models\Ticket;
 use FluxErp\Models\User;
+use FluxErp\Traits\Model\HasParentMorphClass;
 
 test('model customization', function (): void {
     $class = new class() extends Language
     {
-        use FluxErp\Traits\Model\HasParentMorphClass;
+        use HasParentMorphClass;
 
         protected $table = 'languages';
     };
@@ -23,7 +26,7 @@ test('model customization', function (): void {
 test('model relation', function (): void {
     $class = new class() extends Language
     {
-        use FluxErp\Traits\Model\HasParentMorphClass;
+        use HasParentMorphClass;
 
         protected $table = 'languages';
     };
@@ -36,4 +39,30 @@ test('model relation', function (): void {
         ->create(['language_id' => $language->id]);
 
     expect($user->language)->toBeInstanceOf(get_class($class));
+});
+
+test('model morph to eager relation', function (): void {
+    $class = new class() extends Ticket
+    {
+        use HasParentMorphClass;
+
+        protected $table = 'tickets';
+    };
+    $this->app->bind(Ticket::class, get_class($class));
+
+    $user = User::factory()->create();
+
+    $ticket = Ticket::factory()
+        ->create([
+            'authenticatable_type' => $user->getMorphClass(),
+            'authenticatable_id' => $user->getKey(),
+        ]);
+
+    $comment = Comment::factory()
+        ->create([
+            'model_type' => $ticket->getMorphClass(),
+            'model_id' => $ticket->getKey(),
+        ]);
+
+    expect($comment->model)->toBeInstanceOf(get_class($class));
 });


### PR DESCRIPTION
## Summary by Sourcery

Customize MorphTo relationships to respect parent morph class resolution and add coverage for eager loading with model customization.

New Features:
- Introduce a custom MorphTo relation class that resolves models via the container while preserving connection configuration.

Enhancements:
- Override FluxModel morph-to relation creation to use the custom MorphTo implementation for polymorphic relationships with customized models.

Tests:
- Extend model customization tests to cover polymorphic morphTo eager loading using customized ticket and comment models.