### PR TITLE
fix(queue-monitor): resolve queue from connection config when JobQueued has no queue

### DIFF
--- a/src/Support/QueueMonitor/QueueMonitorManager.php
+++ b/src/Support/QueueMonitor/QueueMonitorManager.php
@@ -137,16 +137,19 @@ class QueueMonitorManager
     {
         $now = Carbon::now();
 
+        $queue = $event->job->getQueue()
+            ?: config("queue.connections.{$event->connectionName}.queue", 'default');
+
         $monitor = resolve_static(QueueMonitor::class, 'query')
             ->where('job_id', $jobId = static::getJobId($event->job))
-            ->where('queue', $event->job->getQueue() ?? config('queue.default'))
+            ->where('queue', $queue)
             ->whereState('state', Queued::class)
             ->firstOrNew();
 
         $monitor->fill([
             'job_uuid' => $event->job->uuid(),
             'job_id' => static::getJobId($event->job),
-            'queue' => $event->job->getQueue() ?: config('queue.default'),
+            'queue' => $queue,
             'name' => static::getJobName($event),
             'started_at' => $now,
             'started_at_exact' => $now->format('Y-m-d H:i:s.u'),

--- a/src/Support/QueueMonitor/QueueMonitorManager.php
+++ b/src/Support/QueueMonitor/QueueMonitorManager.php
@@ -177,7 +177,8 @@ class QueueMonitorManager
                 'job_batch_id' => $event->job->batchId ?? null,
                 'job_id' => $event->id,
                 'name' => static::getJobName($event),
-                'queue' => $event->job->queue ?: 'default',
+                'queue' => $event->queue
+                    ?: config("queue.connections.{$event->connectionName}.queue", 'default'),
                 'state' => Queued::class,
                 'queued_at' => now(),
                 'data' => $data ?? null,

--- a/tests/Unit/Support/QueueMonitor/QueueMonitorManagerTest.php
+++ b/tests/Unit/Support/QueueMonitor/QueueMonitorManagerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use FluxErp\Jobs\ExportDataTableJob;
+use FluxErp\Models\QueueMonitor;
+use FluxErp\States\QueueMonitor\Running;
+use FluxErp\Support\QueueMonitor\QueueMonitorManager;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobQueued;
+
+test('jobQueued stores the resolved event queue, not the unset job property', function (): void {
+    $job = new ExportDataTableJob(
+        component: serialize(new stdClass()),
+        modelClass: 'FluxErp\\Models\\Tenant',
+        columns: ['name'],
+        userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
+    );
+
+    QueueMonitorManager::handle(new JobQueued(
+        connectionName: 'redis',
+        queue: 'flux_tenant_queue',
+        id: 'job-id-1',
+        payload: '',
+        job: $job,
+        delay: 0,
+    ));
+
+    expect(QueueMonitor::count())->toBe(1);
+    expect(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
+});
+
+test('jobQueued falls back to the connection default queue when the event queue is null', function (): void {
+    config()->set('queue.connections.redis.queue', 'flux_tenant_queue');
+
+    $job = new ExportDataTableJob(
+        component: serialize(new stdClass()),
+        modelClass: 'FluxErp\\Models\\Tenant',
+        columns: ['name'],
+        userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
+    );
+
+    QueueMonitorManager::handle(new JobQueued(
+        connectionName: 'redis',
+        queue: null,
+        id: 'job-id-null-queue',
+        payload: '',
+        job: $job,
+        delay: 0,
+    ));
+
+    expect(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
+});
+
+test('jobProcessing reuses the QueueMonitor created by a null-queue dispatch on the same connection', function (): void {
+    config()->set('queue.connections.redis.queue', 'flux_tenant_queue');
+
+    $userJob = new ExportDataTableJob(
+        component: serialize(new stdClass()),
+        modelClass: 'FluxErp\\Models\\Tenant',
+        columns: ['name'],
+        userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
+    );
+
+    QueueMonitorManager::handle(new JobQueued(
+        connectionName: 'redis',
+        queue: null,
+        id: 'job-id-1',
+        payload: '',
+        job: $userJob,
+        delay: 0,
+    ));
+
+    expect(QueueMonitor::count())->toBe(1);
+
+    $queueJob = Mockery::mock(Job::class);
+    $queueJob->shouldReceive('resolveName')->andReturn(ExportDataTableJob::class);
+    $queueJob->shouldReceive('getJobId')->andReturn('job-id-1');
+    $queueJob->shouldReceive('getRawBody')->andReturn('');
+    $queueJob->shouldReceive('getQueue')->andReturn('flux_tenant_queue');
+    $queueJob->shouldReceive('uuid')->andReturn('uuid-1');
+    $queueJob->shouldReceive('attempts')->andReturn(1);
+    $queueJob->shouldReceive('payload')->andReturn(['data' => ['commandName' => ExportDataTableJob::class]]);
+
+    QueueMonitorManager::handle(new JobProcessing(
+        connectionName: 'redis',
+        job: $queueJob,
+    ));
+
+    expect(QueueMonitor::count())->toBe(1);
+    expect(QueueMonitor::first()->state)->toBeInstanceOf(Running::class);
+});

--- a/tests/Unit/Support/QueueMonitor/QueueMonitorManagerTest.php
+++ b/tests/Unit/Support/QueueMonitor/QueueMonitorManagerTest.php
@@ -8,84 +8,83 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobQueued;
 
-test('jobQueued stores the resolved event queue, not the unset job property', function (): void {
-    $job = new ExportDataTableJob(
+beforeEach(function (): void {
+    $this->makeExportJob = fn () => new ExportDataTableJob(
         component: serialize(new stdClass()),
         modelClass: 'FluxErp\\Models\\Tenant',
         columns: ['name'],
         userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
     );
 
+    $this->makeQueueJob = function (string $jobId, string $queue, string $uuid) {
+        $queueJob = Mockery::mock(Job::class);
+        $queueJob->shouldReceive('resolveName')->andReturn(ExportDataTableJob::class);
+        $queueJob->shouldReceive('getJobId')->andReturn($jobId);
+        $queueJob->shouldReceive('getRawBody')->andReturn('');
+        $queueJob->shouldReceive('getQueue')->andReturn($queue);
+        $queueJob->shouldReceive('uuid')->andReturn($uuid);
+        $queueJob->shouldReceive('attempts')->andReturn(1);
+        $queueJob->shouldReceive('payload')->andReturn(['data' => ['commandName' => ExportDataTableJob::class]]);
+
+        return $queueJob;
+    };
+
+    $this->originalRedisQueue = config('queue.connections.redis.queue');
+});
+
+afterEach(function (): void {
+    config()->set('queue.connections.redis.queue', $this->originalRedisQueue);
+});
+
+test('jobQueued stores the resolved event queue, not the unset job property', function (): void {
     QueueMonitorManager::handle(new JobQueued(
         connectionName: 'redis',
         queue: 'flux_tenant_queue',
         id: 'job-id-1',
         payload: '',
-        job: $job,
+        job: ($this->makeExportJob)(),
         delay: 0,
     ));
 
-    expect(QueueMonitor::count())->toBe(1);
-    expect(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
+    expect(QueueMonitor::count())->toBe(1)
+        ->and(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
 });
 
 test('jobQueued falls back to the connection default queue when the event queue is null', function (): void {
     config()->set('queue.connections.redis.queue', 'flux_tenant_queue');
-
-    $job = new ExportDataTableJob(
-        component: serialize(new stdClass()),
-        modelClass: 'FluxErp\\Models\\Tenant',
-        columns: ['name'],
-        userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
-    );
 
     QueueMonitorManager::handle(new JobQueued(
         connectionName: 'redis',
         queue: null,
         id: 'job-id-null-queue',
         payload: '',
-        job: $job,
+        job: ($this->makeExportJob)(),
         delay: 0,
     ));
 
-    expect(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
+    expect(QueueMonitor::count())->toBe(1)
+        ->and(QueueMonitor::first()->queue)->toBe('flux_tenant_queue');
 });
 
 test('jobProcessing reuses the QueueMonitor created by a null-queue dispatch on the same connection', function (): void {
     config()->set('queue.connections.redis.queue', 'flux_tenant_queue');
-
-    $userJob = new ExportDataTableJob(
-        component: serialize(new stdClass()),
-        modelClass: 'FluxErp\\Models\\Tenant',
-        columns: ['name'],
-        userMorph: $this->user->getMorphClass() . ':' . $this->user->getKey(),
-    );
 
     QueueMonitorManager::handle(new JobQueued(
         connectionName: 'redis',
         queue: null,
         id: 'job-id-1',
         payload: '',
-        job: $userJob,
+        job: ($this->makeExportJob)(),
         delay: 0,
     ));
 
     expect(QueueMonitor::count())->toBe(1);
 
-    $queueJob = Mockery::mock(Job::class);
-    $queueJob->shouldReceive('resolveName')->andReturn(ExportDataTableJob::class);
-    $queueJob->shouldReceive('getJobId')->andReturn('job-id-1');
-    $queueJob->shouldReceive('getRawBody')->andReturn('');
-    $queueJob->shouldReceive('getQueue')->andReturn('flux_tenant_queue');
-    $queueJob->shouldReceive('uuid')->andReturn('uuid-1');
-    $queueJob->shouldReceive('attempts')->andReturn(1);
-    $queueJob->shouldReceive('payload')->andReturn(['data' => ['commandName' => ExportDataTableJob::class]]);
-
     QueueMonitorManager::handle(new JobProcessing(
         connectionName: 'redis',
-        job: $queueJob,
+        job: ($this->makeQueueJob)('job-id-1', 'flux_tenant_queue', 'uuid-1'),
     ));
 
-    expect(QueueMonitor::count())->toBe(1);
-    expect(QueueMonitor::first()->state)->toBeInstanceOf(Running::class);
+    expect(QueueMonitor::count())->toBe(1)
+        ->and(QueueMonitor::first()->state)->toBeInstanceOf(Running::class);
 });


### PR DESCRIPTION
## Summary

Fixes a duplicate `QueueMonitor` row that was created on every dispatch when the job was queued without an explicit `onQueue()` call and the connection's default queue differs from `'default'`.

Laravel emits `JobQueued` with `$event->queue = null` when nothing was passed to `dispatch()->onQueue(...)`. `QueueMonitorManager::jobQueued()` previously read `$event->job->queue` (the job class property, also null in that path) and fell back to `'default'`. `jobProcessing()` resolves the runtime queue via `$event->job->getQueue()`, which is the connection's configured default queue (e.g. a tenant-specific queue).

The mismatch meant `firstOrNew(... whereState Queued)` in `jobProcessing()` could not find the Queued monitor stored at dispatch time, so it created a second monitor and then marked the original as stale. Each export then produced:

1. An extra `JobFinishedNotification` for the stale monitor with `accept = null` -- which the frontend persisted with no download action.
2. A `UniqueConstraintViolationException` when the real `JobFinishedNotification` tried to insert the same UUID with the real download URL.

Result: the toast on the user's screen showed "Export ist beendet" but no download button.

Read `$event->queue` first and fall back to the connection's configured queue so the row stored at dispatch time matches what the worker resolves.

## Test plan

- `testbench package:test --filter QueueMonitorManagerTest`

## Summary by Sourcery

Ensure QueueMonitor records use the effective queue name resolved from the connection configuration so queued and processing events refer to the same monitor entry.

Bug Fixes:
- Prevent duplicate QueueMonitor rows when jobs are dispatched without an explicit queue on connections whose default queue is not `default`.

Tests:
- Add unit tests covering queue resolution from JobQueued events, fallback to the connection default queue, and reuse of the existing QueueMonitor during job processing.