### PR TITLE
Scroll the form pane of the purchase-invoice modal independently

### DIFF
--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -20,7 +20,7 @@
         x-on:close="$wire.resetEditForm()"
     >
         <div
-            class="grid h-[calc(100vh-5rem)] content-stretch gap-4 overflow-hidden sm:grid-cols-2"
+            class="grid h-full min-h-0 content-stretch gap-4 overflow-hidden sm:grid-cols-2"
             x-data="{
                 showPayment: false,
                 showBank: false,

--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -17,9 +17,10 @@
         scope="fullscreen"
         scrollable
         persistent
+        x-on:close="$wire.resetEditForm()"
     >
         <div
-            class="grid h-full min-h-screen content-stretch gap-4 sm:grid-cols-2"
+            class="grid h-[calc(100vh-5rem)] content-stretch gap-4 overflow-hidden sm:grid-cols-2"
             x-data="{
                 showPayment: false,
                 showBank: false,
@@ -50,7 +51,7 @@
                 @show
             @show
 
-            <div class="flex flex-col gap-4 overflow-auto px-2">
+            <div class="flex min-h-0 flex-col gap-4 overflow-y-auto px-2">
                 @section('tenant')
                     @if(count($tenants ?? []) > 1)
                         <div

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -148,6 +148,8 @@ class PurchaseInvoiceList extends BaseDataTable
     public function resetEditForm(): void
     {
         $this->resetErrorBag();
+        $this->purchaseInvoiceForm->reset();
+        $this->mediaForm->reset();
     }
 
     #[Renderless]

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -145,6 +145,12 @@ class PurchaseInvoiceList extends BaseDataTable
     }
 
     #[Renderless]
+    public function resetEditForm(): void
+    {
+        $this->resetErrorBag();
+    }
+
+    #[Renderless]
     public function fillFromSelectedContact(Contact $contact): void
     {
         $bankConnection = $contact->contactBankConnections()->latest()->first();

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -146,8 +146,8 @@ class ViewServiceProvider extends ServiceProvider
 
         TallStackUi::customize()
             ->modal('fullscreen')
-            ->block('wrapper.fourth', 'dark:bg-dark-700 relative flex w-full transform flex-col rounded-xl bg-white text-left shadow-xl transition-all min-h-screen')
-            ->block('body', 'dark:text-dark-300 grow rounded-b-xl py-5 text-gray-700 px-4 min-h-screen');
+            ->block('wrapper.fourth', 'dark:bg-dark-700 relative flex h-screen w-full transform flex-col overflow-hidden rounded-xl bg-white text-left shadow-xl transition-all')
+            ->block('body', 'dark:text-dark-300 min-h-0 flex-1 rounded-b-xl py-5 text-gray-700 px-4');
 
         TallStackUi::customize()
             ->modal('headless')


### PR DESCRIPTION
## Summary

- Fix scrolling on the edit purchase-invoice modal: the right (form) pane could not reach its own bottom because the grid was forced to \`min-h-screen content-stretch\`, so the column grew with content instead of capping at a height that \`overflow-auto\` could act on.
- The grid now uses a viewport-minus-footer fixed height with \`overflow-hidden\`; the form column gets \`min-h-0 overflow-y-auto\` so it scrolls inside that frame while the PDF column stays put.
- Reset the component error bag on modal close via a new \`Renderless\` \`resetEditForm()\` method invoked from \`x-on:close\`, so reopening on a different invoice no longer carries stale validation errors.

## Summary by Sourcery

Adjust the purchase-invoice edit modal layout to allow the form pane to scroll independently and clear validation state when the modal is closed.

Bug Fixes:
- Allow the purchase-invoice edit form pane to scroll to its full content height while keeping the PDF pane fixed.
- Clear stale validation errors when reopening the purchase-invoice edit modal by resetting the component error bag on close.

Enhancements:
- Use a fixed viewport-based height and overflow handling for the purchase-invoice edit modal grid to better constrain content within the modal.