### PR TITLE
Mount editor button companion components outside the cloned template

### DIFF
--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -145,12 +145,13 @@
         @endif
     @endforeach
     @foreach ($buttonInstances as $buttonInstance)
-        @if (method_exists($buttonInstance, 'companions'))
+        @if ($buttonInstance instanceof \FluxErp\Contracts\HasEditorButtonCompanions)
             @foreach ($buttonInstance->companions() as $companion)
+                @continue(! is_array($companion) || ! isset($companion['class']) || ! is_string($companion['class']))
                 @livewire(
                     $companion['class'],
-                    $companion['params'] ?? [],
-                    key('editor-' . $id . '-companion-' . $loop->parent->index . '-' . $loop->index)
+                    is_array($companion['params'] ?? null) ? $companion['params'] : [],
+                    key('editor-' . $id . '-companion-' . $companion['class'] . '-' . $loop->parent->index . '-' . $loop->index)
                 )
             @endforeach
         @endif

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -144,4 +144,15 @@
             @endif
         @endif
     @endforeach
+    @foreach ($buttonInstances as $buttonInstance)
+        @if (method_exists($buttonInstance, 'companions'))
+            @foreach ($buttonInstance->companions() as $companion)
+                @livewire(
+                    $companion['class'],
+                    $companion['params'] ?? [],
+                    key('editor-' . $id . '-companion-' . $loop->parent->index . '-' . $loop->index)
+                )
+            @endforeach
+        @endif
+    @endforeach
 </div>

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -66,9 +66,11 @@
                     @foreach ($buttonInstances as $buttonInstance)
                         @if ($buttonInstance instanceof \FluxErp\Contracts\EditorTooltipButton)
                             @if ($buttonInstance instanceof \Livewire\Component)
-                                <livewire:dynamic-component
-                                    :is="$buttonInstance::class"
-                                />
+                                @livewire(
+                                    $buttonInstance::class,
+                                    $buttonInstance instanceof \FluxErp\Contracts\HasEditorButtonCompanions ? ['editorId' => $id] : [],
+                                    key('editor-' . $id . '-tooltip-' . $loop->index)
+                                )
                             @else
                                 {!! $buttonInstance->render() !!}
                             @endif
@@ -87,7 +89,11 @@
         @foreach ($buttonInstances as $buttonInstance)
             @if ((! $tooltipDropdown || ! $buttonInstance instanceof \FluxErp\Contracts\EditorDropdownButton) && ! ($tooltipDropdown && $buttonInstance instanceof \FluxErp\Contracts\EditorTooltipButton))
                 @if ($buttonInstance instanceof \Livewire\Component)
-                    <livewire:dynamic-component :is="$buttonInstance::class" />
+                    @livewire(
+                        $buttonInstance::class,
+                        $buttonInstance instanceof \FluxErp\Contracts\HasEditorButtonCompanions ? ['editorId' => $id] : [],
+                        key('editor-' . $id . '-command-' . $loop->index)
+                    )
                 @else
                     {!! $buttonInstance->render() !!}
                 @endif

--- a/src/Contracts/HasEditorButtonCompanions.php
+++ b/src/Contracts/HasEditorButtonCompanions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FluxErp\Contracts;
+
+interface HasEditorButtonCompanions
+{
+    /**
+     * @return list<array{class: class-string<\Livewire\Component>, params?: array<string, mixed>}>
+     */
+    public function companions(): array;
+}


### PR DESCRIPTION
Editor buttons that implement the new `HasEditorButtonCompanions` contract get their declared sibling Livewire components (modals, popovers, ...) rendered next to the editor instead of inside the `<template x-ref="commands">` that tiptap.js clones via `cloneNode(true)`. The cloned `<div wire:id>` has no live Livewire snapshot, so any `\$wire` reference inside it would otherwise walk up to the nearest ancestor component and misfire. Buttons that don't implement the interface are unaffected.

Hook for the flux-ai `AiEditorButton` modal split (Flare #8637312, 27x / 7 users). Until flux-ai releases a version that implements the interface, no button declares companions, so this PR is a safe no-op on its own.

> **Merge + release this first**, then https://github.com/Team-Nifty-GmbH/flux-ai/pull/52 (marked draft) can be promoted and merged once it pulls the new flux-core release.