### PR TITLE
Abort with 404 before class_uses_recursive() on unknown search models

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -20,17 +20,15 @@ class SearchController extends Controller
         // check if $model is a morph alias
         $model = morphed_model($model) ?? $model;
         $model = qualify_model(str_replace('/', '\\', $model));
+
+        abort_unless(class_exists($model), 404);
+
         $isSearchable = in_array(
             Searchable::class,
             class_uses_recursive(resolve_static($model, 'class'))
         );
 
-        if (
-            ! class_exists($model)
-            || (! $isSearchable && ! $request->input('searchFields'))
-        ) {
-            abort(404);
-        }
+        abort_if(! $isSearchable && ! $request->input('searchFields'), 404);
 
         Event::dispatch('tall-datatables-searching', $request);
 


### PR DESCRIPTION
When the search route gets a $model that's not a real class (e.g. the unresolved template placeholder __model__ sent by some selects), class_uses_recursive() crashed because class_parents() rejects unknown classes. Run class_exists() first and bail with 404 instead.

## Summary by Sourcery

Bug Fixes:
- Prevent crashes in the search route when an invalid or unresolved model name is provided by first verifying the model class exists before inspecting its traits.