### PR TITLE
Fix tenant postal_address_one_line to include city after postcode

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -114,7 +114,7 @@ class Tenant extends FluxModel implements HasMedia
                 array_filter([
                     $attributes['name'] ?? null,
                     $attributes['street'] ?? null,
-                    trim($attributes['postcode'] ?? null . ' ' . $attributes['city'] ?? null),
+                    trim(($attributes['postcode'] ?? '') . ' ' . ($attributes['city'] ?? '')) ?: null,
                 ])
             )
         );

--- a/tests/Unit/Models/TenantPostalAddressOneLineTest.php
+++ b/tests/Unit/Models/TenantPostalAddressOneLineTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use FluxErp\Models\Tenant;
+
+it('combines name street postcode and city in postal_address_one_line', function (): void {
+    $tenant = new Tenant([
+        'name' => 'Acme Corp',
+        'street' => 'Example Street 1',
+        'postcode' => '12345',
+        'city' => 'Example City',
+    ]);
+
+    expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1 | 12345 Example City');
+});
+
+it('includes city after postcode in postal_address_one_line', function (): void {
+    $tenant = new Tenant([
+        'name' => 'Acme Corp',
+        'street' => 'Example Street 1',
+        'postcode' => '12345',
+        'city' => 'Example City',
+    ]);
+
+    expect($tenant->postal_address_one_line)->toContain('12345 Example City');
+});
+
+it('omits postcode segment from postal_address_one_line when both postcode and city are empty', function (): void {
+    $tenant = new Tenant([
+        'name' => 'Acme Corp',
+        'street' => 'Example Street 1',
+    ]);
+
+    expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1');
+});
+
+it('shows only postcode in postal_address_one_line when city is missing', function (): void {
+    $tenant = new Tenant([
+        'name' => 'Acme Corp',
+        'street' => 'Example Street 1',
+        'postcode' => '12345',
+    ]);
+
+    expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1 | 12345');
+});
+
+it('shows only city in postal_address_one_line when postcode is missing', function (): void {
+    $tenant = new Tenant([
+        'name' => 'Acme Corp',
+        'street' => 'Example Street 1',
+        'city' => 'Example City',
+    ]);
+
+    expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1 | Example City');
+});

--- a/tests/Unit/Models/TenantPostalAddressOneLineTest.php
+++ b/tests/Unit/Models/TenantPostalAddressOneLineTest.php
@@ -3,7 +3,7 @@
 use FluxErp\Models\Tenant;
 
 it('combines name street postcode and city in postal_address_one_line', function (): void {
-    $tenant = new Tenant([
+    $tenant = Tenant::factory()->create([
         'name' => 'Acme Corp',
         'street' => 'Example Street 1',
         'postcode' => '12345',
@@ -13,40 +13,33 @@ it('combines name street postcode and city in postal_address_one_line', function
     expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1 | 12345 Example City');
 });
 
-it('includes city after postcode in postal_address_one_line', function (): void {
-    $tenant = new Tenant([
-        'name' => 'Acme Corp',
-        'street' => 'Example Street 1',
-        'postcode' => '12345',
-        'city' => 'Example City',
-    ]);
-
-    expect($tenant->postal_address_one_line)->toContain('12345 Example City');
-});
-
 it('omits postcode segment from postal_address_one_line when both postcode and city are empty', function (): void {
-    $tenant = new Tenant([
+    $tenant = Tenant::factory()->create([
         'name' => 'Acme Corp',
         'street' => 'Example Street 1',
+        'postcode' => null,
+        'city' => null,
     ]);
 
     expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1');
 });
 
 it('shows only postcode in postal_address_one_line when city is missing', function (): void {
-    $tenant = new Tenant([
+    $tenant = Tenant::factory()->create([
         'name' => 'Acme Corp',
         'street' => 'Example Street 1',
         'postcode' => '12345',
+        'city' => null,
     ]);
 
     expect($tenant->postal_address_one_line)->toBe('Acme Corp | Example Street 1 | 12345');
 });
 
 it('shows only city in postal_address_one_line when postcode is missing', function (): void {
-    $tenant = new Tenant([
+    $tenant = Tenant::factory()->create([
         'name' => 'Acme Corp',
         'street' => 'Example Street 1',
+        'postcode' => null,
         'city' => 'Example City',
     ]);
 


### PR DESCRIPTION
## Summary
- `postcode` and `city` were combined with `??` having lower precedence than `.`, so the expression collapsed to just `$attributes['postcode'] ?? ' ' . $attributes['city']` and the city was always dropped
- Fix wraps both sides of the concatenation in `(... ?? '')`, then `?: null` keeps an empty segment out of the `array_filter` chain
- Adds a unit test covering full data, missing city, missing postcode, and both empty

## Summary by Sourcery

Fix tenant postal address formatting so postcode and city are correctly combined on one line while omitting empty postcode/city segments.

Bug Fixes:
- Correct postal_address_one_line composition to ensure both postcode and city are included when present and omitted when empty.

Tests:
- Add unit tests covering postal_address_one_line formatting for full data, missing city, missing postcode, and both values empty.