### PR TITLE
fix(navigation): invalidate menu cache when user permissions change

### DIFF
--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -65,7 +65,7 @@ class Navigation extends Component
     {
         $menuAll = Menu::all();
         data_forget($menuAll, 'settings.children');
-        $menuHash = md5(serialize($menuAll));
+        $menuHash = md5(serialize($menuAll) . '|' . $this->authFingerprint());
 
         $cached = Session::get('navigations.' . $menuHash);
         if (is_array($cached)) {
@@ -100,6 +100,21 @@ class Navigation extends Component
         Session::put('navigations.' . $menuHash, $navigations);
 
         return collect($navigations);
+    }
+
+    protected function authFingerprint(): string
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return 'guest';
+        }
+
+        $permissionIds = method_exists($user, 'getAllPermissions')
+            ? $user->getAllPermissions()->pluck('id')->sort()->values()->all()
+            : [];
+
+        return $user->getAuthIdentifier() . ':' . md5(implode(',', $permissionIds));
     }
 
     protected function getVisits(): ?array

--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -111,10 +111,10 @@ class Navigation extends Component
         }
 
         $permissionIds = method_exists($user, 'getAllPermissions')
-            ? $user->getAllPermissions()->pluck('id')->sort()->values()->all()
-            : [];
+            ? $user->getAllPermissions()->pluck('id')->sort()->implode(',')
+            : '';
 
-        return $user->getAuthIdentifier() . ':' . md5(implode(',', $permissionIds));
+        return $user->getAuthIdentifier() . ':' . $permissionIds;
     }
 
     protected function getVisits(): ?array

--- a/tests/Livewire/NavigationTest.php
+++ b/tests/Livewire/NavigationTest.php
@@ -4,6 +4,8 @@ use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Facades\Menu;
 use FluxErp\Livewire\Navigation;
 use FluxErp\Models\OrderType;
+use FluxErp\Models\Permission;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
@@ -30,4 +32,27 @@ test('shows order types', function (): void {
     Livewire::actingAs($this->user)
         ->test(Navigation::class)
         ->assertDontSee(Str::headline($orderTypes->first()->name));
+});
+
+test('navigation cache is invalidated when user permissions change', function (): void {
+    Menu::clear();
+    Route::middleware('auth:web')->get('navigation-cache-probe', fn () => null)
+        ->name('navigation-cache-probe');
+    Menu::register(route: 'navigation-cache-probe', label: 'Cache Probe Page');
+
+    $permission = Permission::findOrCreate('navigation-cache-probe.get', 'web');
+
+    // First render: user lacks the permission, the menu item must be filtered out
+    // and the (empty) result gets cached in the session.
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertDontSee('Cache Probe Page');
+
+    // Permission grant happens between the two renders — exactly the situation the
+    // session-side menu cache used to swallow.
+    $this->user->givePermissionTo($permission);
+
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertSee('Cache Probe Page');
 });


### PR DESCRIPTION
## Problem

`Navigation::getMenu()` caches the rendered menu in the user's session under a key that hashes only `Menu::all()` — the globally registered menu items. The hash does not depend on the user or their permissions.

```php
$menuHash = md5(serialize($menuAll));
$cached = Session::get('navigations.' . $menuHash);
```

Since `Menu::all()` is identical across requests for the lifetime of the worker, the hash never changes. As a result, if a user's roles or permissions are modified after their first menu render, they continue to see the stale menu for the remaining session lifetime — sometimes for hours. This was reported in the wild as "the new menu entry doesn't show up for some users" after a permission was added to a role.

## Fix

Include an auth fingerprint — the authenticated user's identifier plus a hash of all their permission IDs (from `getAllPermissions()`) — in the cache key.

```php
$menuHash = md5(serialize($menuAll) . '|' . $this->authFingerprint());
```

`getAllPermissions()` is served from Spatie's internal permission cache, so this does not add a database round-trip on the hot path. When a user gains or loses a permission, the fingerprint changes, the cache key changes, and the menu is rebuilt on the next render. Existing cached entries become unreachable and expire with the session.

## Test

Added a Pest test in `tests/Livewire/NavigationTest.php` that:
1. Registers a route + menu item gated by a new permission
2. Renders the navigation as a user *without* the permission → menu item is absent and cached
3. Grants the permission
4. Renders again → asserts the menu item is now visible

The test fails on `main` (stale cache returned) and passes with this fix.

## Backward compatibility

- No public API changes
- Cache key changes shape, so previously cached entries become unreachable on first render after deploy — they expire naturally with the session
- Guests get a stable `"guest"` fingerprint

## Summary by Sourcery

Ensure navigation menus are cached per user and permission set to prevent stale menus after permission changes.

Bug Fixes:
- Prevent users from seeing stale navigation menus after their roles or permissions are updated by including an auth-based fingerprint in the menu cache key.

Tests:
- Add a Livewire navigation test verifying that the menu cache is invalidated and updated when a user gains a new permission-gated menu item.