### PR TITLE
Pin Composer to v2 in CI image, force rebuild

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) pdo_mysql gd zip bcmath intl exif pcntl sockets xsl \
     && pecl install imagick redis xdebug && docker-php-ext-enable imagick redis xdebug \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Why
The CI image at `ghcr.io/team-nifty-gmbh/flux-ci:php8.5` was last built on 2026-04-15 and ships an older Composer. GitHub Actions has begun rotating `GITHUB_TOKEN` between two formats: the legacy opaque `ghs_xxxxxxxx` and a JWT-style `ghs_<id>_<header>.<payload>.<signature>`.

The Composer version inside the current image rejects the JWT format with `Your github oauth token for github.com contains invalid characters`, breaking `composer config --global github-oauth.github.com ${{ github.token }}` in workflows that depend on this image (mega-meal PR #59 hit it). Composer ≥ 2.8 accepts the new format.

## What
- Adds `--2` to the Composer installer invocation in the CI Dockerfile.
- That alone bumps Composer to the latest 2.x release at image-build time (which is ≥ 2.8 today and handles JWT tokens).
- The file change also triggers `build-ci-image.yml` (paths-filter), so the `:php8.5` tag gets refreshed.

## Effect
After merge, the next CI image build pushes a fresh `ghcr.io/team-nifty-gmbh/flux-ci:php8.5`. All downstream repos pull the new image automatically on their next CI run — no per-repo workflow edits needed.

## Verification
Once the image is rebuilt: re-run any composer-failing job (e.g. mega-meal PR #59 most recent failed Tests job).