### PR TITLE
fix(media): serve conversion files via media.private when the conversion disk is private

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -6,6 +6,7 @@ use FluxErp\Actions\PushSubscription\UpsertPushSubscription;
 use FluxErp\Http\Controllers\AuthController;
 use FluxErp\Http\Controllers\CalendarEventController;
 use FluxErp\Http\Controllers\CalendarSearchController;
+use FluxErp\Http\Controllers\PrivateMediaController;
 use FluxErp\Http\Controllers\SearchController;
 use FluxErp\Http\Middleware\TrackVisits;
 use FluxErp\Livewire\AbsenceRequest\AbsenceRequest;
@@ -374,9 +375,7 @@ Route::middleware('web')
         });
 
         Route::middleware('signed')->group(function (): void {
-            Route::get('/media-private/{media}/{filename}', function (Media $media) {
-                return $media;
-            })
+            Route::get('/media-private/{media}/{filename}', PrivateMediaController::class)
                 ->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {

--- a/src/Http/Controllers/PrivateMediaController.php
+++ b/src/Http/Controllers/PrivateMediaController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use FluxErp\Models\Media;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PrivateMediaController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        Media $media,
+    ): Media|BinaryFileResponse|StreamedResponse|RedirectResponse {
+        $conversion = (string) $request->query('conversion', '');
+
+        if (blank($conversion)) {
+            return $media;
+        }
+
+        abort_unless($media->hasGeneratedConversion($conversion), 404);
+
+        $disk = Storage::disk($media->conversions_disk);
+        $relativePath = $media->getPathRelativeToRoot($conversion);
+        $fileName = basename($relativePath);
+
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_INLINE,
+            $fileName,
+        );
+
+        if ($disk->providesTemporaryUrls()) {
+            return redirect()->away(
+                $disk->temporaryUrl(
+                    $relativePath,
+                    now()->addMinutes(5),
+                    ['ResponseContentDisposition' => $disposition],
+                )
+            );
+        }
+
+        return $disk->response(
+            $relativePath,
+            $fileName,
+            ['Content-Disposition' => $disposition],
+        );
+    }
+}

--- a/src/Http/Controllers/PrivateMediaController.php
+++ b/src/Http/Controllers/PrivateMediaController.php
@@ -26,6 +26,9 @@ class PrivateMediaController extends Controller
 
         $disk = Storage::disk($media->conversions_disk);
         $relativePath = $media->getPathRelativeToRoot($conversion);
+
+        abort_unless($disk->exists($relativePath), 404);
+
         $fileName = basename($relativePath);
 
         $disposition = HeaderUtils::makeDisposition(
@@ -37,7 +40,7 @@ class PrivateMediaController extends Controller
             return redirect()->away(
                 $disk->temporaryUrl(
                     $relativePath,
-                    now()->addMinutes(5),
+                    now()->addMinutes(Media::PRIVATE_URL_TTL_MINUTES),
                     ['ResponseContentDisposition' => $disposition],
                 )
             );

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -16,6 +16,8 @@ class Media extends BaseMedia
 {
     use HasPackageFactory, LogsActivity, ResolvesRelationsThroughContainer;
 
+    public const int PRIVATE_URL_TTL_MINUTES = 5;
+
     public bool $isTemporary = false;
 
     public ?string $path = null;

--- a/src/Support/MediaLibrary/UrlGenerator.php
+++ b/src/Support/MediaLibrary/UrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Support\MediaLibrary;
 
+use FluxErp\Models\Media;
 use Illuminate\Support\Facades\URL;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 
@@ -26,7 +27,11 @@ class UrlGenerator extends DefaultUrlGenerator
                 $params['conversion'] = $this->conversion->getName();
             }
 
-            return URL::temporarySignedRoute('media.private', now()->addMinutes(5), $params);
+            return URL::temporarySignedRoute(
+                'media.private',
+                now()->addMinutes(Media::PRIVATE_URL_TTL_MINUTES),
+                $params,
+            );
         }
 
         return parent::getUrl();

--- a/src/Support/MediaLibrary/UrlGenerator.php
+++ b/src/Support/MediaLibrary/UrlGenerator.php
@@ -9,11 +9,24 @@ class UrlGenerator extends DefaultUrlGenerator
 {
     public function getUrl(): string
     {
-        if ($this->media->disk !== 'public' && $this->media->id && $this->media->file_name) {
-            return URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
-                'media' => $this->media->id,
+        // Conversions and originals can live on different disks (e.g. originals on s3,
+        // conversions on the local public disk). Pick the disk that actually backs the
+        // file we're being asked for, not just the original's disk.
+        $effectiveDisk = is_null($this->conversion)
+            ? $this->media->disk
+            : $this->media->conversions_disk;
+
+        if ($effectiveDisk !== 'public' && $this->media->getKey() && $this->media->file_name) {
+            $params = [
+                'media' => $this->media->getKey(),
                 'filename' => $this->media->file_name,
-            ]);
+            ];
+
+            if (! is_null($this->conversion)) {
+                $params['conversion'] = $this->conversion->getName();
+            }
+
+            return URL::temporarySignedRoute('media.private', now()->addMinutes(5), $params);
         }
 
         return parent::getUrl();

--- a/tests/Feature/Web/PrivateMediaTest.php
+++ b/tests/Feature/Web/PrivateMediaTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use FluxErp\Models\Media;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+beforeEach(function (): void {
+    $file = UploadedFile::fake()->image('original.png', 800, 600);
+
+    /** @var Media $media */
+    $this->media = $this->user->addMedia($file)
+        ->usingFileName($this->filename = Str::random() . '.png')
+        ->toMediaCollection();
+
+    // Pretend a thumb_400x400 has been generated. The actual file is created below
+    // so the controller can stream a real conversion file.
+    $this->media->generated_conversions = ['thumb_400x400' => true];
+    $this->media->save();
+
+    $conversionPath = $this->media->getPath('thumb_400x400');
+    @mkdir(dirname($conversionPath), recursive: true);
+    file_put_contents($conversionPath, 'fake-thumb-bytes');
+});
+
+test('signed route without conversion query returns the original', function (): void {
+    $url = URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
+        'media' => $this->media->getKey(),
+        'filename' => $this->filename,
+    ]);
+
+    $this->get($url)->assertOk();
+});
+
+test('signed route with conversion query serves the conversion file', function (): void {
+    $url = URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
+        'media' => $this->media->getKey(),
+        'filename' => $this->filename,
+        'conversion' => 'thumb_400x400',
+    ]);
+
+    $response = $this->get($url);
+
+    $response->assertOk();
+    $response->assertHeader('Content-Disposition');
+    expect($response->streamedContent())->toBe('fake-thumb-bytes');
+});
+
+test('unsigned request to the private route is rejected', function (): void {
+    $this->get('/media-private/' . $this->media->getKey() . '/' . $this->filename)
+        ->assertStatus(403);
+});
+
+test('signed route with conversion query 404s when the conversion is not generated', function (): void {
+    $this->media->generated_conversions = [];
+    $this->media->save();
+
+    $url = URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
+        'media' => $this->media->getKey(),
+        'filename' => $this->filename,
+        'conversion' => 'thumb_400x400',
+    ]);
+
+    $this->get($url)->assertNotFound();
+});

--- a/tests/Feature/Web/PrivateMediaTest.php
+++ b/tests/Feature/Web/PrivateMediaTest.php
@@ -63,3 +63,15 @@ test('signed route with conversion query 404s when the conversion is not generat
 
     $this->get($url)->assertNotFound();
 });
+
+test('signed route with conversion query 404s when the conversion file is missing on disk', function (): void {
+    @unlink($this->media->getPath('thumb_400x400'));
+
+    $url = URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
+        'media' => $this->media->getKey(),
+        'filename' => $this->filename,
+        'conversion' => 'thumb_400x400',
+    ]);
+
+    $this->get($url)->assertNotFound();
+});

--- a/tests/Unit/Support/MediaLibrary/UrlGeneratorTest.php
+++ b/tests/Unit/Support/MediaLibrary/UrlGeneratorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use FluxErp\Models\Media;
+use FluxErp\Support\MediaLibrary\UrlGenerator;
+use Illuminate\Support\Str;
+use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+
+function makeGenerator(Media $media, ?Conversion $conversion = null): UrlGenerator
+{
+    $generator = app(UrlGenerator::class);
+    $generator->setMedia($media);
+    $generator->setPathGenerator(new DefaultPathGenerator());
+
+    if ($conversion !== null) {
+        $generator->setConversion($conversion);
+    }
+
+    return $generator;
+}
+
+function makeMediaOnDisk(string $disk, string $conversionsDisk, string $thumbnailKey = 'thumb_400x400'): Media
+{
+    // We can't rely on toMediaCollection() because it has side effects (writing actual files).
+    // For URL generation we only need a valid Media instance whose attributes drive the URL builder.
+    $media = Media::query()->forceCreate([
+        'model_type' => 'user',
+        'model_id' => test()->user->getKey(),
+        'uuid' => (string) Str::uuid(),
+        'collection_name' => 'default',
+        'name' => 'sample',
+        'file_name' => 'sample.pdf',
+        'mime_type' => 'application/pdf',
+        'disk' => $disk,
+        'conversions_disk' => $conversionsDisk,
+        'size' => 1024,
+        'manipulations' => '[]',
+        'custom_properties' => '[]',
+        'generated_conversions' => json_encode([$thumbnailKey => true]),
+        'responsive_images' => '[]',
+    ]);
+
+    return $media;
+}
+
+function makeThumbConversion(string $name = 'thumb_400x400'): Conversion
+{
+    return tap(new Conversion($name))
+        ->width(400)
+        ->height(400)
+        ->keepOriginalImageFormat();
+}
+
+test('serves originals on the private disk through the signed media.private route', function (): void {
+    $media = makeMediaOnDisk(disk: 'hetzner', conversionsDisk: 'public');
+
+    $url = makeGenerator($media)->getUrl();
+
+    expect($url)->toContain('/media-private/' . $media->getKey() . '/sample.pdf');
+    expect($url)->toContain('signature=');
+    expect($url)->not->toContain('conversion=');
+});
+
+test('serves conversions through the public disk URL when their disk is public', function (): void {
+    // VVO's actual layout: originals on hetzner, derivatives written to the local public disk.
+    // The generated thumb must be addressable via /storage/... — not signed-rerouted to the original.
+    $media = makeMediaOnDisk(disk: 'hetzner', conversionsDisk: 'public');
+    $conversion = makeThumbConversion();
+
+    $url = makeGenerator($media, $conversion)->getUrl();
+
+    expect($url)->toContain('/storage/' . $media->getKey() . '/conversions/sample-thumb_400x400.jpg');
+    expect($url)->not->toContain('/media-private/');
+    expect($url)->not->toContain('signature=');
+});
+
+test('signs the media.private route with a conversion parameter when the conversions disk is private', function (): void {
+    $media = makeMediaOnDisk(disk: 'hetzner', conversionsDisk: 'hetzner');
+    $conversion = makeThumbConversion();
+
+    $url = makeGenerator($media, $conversion)->getUrl();
+
+    expect($url)->toContain('/media-private/' . $media->getKey() . '/sample.pdf');
+    expect($url)->toContain('conversion=thumb_400x400');
+    expect($url)->toContain('signature=');
+});
+
+test('falls back to the Spatie default when both disks are public', function (): void {
+    $media = makeMediaOnDisk(disk: 'public', conversionsDisk: 'public');
+
+    expect(makeGenerator($media)->getUrl())
+        ->toContain('/storage/' . $media->getKey() . '/sample.pdf')
+        ->not->toContain('/media-private/');
+
+    expect(makeGenerator($media, makeThumbConversion())->getUrl())
+        ->toContain('/storage/' . $media->getKey() . '/conversions/sample-thumb_400x400.jpg')
+        ->not->toContain('/media-private/');
+});


### PR DESCRIPTION
## Problem

\`FluxErp\\Support\\MediaLibrary\\UrlGenerator::getUrl()\` chose between a signed \`media.private\` route and \`parent::getUrl()\` purely on the original \`\$media->disk\`. So for any media whose original lives on a private disk — even when a conversion was explicitly requested — it returned a signed URL to the **original** file, never to the generated derivative.

Concrete failure mode in production: VVO stores originals on a Hetzner S3 disk (\`disk=hetzner\`) and conversions on the local public disk (\`conversions_disk=public\`). The Cloud Browser's \`MediaGrid\` calls \`\$media->getUrl('thumb_400x400')\` and shipped the signed \`/media-private/{id}/{original}.pdf\` URL to the browser as a thumbnail \`<img src>\`. Result: 5–30 MB PDFs/images downloaded per tile, no actual thumbnail rendered.

## Fix

1. \`UrlGenerator\` now picks the *effective* disk based on whether a conversion is requested:
   - \`null\` conversion → \`\$media->disk\`
   - any conversion → \`\$media->conversions_disk\`
2. When that effective disk is \`public\`, fall through to \`parent::getUrl()\` and let Spatie produce the standard \`/storage/.../-thumb_400x400.jpg\` URL.
3. When the effective disk is private (i.e. the conversion itself needs auth), sign the \`media.private\` route and pass \`?conversion={name}\` so the route handler can serve the matching derivative.
4. The route closure moved into a single-action \`PrivateMediaController\`. With a conversion query parameter present, it streams the conversion file from the conversions disk (or 302s to a temporary URL for disks that support them); without it, returns the original (unchanged behavior).
5. \`404\` when a conversion query parameter is supplied for a conversion that wasn't generated.

## Compatibility

- Public-disk-only installs (originals on \`public\`): no change, both branches go through \`parent::getUrl()\`.
- Private-disk originals without conversions: unchanged — same signed \`media.private\` URL as before.
- Private-disk originals with a public conversions disk (VVO setup): now returns the public \`/storage/...\` thumbnail URL instead of a signed original URL.
- Private-disk originals with a private conversions disk: now signs the route with \`?conversion=…\` and the controller serves the derivative.

## Tests

- \`tests/Unit/Support/MediaLibrary/UrlGeneratorTest.php\`: 4 unit cases for each disk combination.
- \`tests/Feature/Web/PrivateMediaTest.php\`: 4 HTTP tests for the new controller (original, conversion served, unsigned rejected, ungenerated conversion → 404).

\`\`\`
Tests:    8 passed (19 assertions)
\`\`\`

## Summary by Sourcery

Serve media conversions and originals from the appropriate disk, signing private routes when needed and delegating conversion responses to a dedicated controller.

Bug Fixes:
- Ensure media conversions requested for media on private disks return URLs to the conversion files instead of the original files.

Enhancements:
- Determine the effective disk per request (original vs. conversion) when generating media URLs and append the conversion name to signed private routes where applicable.
- Introduce a dedicated PrivateMediaController to handle signed media-private requests for originals and conversions, including streaming or redirecting to temporary URLs for conversion files.

Tests:
- Add unit tests for UrlGenerator to cover combinations of original and conversion disks and URL generation behavior.
- Add feature tests for the media.private route to verify access control, original vs. conversion responses, and 404 handling for missing conversions.