### PR TITLE
Restore x-teleport clones after Livewire navigate

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -13,6 +13,7 @@ import sort from '@alpinejs/sort';
 import collapse from '@alpinejs/collapse';
 import navigationSpinner from './navigation-spinner.js';
 import wireNavigation from './wire-navigation.js';
+import teleportRestore from './teleport-restore.js';
 import comments from './comments.js';
 import familyTree from './family-tree.js';
 import documentScanner from './document-scanner.js';
@@ -75,6 +76,7 @@ Alpine.data('folder_tree', folders);
 Alpine.data('comments', comments);
 
 document.addEventListener('livewire:navigated', wireNavigation, { once: true });
+document.addEventListener('livewire:navigated', teleportRestore);
 
 document.addEventListener('livewire:init', () => {
     wireNavigation();

--- a/resources/js/components/teleport-restore.js
+++ b/resources/js/components/teleport-restore.js
@@ -1,0 +1,36 @@
+// Re-runs Alpine's x-teleport for templates whose teleported clone has been
+// removed during wire:navigate. Livewire's dom-morph keeps the source
+// template (and its `_x_teleport` back-reference), but Alpine's release
+// callback already removed the clone in the target. Without this restore the
+// dropdown/dialog/tooltip stays trapped in the <template> tag.
+export default function teleportRestore() {
+    document.querySelectorAll('template[x-teleport]').forEach((template) => {
+        if (!template._x_teleport || template._x_teleport.isConnected) {
+            return;
+        }
+
+        const scopeRoot = template.closest('[x-data]');
+        if (!scopeRoot) {
+            return;
+        }
+
+        const targetSelector = template.getAttribute('x-teleport');
+        const target =
+            targetSelector === 'body'
+                ? document.body
+                : document.querySelector(targetSelector);
+
+        if (!target || !template.content.firstElementChild) {
+            return;
+        }
+
+        const clone = template.content.firstElementChild.cloneNode(true);
+        target.appendChild(clone);
+
+        template._x_teleport = clone;
+        clone._x_teleportBack = template;
+
+        window.Alpine.addScopeToNode(clone, {}, scopeRoot);
+        window.Alpine.initTree(clone);
+    });
+}


### PR DESCRIPTION
## Summary

- Hook into `livewire:navigated` and re-teleport any `<template x-teleport>` whose previously-teleported clone is no longer in the DOM.
- Reattach the parent Alpine scope to the new clone so reactive bindings keep working.

## Background

Alpine's `x-teleport` directive moves a template's content into a target (usually `<body>`) and stores a back-reference (`_x_teleport`) on the source template. Livewire's `wire:navigate` performs a dom-morph that preserves the source template (including the back-reference) while Alpine's release callback removes the clone from the target during navigation. The next render leaves Alpine convinced that the template is already teleported, so the dropdown / dialog / tooltip stays trapped inside the `<template>` tag and is invisible to users until a hard reload.

This affects every TallStackUI floating component (`x-select.styled`, dropdown, dialog, tooltip) as well as any other consumer of `template[x-teleport]`.

## Summary by Sourcery

Restore Alpine x-teleport content after Livewire navigation so teleported UI elements remain visible and functional.

Bug Fixes:
- Recreate and reattach missing x-teleport clones after Livewire wire:navigate DOM morphs so teleported components no longer stay hidden inside their templates.

Enhancements:
- Hook Livewire navigation events into an Alpine teleport restoration helper to keep floating UI components working across navigations.