### PR TITLE
Skip free-text positions when numbering order position slugs

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1109,55 +1109,7 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
 
     public function recalculateOrderPositionSlugPositions(): static
     {
-        DB::table('order_positions')
-            ->where('order_id', $this->getKey())
-            ->whereNull('parent_id')
-            ->update([
-                'slug_position' => DB::raw('LPAD(sort_number, 8, "0")'),
-            ]);
-
-        $query = "
-            WITH RECURSIVE position_hierarchy AS (
-                SELECT
-                    id,
-                    parent_id,
-                    order_id,
-                    slug_position,
-                    sort_number,
-                    0 AS level
-                FROM
-                    order_positions
-                WHERE
-                    order_id = ? AND parent_id IS NULL
-
-                UNION ALL
-
-                SELECT
-                    c.id,
-                    c.parent_id,
-                    c.order_id,
-                    CONCAT(p.slug_position, '.', LPAD(c.sort_number, 8, '0')) AS slug_position,
-                    c.sort_number,
-                    p.level + 1 AS level
-                FROM
-                    position_hierarchy p
-                JOIN
-                    order_positions c ON p.id = c.parent_id AND c.order_id = ?
-            )
-
-            UPDATE order_positions op,
-                   position_hierarchy ph
-            SET op.slug_position = ph.slug_position
-            WHERE op.id = ph.id
-              AND op.order_id = ?
-              AND op.parent_id IS NOT NULL;
-        ";
-
-        DB::statement($query, [
-            $this->getKey(),
-            $this->getKey(),
-            $this->getKey(),
-        ]);
+        $this->reslugOrderPositionsUnder(null, null);
 
         return $this;
     }
@@ -1338,6 +1290,39 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
 
         if ($orderTypeId = data_get($info, 'order_type_id')) {
             $builder->where('order_type_id', $orderTypeId);
+        }
+    }
+
+    protected function reslugOrderPositionsUnder(?int $parentId, ?string $parentSlug): void
+    {
+        $counter = 0;
+
+        $positions = resolve_static(OrderPosition::class, 'query')
+            ->where('order_id', $this->getKey())
+            ->when(
+                is_null($parentId),
+                fn (Builder $query) => $query->whereNull('parent_id'),
+                fn (Builder $query) => $query->where('parent_id', $parentId),
+            )
+            ->orderBy('sort_number')
+            ->get(['id', 'is_free_text']);
+
+        foreach ($positions as $position) {
+            if ($position->is_free_text) {
+                $newSlug = null;
+            } else {
+                $counter++;
+                $segment = str_pad((string) $counter, 8, '0', STR_PAD_LEFT);
+                $newSlug = is_null($parentSlug) ? $segment : $parentSlug . '.' . $segment;
+            }
+
+            DB::table('order_positions')
+                ->where('id', $position->getKey())
+                ->update(['slug_position' => $newSlug]);
+
+            if (! $position->is_free_text) {
+                $this->reslugOrderPositionsUnder($position->getKey(), $newSlug);
+            }
         }
     }
 

--- a/tests/Unit/Models/OrderRecalculateSlugPositionsTest.php
+++ b/tests/Unit/Models/OrderRecalculateSlugPositionsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order]);
+
+    $this->order = Order::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'address_delivery_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'is_locked' => false,
+    ]);
+});
+
+test('free text positions do not consume a slug number', function (): void {
+    $first = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sort_number' => 1,
+        'is_free_text' => false,
+    ]);
+    $freeText = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sort_number' => 2,
+        'is_free_text' => true,
+    ]);
+    $third = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sort_number' => 3,
+        'is_free_text' => false,
+    ]);
+
+    $this->order->recalculateOrderPositionSlugPositions();
+
+    expect($first->fresh()->slug_position)->toBe('1')
+        ->and(DB::table('order_positions')->where('id', $freeText->getKey())->value('slug_position'))->toBeNull()
+        ->and($third->fresh()->slug_position)->toBe('2');
+});
+
+test('free text children do not consume a slug number under their parent', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sort_number' => 1,
+        'is_free_text' => false,
+    ]);
+    $childOne = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'parent_id' => $parent->getKey(),
+        'sort_number' => 1,
+        'is_free_text' => false,
+    ]);
+    $freeTextChild = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'parent_id' => $parent->getKey(),
+        'sort_number' => 2,
+        'is_free_text' => true,
+    ]);
+    $childThree = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'parent_id' => $parent->getKey(),
+        'sort_number' => 3,
+        'is_free_text' => false,
+    ]);
+
+    $this->order->recalculateOrderPositionSlugPositions();
+
+    expect($parent->fresh()->slug_position)->toBe('1')
+        ->and($childOne->fresh()->slug_position)->toBe('1.1')
+        ->and(DB::table('order_positions')->where('id', $freeTextChild->getKey())->value('slug_position'))->toBeNull()
+        ->and($childThree->fresh()->slug_position)->toBe('1.2');
+});
+
+test('order with only free text positions assigns no slug numbers', function (): void {
+    $freeText = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'sort_number' => 1,
+        'is_free_text' => true,
+    ]);
+
+    $this->order->recalculateOrderPositionSlugPositions();
+
+    expect(DB::table('order_positions')->where('id', $freeText->getKey())->value('slug_position'))->toBeNull();
+});


### PR DESCRIPTION
## Summary

- \`Order::recalculateOrderPositionSlugPositions\` no longer counts \`is_free_text\` positions into the displayed numbering. A free-text row gets its \`slug_position\` cleared; its non-free-text siblings keep a consecutive 1, 2, 3 sequence instead of jumping over the hidden row.
- The recursion that used to live in a recursive SQL CTE is now a small PHP helper (\`reslugOrderPositionsUnder\`) that walks each parent group with its own counter. The Eloquent saved hook stays one level deep because the helper writes via \`DB::table()->update()\`.
- Adds unit tests covering top-level free-text, free-text children inside a numbered parent, and an order that holds only free-text rows.

## Summary by Sourcery

Adjust order position slug recalculation to skip free-text positions and ensure consecutive numbering for non-free-text positions, including nested structures.

Bug Fixes:
- Exclude free-text order positions from consuming slug numbers while maintaining contiguous numbering for visible positions.
- Ensure child positions under a parent are numbered consecutively even when free-text children are present.
- Prevent slug numbers from being assigned when an order consists only of free-text positions.

Enhancements:
- Replace the recursive SQL CTE for slug computation with a PHP helper that traverses the order position hierarchy and updates slugs iteratively.

Tests:
- Add unit tests covering top-level free-text positions, free-text children under a numbered parent, and orders containing only free-text positions.