### PR TITLE
Make Login::$email nullable to fix uninitialized property error

### DIFF
--- a/src/Livewire/Auth/Login.php
+++ b/src/Livewire/Auth/Login.php
@@ -23,7 +23,7 @@ class Login extends Component
     use Actions;
 
     #[Rule(['required', 'email'])]
-    public string $email;
+    public ?string $email = null;
 
     public ?string $password = null;
 


### PR DESCRIPTION
The login form's Livewire snapshot ships email as null. Without a default, any read of $email before the user types throws "must not be accessed before initialization". The required+email rule still catches empty input.

## Summary by Sourcery

Bug Fixes:
- Prevent uninitialized property errors by defaulting the login email field to null instead of requiring prior assignment.