### PR TITLE
Add stack hook for extending bundle product modal fields

### DIFF
--- a/resources/views/livewire/product/bundle-list.blade.php
+++ b/resources/views/livewire/product/bundle-list.blade.php
@@ -64,6 +64,7 @@
                 :label="__('Count')"
                 :min="0.01"
             />
+            @stack('product-bundle-modal-fields')
         </div>
         <x-slot:footer>
             <x-button


### PR DESCRIPTION
## Summary
- Adds `@stack('product-bundle-product-modal-fields')` inside the bundle product edit modal body, right after the count input
- Lets downstream applications push additional fields into the modal without overriding the entire view

## Summary by Sourcery

New Features:
- Introduce a Blade stack hook in the bundle product modal body for injecting additional fields from downstream applications.