### PR TITLE
Accept Ticket::mount() $id as string to avoid TypeError on garbage URLs

### DIFF
--- a/src/Livewire/Ticket/Ticket.php
+++ b/src/Livewire/Ticket/Ticket.php
@@ -34,6 +34,8 @@ class Ticket extends Component
 
     public function mount(string $id): void
     {
+        abort_if(! ctype_digit($id), 404);
+
         $this->fetchTicket((int) $id);
     }
 

--- a/src/Livewire/Ticket/Ticket.php
+++ b/src/Livewire/Ticket/Ticket.php
@@ -32,9 +32,9 @@ class Ticket extends Component
 
     public array $ticketTypes;
 
-    public function mount(int $id): void
+    public function mount(string $id): void
     {
-        $this->fetchTicket($id);
+        $this->fetchTicket((int) $id);
     }
 
     public function render(): View


### PR DESCRIPTION
Sibling Task and Project mount() signatures take string $id, so URLs like /tickets/undefined get a 404 from firstOrFail() instead of a 500. Cast to int before forwarding to fetchTicket() to keep its existing ?int signature.

## Summary by Sourcery

Bug Fixes:
- Prevent a TypeError in Ticket::mount() by accepting string IDs (including garbage values) and casting them before fetching the ticket.