### PR TITLE
Carry monitor accept/reject on all queue-monitor job toasts

### DIFF
--- a/src/Notifications/QueueMonitor/Job/JobProcessingNotification.php
+++ b/src/Notifications/QueueMonitor/Job/JobProcessingNotification.php
@@ -29,6 +29,8 @@ class JobProcessingNotification extends Notification implements HasToastNotifica
             ->title(__(':job_name is processing', ['job_name' => __($this->model->getJobName())]))
             ->description($this->model->message)
             ->persistent()
+            ->accept(unserialize($this->model->accept) ?: null)
+            ->reject(unserialize($this->model->reject) ?: null)
             ->progress($this->model->jobBatch?->progress ?? $this->model->progress)
             ->markAsRead()
             ->attributes([

--- a/src/Notifications/QueueMonitor/Job/JobStartedNotification.php
+++ b/src/Notifications/QueueMonitor/Job/JobStartedNotification.php
@@ -29,6 +29,8 @@ class JobStartedNotification extends Notification implements HasToastNotificatio
             ->title(__(':job_name started', ['job_name' => __($this->model->getJobName())]))
             ->description($this->model->message)
             ->persistent()
+            ->accept(unserialize($this->model->accept) ?: null)
+            ->reject(unserialize($this->model->reject) ?: null)
             ->progress($this->model->jobBatch?->progress ?? $this->model->progress)
             ->markAsRead()
             ->attributes([

--- a/tests/Unit/Notifications/QueueMonitor/Job/JobNotificationsAcceptRejectTest.php
+++ b/tests/Unit/Notifications/QueueMonitor/Job/JobNotificationsAcceptRejectTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use FluxErp\Models\QueueMonitor;
+use FluxErp\Models\User;
+use FluxErp\Notifications\QueueMonitor\Job\JobFinishedNotification;
+use FluxErp\Notifications\QueueMonitor\Job\JobProcessingNotification;
+use FluxErp\Notifications\QueueMonitor\Job\JobStartedNotification;
+use FluxErp\Support\Notification\ToastNotification\NotificationAction;
+
+beforeEach(function (): void {
+    $this->notifiable = User::factory()->create();
+
+    $this->action = NotificationAction::make()
+        ->label('Download')
+        ->url('https://example.test/storage/exports/test.xlsx')
+        ->download();
+});
+
+test('JobProcessingNotification carries the accept action stored on the monitor', function (): void {
+    $monitor = QueueMonitor::factory()->create([
+        'job_id' => 'job-with-accept',
+        'job_batch_id' => null,
+        'accept' => serialize($this->action),
+    ]);
+
+    $payload = (new JobProcessingNotification($monitor))->toArray($this->notifiable);
+
+    expect(data_get($payload, 'accept.label'))->toBe('Download');
+    expect(data_get($payload, 'accept.url'))->toBe('https://example.test/storage/exports/test.xlsx');
+    expect(data_get($payload, 'accept.download'))->toBeTrue();
+});
+
+test('JobStartedNotification carries the accept action stored on the monitor', function (): void {
+    $monitor = QueueMonitor::factory()->create([
+        'job_id' => 'started-with-accept',
+        'job_batch_id' => null,
+        'accept' => serialize($this->action),
+    ]);
+
+    $payload = (new JobStartedNotification($monitor))->toArray($this->notifiable);
+
+    expect(data_get($payload, 'accept.label'))->toBe('Download');
+    expect(data_get($payload, 'accept.url'))->toBe('https://example.test/storage/exports/test.xlsx');
+});
+
+test('JobProcessingNotification has no accept when the monitor has no accept', function (): void {
+    $monitor = QueueMonitor::factory()->create([
+        'job_id' => 'job-without-accept',
+        'job_batch_id' => null,
+        'accept' => null,
+    ]);
+
+    $payload = (new JobProcessingNotification($monitor))->toArray($this->notifiable);
+
+    expect(data_get($payload, 'accept'))->toBeNull();
+});
+
+test('JobFinishedNotification still carries the accept action stored on the monitor', function (): void {
+    $monitor = QueueMonitor::factory()->create([
+        'job_id' => 'finished-with-accept',
+        'job_batch_id' => null,
+        'accept' => serialize($this->action),
+    ]);
+
+    $payload = (new JobFinishedNotification($monitor))->toArray($this->notifiable);
+
+    expect(data_get($payload, 'accept.label'))->toBe('Download');
+    expect(data_get($payload, 'accept.url'))->toBe('https://example.test/storage/exports/test.xlsx');
+});


### PR DESCRIPTION
## Summary

- `JobStartedNotification` and `JobProcessingNotification` now read `accept` / `reject` from the `QueueMonitor`, matching `JobFinishedNotification`.
- All three share the same `toastId` and upsert in place, so whichever notification arrives last now carries the same action payload -- a delayed or reordered Processing broadcast can no longer overwrite the download button.
- Adds focused tests covering accept passthrough for all three notification classes.

## Summary by Sourcery

Ensure queue monitor job toast notifications consistently carry action payloads from the monitor.

Bug Fixes:
- Make JobStarted and JobProcessing queue monitor notifications include accept/reject actions stored on the monitor, consistent with JobFinished notifications.

Tests:
- Add unit tests verifying accept action passthrough and null handling for job queue monitor notifications.