### PR TITLE
fix livewire / alpine js racing condition

### DIFF
--- a/resources/views/livewire/features/notifications.blade.php
+++ b/resources/views/livewire/features/notifications.blade.php
@@ -27,7 +27,11 @@
         <x-slide
             id="notifications-slide"
             scope="notifications"
-            x-on:close="$wire.closeNotifications().then(() => $dispatch('notifications:clear'))"
+            x-on:close="
+                $wire
+                    .closeNotifications()
+                    .then(() => $dispatch('notifications:clear'))
+            "
         >
             <div
                 x-data="{

--- a/resources/views/livewire/features/notifications.blade.php
+++ b/resources/views/livewire/features/notifications.blade.php
@@ -27,7 +27,7 @@
         <x-slide
             id="notifications-slide"
             scope="notifications"
-            x-on:close="$wire.closeNotifications()"
+            x-on:close="$wire.closeNotifications().then(() => $dispatch('notifications:clear'))"
         >
             <div
                 x-data="{

--- a/src/Livewire/Features/Notifications.php
+++ b/src/Livewire/Features/Notifications.php
@@ -7,7 +7,6 @@ use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 
@@ -26,8 +25,6 @@ class Notifications extends Component
 
     public function render(): View|Factory|Application
     {
-        Log::info('notifications created');
-
         return view('flux::livewire.features.notifications');
     }
 

--- a/src/Livewire/Features/Notifications.php
+++ b/src/Livewire/Features/Notifications.php
@@ -7,6 +7,7 @@ use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 
@@ -25,6 +26,8 @@ class Notifications extends Component
 
     public function render(): View|Factory|Application
     {
+        Log::info('notifications created');
+
         return view('flux::livewire.features.notifications');
     }
 
@@ -48,10 +51,6 @@ class Notifications extends Component
     public function closeNotifications(): void
     {
         $this->loaded = 0;
-
-        $this->js(<<<'JS'
-            removeAll();
-        JS);
     }
 
     #[Renderless]


### PR DESCRIPTION
removed
` $this->js(<<<'JS'
            removeAll();
        JS);` from closeNotifications -> the js runs after the modal is closed, which results removeAll not defined -> thats why one could not open the notification slide on a second attempt 

dispatching now removeAll from blade file 

Please test before approving

## Summary by Sourcery

Fix notification modal closing behavior to avoid frontend race conditions between Livewire and Alpine.

Bug Fixes:
- Prevent errors when closing the notifications slide by moving the notifications clearing logic from a delayed Livewire JS call to an Alpine event dispatch on close.

Enhancements:
- Add server-side logging when the notifications component is rendered to aid debugging of notification lifecycle issues.