### PR TITLE
Stop the print header from clipping the first body line on continuation pages

### DIFF
--- a/resources/views/components/print/header.blade.php
+++ b/resources/views/components/print/header.blade.php
@@ -16,6 +16,7 @@
                 >
                     <h2
                         style="
+                            margin: 0;
                             font-size: 20px;
                             line-height: 28px;
                             font-weight: 600;
@@ -23,7 +24,10 @@
                     >
                         {{ $subject ?? '' }}
                     </h2>
-                    <div class="page-count" style="font-size: 12px"></div>
+                    <div
+                        class="page-count"
+                        style="margin: 0; font-size: 12px; line-height: 16px"
+                    ></div>
                 </div>
             @show
             @section('logo')

--- a/tests/Unit/View/Printing/HeaderTest.php
+++ b/tests/Unit/View/Printing/HeaderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use FluxErp\Actions\Printing;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Language;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use Illuminate\Support\Str;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+
+    $address = Address::factory()->create([
+        'company' => Str::uuid()->toString(),
+        'contact_id' => $contact->getKey(),
+    ]);
+
+    $orderType = OrderType::factory()
+        ->create([
+            'print_layouts' => ['invoice'],
+            'order_type_enum' => OrderTypeEnum::Order,
+        ]);
+
+    $paymentType = PaymentType::factory()
+        ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $this->order = Order::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'language_id' => Language::factory()->create()->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'currency_id' => Currency::factory()->create(['is_default' => true])->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'address_delivery_id' => $address->getKey(),
+        'is_locked' => false,
+    ]);
+});
+
+test('continuation-page header keeps the subject heading within its allotted vertical space', function (): void {
+    $this->withoutVite();
+
+    $html = Printing::make([
+        'model_type' => $this->order->getMorphClass(),
+        'model_id' => $this->order->getKey(),
+        'view' => 'invoice',
+        'preview' => false,
+        'html' => true,
+    ])
+        ->validate()
+        ->execute()
+        ->toHtml();
+
+    // dompdf applies UA-style margins to <h2>; on the fixed continuation-page
+    // header that pushes the box past its -20mm top offset and overlaps the
+    // first line of body content on page 2+. The header's <h2> must zero its
+    // margins so the header's rendered height stays within 20mm.
+    expect($html)->toMatch('/<header\b[^>]*>.*?<h2\b[^>]*style="[^"]*\bmargin:\s*0\b/s');
+});


### PR DESCRIPTION
## Summary

- Reset the print header's \`<h2>\` margin and lock the page-count line-height so the fixed continuation-page header stays inside its 20mm allotted area.
- Without the reset, dompdf applied the UA default (~13px top + 13px bottom) on top of the 28px line-height; the header's box exceeded 20mm and overlapped the first line of body content on pages 2+.
- Added a unit test that asserts the rendered \`<h2>\` carries \`margin: 0\` inline, so the reset cannot be silently dropped again.

## Summary by Sourcery

Ensure printed continuation-page headers stay within their allotted height to avoid overlapping body content.

Bug Fixes:
- Prevent the print header subject and page-count elements from clipping or overlapping the first body line on continuation pages by constraining their vertical space.

Tests:
- Add a unit test that verifies the rendered continuation-page header subject applies an inline zero margin to prevent regressions.