### PR TITLE
feat(controller): add hasPermission opt-out flag for routes

### DIFF
--- a/src/Console/Commands/Init/InitPermissions.php
+++ b/src/Console/Commands/Init/InitPermissions.php
@@ -7,6 +7,7 @@ use FluxErp\Actions\FluxAction;
 use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Facades\Action;
 use FluxErp\Facades\Widget;
+use FluxErp\Http\Controllers\Controller;
 use FluxErp\Models\Permission;
 use FluxErp\Traits\Livewire\WithTabs;
 use FluxErp\Traits\Model\HasModelPermission;
@@ -115,6 +116,13 @@ class InitPermissions extends Command
         foreach ($routes as $route) {
             $permissionName = route_to_permission($route, false);
             if (! $permissionName || $this->isVendorRoute($route) || str_starts_with($permissionName, 'search.')) {
+                $bar->advance();
+
+                continue;
+            }
+
+            $controllerClass = is_string($route->action['uses'] ?? null) ? $route->getControllerClass() : null;
+            if ($controllerClass && is_a($controllerClass, Controller::class, true) && ! $controllerClass::hasPermission()) {
                 $bar->advance();
 
                 continue;

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -11,10 +11,21 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
+    protected static bool $hasPermission = true;
+
     public function __construct(?string $permission = null)
     {
+        if (! static::$hasPermission) {
+            return;
+        }
+
         if (! $permission && $permission = route_to_permission()) {
             $this->middleware(['permission:' . $permission]);
         }
+    }
+
+    public static function hasPermission(): bool
+    {
+        return static::$hasPermission;
     }
 }

--- a/src/Http/Controllers/FilePondChunkController.php
+++ b/src/Http/Controllers/FilePondChunkController.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 
 class FilePondChunkController extends Controller
 {
+    protected static bool $hasPermission = false;
+
     public function handle(Request $request): JsonResponse
     {
         if (FileUploadConfiguration::isUsingS3() || FileUploadConfiguration::isUsingGCS()) {

--- a/tests/Feature/Http/FilePondChunkTest.php
+++ b/tests/Feature/Http/FilePondChunkTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use FluxErp\Models\Permission;
 use FluxErp\Models\User;
 use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -251,4 +252,21 @@ test('chunk init rejects negative upload length', function (): void {
     ]);
 
     $response->assertStatus(422);
+});
+
+test('chunk init does not require the auto-derived permission', function (): void {
+    Permission::query()->create([
+        'name' => 'file-pond.chunk.post',
+        'guard_name' => 'web',
+    ]);
+
+    $user = User::factory()->create([
+        'is_active' => true,
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+    $this->be($user, 'web');
+
+    $response = chunkInit();
+
+    $response->assertOk();
 });

--- a/tests/Unit/Http/Controllers/ControllerHasPermissionTest.php
+++ b/tests/Unit/Http/Controllers/ControllerHasPermissionTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use FluxErp\Http\Controllers\Controller;
+use FluxErp\Http\Controllers\FilePondChunkController;
+
+test('FilePondChunkController opts out of the permission middleware', function (): void {
+    expect(FilePondChunkController::hasPermission())->toBeFalse();
+});
+
+test('base controllers require permission by default', function (): void {
+    expect(Controller::hasPermission())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Mirrors the \`\$hasPermission\` opt-out pattern already used on \`FluxAction\` (cart, cart item, mail folder actions) on the base \`Controller\` class.

A controller can now set \`protected static bool \$hasPermission = false;\` to skip the auto-bound \`permission:\` middleware. The route still requires whatever guard is on the route definition (\`auth:web\`, etc.).

\`FilePondChunkController\` uses the opt-out so chunked uploads stay reachable for any authenticated user without needing a dedicated \`file-pond.chunk.post\` permission grant.

\`InitPermissions::registerRoutePermissions()\` now also skips routes whose controller opts out, so the orphan permission rows are no longer created on \`php artisan init:permissions\`.

## Existing permissions

The change does not delete existing permission rows. Tenants that previously had \`file-pond.chunk.post\` / \`file-pond.chunk.patch\` registered will keep them; they are simply no longer enforced for the route and no longer recreated by \`init:permissions\`. Cleanup of orphan permissions is left to the existing housekeeping in \`InitPermissions\`.

## Summary by Sourcery

Introduce a controller-level opt-out flag for automatic permission middleware and apply it to file upload chunks while ensuring route permission registration respects the opt-out.

New Features:
- Add a static hasPermission flag and accessor on the base Controller to control automatic permission middleware binding.
- Allow FilePondChunkController routes to bypass the auto-derived permission requirement while still enforcing authentication.

Enhancements:
- Update InitPermissions route permission registration to skip controllers that opt out via the hasPermission flag.

Tests:
- Add feature and unit tests to confirm FilePondChunkController bypasses the auto-derived permission while remaining accessible to authenticated users and that controllers require permissions by default.