### PR TITLE
Skip print header logo block when tenant or logo is missing

### DIFF
--- a/resources/views/components/print/header.blade.php
+++ b/resources/views/components/print/header.blade.php
@@ -27,21 +27,23 @@
                 </div>
             @show
             @section('logo')
-                <div
-                    style="
-                        float: right;
-                        display: inline-block;
-                        max-height: 288px;
-                        width: 176px;
-                        text-align: right;
-                    "
-                >
-                    <img
-                        class="logo-small"
-                        src="{{ $tenant->logo_small }}"
-                        alt="logo-small"
-                    />
-                </div>
+                @if ($tenant?->logo_small)
+                    <div
+                        style="
+                            float: right;
+                            display: inline-block;
+                            max-height: 288px;
+                            width: 176px;
+                            text-align: right;
+                        "
+                    >
+                        <img
+                            class="logo-small"
+                            src="{{ $tenant->logo_small }}"
+                            alt="logo-small"
+                        />
+                    </div>
+                @endif
             @show
             <div style="clear: both"></div>
         </div>

--- a/resources/views/components/print/header.blade.php
+++ b/resources/views/components/print/header.blade.php
@@ -27,7 +27,7 @@
                 </div>
             @show
             @section('logo')
-                @if($tenant?->logo_small)
+                @if ($tenant?->logo_small)
                     <div
                         style="
                             float: right;

--- a/resources/views/components/print/header.blade.php
+++ b/resources/views/components/print/header.blade.php
@@ -27,7 +27,7 @@
                 </div>
             @show
             @section('logo')
-                @if ($tenant?->logo_small)
+                @if($tenant?->logo_small)
                     <div
                         style="
                             float: right;


### PR DESCRIPTION
PrintableView::hydrateSharedData() shares $tenant as null when no tenant record exists (e.g. soft-deleted) and the public signature route still rendered the header, crashing on $tenant->logo_small. Wrap the logo section in a null-safe check so the print just omits the logo instead of 500ing.

## Summary by Sourcery

Bug Fixes:
- Prevent printable views from throwing errors when rendering the header for tenants without a record or logo by skipping the logo block in that case.