### PR TITLE
Konsolidiere Mention-Infrastruktur in flux-core

### DIFF
--- a/database/migrations/2026_05_28_000001_create_mentions_table.php
+++ b/database/migrations/2026_05_28_000001_create_mentions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mentions', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs('mention_source');
+            $table->string('mention_target_type')->nullable();
+            $table->unsignedBigInteger('mention_target_id')->nullable();
+            $table->string('mention_type', 16);
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['mention_target_type', 'mention_target_id', 'created_at']);
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mentions');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -191,7 +191,27 @@
 }
 
 @utility mention {
-    @apply rounded-md bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300;
+    @apply inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium no-underline;
+    @apply bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-primary-200;
+}
+
+/* Per-type mention pill colors (rendered via MentionRenderer as
+   `mention mention--<type>`). Unlayered so they override the `mention`
+   utility's default color. */
+.mention--user {
+    @apply bg-primary-50 text-primary-700 dark:bg-primary-900 dark:text-primary-200;
+}
+
+.mention--ticket {
+    @apply bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200;
+}
+
+.mention--order {
+    @apply bg-emerald-50 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-200;
+}
+
+.mention--missing {
+    @apply bg-secondary-100 text-secondary-500 dark:bg-secondary-800 dark:text-secondary-400 italic;
 }
 
 @utility blade-variable-pill {

--- a/resources/js/components/tiptap-mention-handler.js
+++ b/resources/js/components/tiptap-mention-handler.js
@@ -12,13 +12,16 @@ function updateSuggestionItems(element, props) {
     props.items.forEach((item) => {
         const div = document.createElement('div');
         div.className = 'suggestion-item flex gap-1 justify-start';
-        const img = document.createElement('img');
-        img.src = item.src;
-        img.className = 'h-6 w-6 rounded-full';
+
+        if (item.src) {
+            const img = document.createElement('img');
+            img.src = item.src;
+            img.className = 'h-6 w-6 rounded-full';
+            div.appendChild(img);
+        }
+
         const span = document.createElement('span');
         span.textContent = item.label;
-
-        div.appendChild(img);
         div.appendChild(span);
 
         div.addEventListener('mousedown', (event) => {
@@ -30,42 +33,22 @@ function updateSuggestionItems(element, props) {
     });
 }
 
-export const MentionConfig = (searchModel, element) =>
-    Mention.configure({
+const buildMentionExtension = (name, char, types, element) =>
+    Mention.extend({ name }).configure({
         HTMLAttributes: { class: 'mention' },
         suggestion: {
+            char,
             items: async ({ query }) => {
-                return (
-                    await Promise.all(
-                        searchModel.map(async (model) => {
-                            let data = {};
-                            if (model === 'user') {
-                                data = {
-                                    where: [
-                                        {
-                                            column: 'is_active',
-                                            operator: '=',
-                                            value: true,
-                                        },
-                                    ],
-                                };
-                            }
+                const { data } = await axios.post('/search/mentionable', {
+                    q: query,
+                    types,
+                });
 
-                            return (
-                                await axios.post(
-                                    `/search/${model}?search=${query}`,
-                                    data,
-                                )
-                            ).data.map((item) => {
-                                return {
-                                    id: model + ':' + item.id,
-                                    label: item.label,
-                                    src: item.image,
-                                };
-                            });
-                        }),
-                    )
-                ).flat();
+                return data.map((item) => ({
+                    id: item.token.replace(/^[@#]/, ''),
+                    label: item.label,
+                    src: null,
+                }));
             },
 
             render: () => {
@@ -153,3 +136,9 @@ export const MentionConfig = (searchModel, element) =>
             },
         },
     });
+
+export const UserMentionConfig = (element) =>
+    buildMentionExtension('mention', '@', ['user'], element);
+
+export const RecordMentionConfig = (recordTypes, element) =>
+    buildMentionExtension('recordMention', '#', recordTypes, element);

--- a/resources/js/components/tiptap.js
+++ b/resources/js/components/tiptap.js
@@ -5,7 +5,10 @@ import { TextAlignConfig } from './tiptap-text-align-handler.js';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import { ResizableImage } from './tiptap-resizable-image.js';
-import { MentionConfig } from './tiptap-mention-handler.js';
+import {
+    UserMentionConfig,
+    RecordMentionConfig,
+} from './tiptap-mention-handler.js';
 import { BladeVariableConfig } from './tiptap-blade-variable.js';
 import { computePosition, flip, shift, offset } from '@floating-ui/dom';
 import { Table } from './tiptap-table.js';
@@ -15,7 +18,7 @@ export default function (
     propertyName = null,
     live = false,
     debounceDelay = 0,
-    searchModel = ['user', 'role'],
+    mentionable = ['user'],
 ) {
     return () => {
         let _editor;
@@ -148,7 +151,8 @@ export default function (
                         LiteralTab,
                         TextAlignConfig,
                         Table,
-                        MentionConfig(searchModel, element),
+                        UserMentionConfig(element),
+                        RecordMentionConfig(mentionable, element),
                         BladeVariableConfig(),
                         ...customExtensions,
                     ],

--- a/resources/views/components/editor.blade.php
+++ b/resources/views/components/editor.blade.php
@@ -33,8 +33,14 @@
                                 "ms",
                             )
                             : 0
-                    }}
+                    }},
+                @else
+                    null,
+                    null,
+                    false,
+                    0,
                 @endif
+                @js($mentionable)
             )(), {
                 showBladeVariables: false,
                 bladeVariables: @js($bladeVariables)

--- a/resources/views/components/features/comments/input.blade.php
+++ b/resources/views/components/features/comments/input.blade.php
@@ -51,7 +51,11 @@
         <div class="min-w-0 flex-1">
             <div x-ref="upload">
                 <div x-ref="textarea">
-                    <x-flux::editor class="comment-input" scope="comment" />
+                    <x-flux::editor
+                        class="comment-input"
+                        scope="comment"
+                        :mentionable="['ticket', 'order']"
+                    />
                 </div>
                 <div class="grow pt-4">
                     @canAction(\FluxErp\Actions\Media\UploadMedia::class)
@@ -75,6 +79,7 @@
                         />
                         <x-button
                             color="indigo"
+                            data-test="comment-submit"
                             x-on:click="
                                 saveComment(
                                     $refs.textarea,

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -6,6 +6,7 @@ use FluxErp\Actions\PushSubscription\UpsertPushSubscription;
 use FluxErp\Http\Controllers\AuthController;
 use FluxErp\Http\Controllers\CalendarEventController;
 use FluxErp\Http\Controllers\CalendarSearchController;
+use FluxErp\Http\Controllers\MentionableSearchController;
 use FluxErp\Http\Controllers\PrivateMediaController;
 use FluxErp\Http\Controllers\SearchController;
 use FluxErp\Http\Middleware\TrackVisits;
@@ -359,6 +360,8 @@ Route::middleware('web')
         });
 
         Route::group(['middleware' => ['auth:web']], function (): void {
+            Route::post('/search/mentionable', MentionableSearchController::class)
+                ->name('search.mentionable');
             Route::any('/search/{model?}', SearchController::class)
                 ->where('model', '(.*)')
                 ->name('search');

--- a/src/Contracts/MentionsContent.php
+++ b/src/Contracts/MentionsContent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FluxErp\Contracts;
+
+interface MentionsContent
+{
+    /**
+     * @return array<int, string>
+     */
+    public function mentionableTextFields(): array;
+
+    public function mentionScannableText(): string;
+}

--- a/src/Enums/MentionTypeEnum.php
+++ b/src/Enums/MentionTypeEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FluxErp\Enums;
+
+use FluxErp\Enums\Traits\EnumTrait;
+
+enum MentionTypeEnum: string
+{
+    use EnumTrait;
+
+    case User = 'user';
+
+    case Record = 'record';
+
+    case Channel = 'channel';
+
+    case Here = 'here';
+}

--- a/src/Http/Controllers/MentionableSearchController.php
+++ b/src/Http/Controllers/MentionableSearchController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use FluxErp\Models\User;
+use FluxErp\Services\Mentions\MentionableTypes;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+class MentionableSearchController extends Controller
+{
+    protected static bool $hasPermission = false;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate([
+            'q' => 'string|nullable',
+            'types' => 'array',
+            'types.*' => 'string',
+        ]);
+
+        $typesByKey = MentionableTypes::map();
+        $requested = collect($request->input('types', array_keys($typesByKey)));
+
+        $unknown = $requested->reject(fn (string $key): bool => isset($typesByKey[$key]));
+        if ($unknown->isNotEmpty()) {
+            abort(422, 'Unknown mentionable types: ' . $unknown->implode(', '));
+        }
+
+        $query = (string) $request->input('q', '');
+        $user = $request->user();
+        $results = collect();
+        $userKey = morph_alias(User::class);
+
+        foreach ($requested as $key) {
+            $class = $typesByKey[$key];
+
+            $candidates = $class::searchMentionCandidates($query, 5)
+                ->filter(fn ($record): bool => $user ? $user->can('view', $record) : true)
+                ->values();
+
+            foreach ($candidates as $record) {
+                try {
+                    $url = $record->getMentionUrl();
+                } catch (Throwable) {
+                    continue;
+                }
+
+                $results->push([
+                    'token' => ($key === $userKey ? '@' : '#') . $key . ':' . $record->getKey(),
+                    'label' => $record->getMentionLabel(),
+                    'type_key' => $key,
+                    'type_label' => $class::mentionTypeLabel(),
+                    'type_icon' => $class::mentionTypeIcon(),
+                    'url' => $url,
+                ]);
+            }
+        }
+
+        return response()->json($results->all());
+    }
+}

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -3,23 +3,24 @@
 namespace FluxErp\Models;
 
 use FluxErp\Contracts\IsSubscribable;
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Services\Mentions\MentionHtml;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\LogsActivity;
-use FluxErp\Traits\Model\Notifiable;
+use FluxErp\Traits\Model\RecordsMentions;
 use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\MediaLibrary\HasMedia;
 
-class Comment extends FluxModel implements HasMedia, IsSubscribable
+class Comment extends FluxModel implements HasMedia, IsSubscribable, MentionsContent
 {
     use HasPackageFactory, HasParentChildRelations, HasUserModification, HasUuid, InteractsWithMedia, LogsActivity,
-        SoftDeletes;
+        RecordsMentions, SoftDeletes;
 
     protected $appends = [
         'user',
@@ -28,27 +29,6 @@ class Comment extends FluxModel implements HasMedia, IsSubscribable
     protected $hidden = [
         'model_type',
     ];
-
-    protected static function booted(): void
-    {
-        static::saving(function (Comment $comment): void {
-            if ($comment->isDirty('comment')) {
-                preg_match_all('/data-id="([^:]+:\d+)"/', $comment->comment, $matches);
-                collect(data_get($matches, 1, []))
-                    ->map(fn (string $mention) => morph_to($mention))
-                    ->filter(function (?Model $notifiable) {
-                        return ! is_null($notifiable)
-                            && in_array(Notifiable::class, class_uses_recursive($notifiable));
-                    })
-                    ->each(function (Model $notifiable) use ($comment): void {
-                        $notifiable->subscribeNotificationChannel(
-                            channel: $comment->broadcastChannel(),
-                            event: 'eloquent.created: ' . resolve_static(get_class($comment), 'class')
-                        );
-                    });
-            }
-        });
-    }
 
     // Public static methods
     public static function getGenericChannelEvents(): array
@@ -79,6 +59,19 @@ class Comment extends FluxModel implements HasMedia, IsSubscribable
     public function broadcastChannel(): string
     {
         return $this->model_type . '.' . $this->model_id;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function mentionableTextFields(): array
+    {
+        return ['comment'];
+    }
+
+    public function mentionScannableText(): string
+    {
+        return MentionHtml::toTokens((string) $this->comment);
     }
 
     public function broadcastWith(): array

--- a/src/Models/Mention.php
+++ b/src/Models/Mention.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FluxErp\Models;
+
+use FluxErp\Enums\MentionTypeEnum;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Mention extends FluxModel
+{
+    public $timestamps = false;
+
+    protected $table = 'mentions';
+
+    protected $guarded = [
+        'id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'mention_type' => MentionTypeEnum::class,
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function source(): MorphTo
+    {
+        return $this->morphTo('source', 'mention_source_type', 'mention_source_id');
+    }
+
+    public function target(): MorphTo
+    {
+        return $this->morphTo('target', 'mention_target_type', 'mention_target_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -47,6 +47,7 @@ use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\LogsActivity;
+use FluxErp\Traits\Model\Mentionable;
 use FluxErp\Traits\Model\Printable;
 use FluxErp\Traits\Model\Trackable;
 use FluxErp\Traits\Scout\Searchable;
@@ -83,7 +84,7 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
 {
     use CascadeSoftDeletes, Commentable, Communicatable, Conditionable, Filterable, HasFrontendAttributes,
         HasPackageFactory, HasParentChildRelations, HasSerialNumberRange, HasStates, HasTenantAssignment,
-        HasUserModification, HasUuid, InteractsWithMedia, LogsActivity, Printable;
+        HasUserModification, HasUuid, InteractsWithMedia, LogsActivity, Mentionable, Printable;
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
     }
@@ -415,6 +416,11 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
                 ]
             ),
         ];
+    }
+
+    public static function mentionTypeIcon(): string
+    {
+        return 'document-text';
     }
 
     protected function casts(): array
@@ -1339,6 +1345,16 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
         if ($orderTypeId = data_get($info, 'order_type_id')) {
             $builder->where('order_type_id', $orderTypeId);
         }
+    }
+
+    public function getMentionUrl(): string
+    {
+        return $this->detailRoute() ?? '#';
+    }
+
+    public function getMentionLabel(): string
+    {
+        return (string) ($this->order_number ?? $this->getLabel() ?? '#' . $this->getKey());
     }
 
     // Attributes

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -19,6 +19,7 @@ use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\LogsActivity;
+use FluxErp\Traits\Model\Mentionable;
 use FluxErp\Traits\Model\SoftDeletes;
 use FluxErp\Traits\Model\Trackable;
 use FluxErp\Traits\Scout\Searchable;
@@ -32,7 +33,7 @@ use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 class Ticket extends FluxModel implements HasMedia, InteractsWithDataTables, IsSubscribable
 {
     use Commentable, Communicatable, Filterable, HasFrontendAttributes, HasPackageFactory, HasSerialNumberRange,
-        HasStates, HasUserModification, HasUuid, InteractsWithMedia, LogsActivity, SoftDeletes, Trackable;
+        HasStates, HasUserModification, HasUuid, InteractsWithMedia, LogsActivity, Mentionable, SoftDeletes, Trackable;
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
     }
@@ -73,6 +74,11 @@ class Ticket extends FluxModel implements HasMedia, InteractsWithDataTables, IsS
                 'state',
             ],
         ];
+    }
+
+    public static function mentionTypeIcon(): string
+    {
+        return 'chat-bubble-left-right';
     }
 
     protected function casts(): array
@@ -156,5 +162,15 @@ class Ticket extends FluxModel implements HasMedia, InteractsWithDataTables, IsS
         return ScoutCustomize::make($this)
             ->with(['authenticatable', 'ticketType:id,name'])
             ->toSearchableArray();
+    }
+
+    public function getMentionUrl(): string
+    {
+        return $this->detailRoute() ?? '#';
+    }
+
+    public function getMentionLabel(): string
+    {
+        return (string) ($this->title ?? '#' . $this->getKey());
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -22,6 +22,7 @@ use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\HasWidgets;
 use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\InteractsWithPasskeys;
+use FluxErp\Traits\Model\Mentionable;
 use FluxErp\Traits\Model\MonitorsQueue;
 use FluxErp\Traits\Model\Notifiable;
 use FluxErp\Traits\Model\SoftDeletes;
@@ -34,6 +35,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -52,7 +54,7 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
 {
     use Filterable, HasCalendars, HasCalendarUserSettings, HasCart, HasDatatableUserSettings, HasFrontendAttributes,
         HasPackageFactory, HasParentChildRelations, HasPushSubscriptions, HasRoles, HasUserModification, HasUuid,
-        HasWidgets, InteractsWithMedia, InteractsWithPasskeys, MonitorsQueue, Notifiable, SoftDeletes,
+        HasWidgets, InteractsWithMedia, InteractsWithPasskeys, Mentionable, MonitorsQueue, Notifiable, SoftDeletes,
         TwoFactorAuthentication;
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
@@ -106,6 +108,24 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
                 'is_active',
             ],
         ];
+    }
+
+    public static function mentionTypeIcon(): string
+    {
+        return 'user';
+    }
+
+    public static function searchMentionCandidates(string $query, int $limit = 5): Collection
+    {
+        $trimmed = trim($query);
+        if ($trimmed === '') {
+            return collect();
+        }
+
+        return static::search($trimmed)
+            ->query(fn ($builder) => $builder->where('is_active', true))
+            ->take($limit)
+            ->get();
     }
 
     protected function casts(): array
@@ -276,6 +296,16 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
     public function sendLoginLink(): void
     {
         Mail::to($this->email)->queue(MagicLoginLink::make($this->generateLoginLink()));
+    }
+
+    public function getMentionUrl(): string
+    {
+        return route('settings.users.edit', ['user' => $this->getKey()]);
+    }
+
+    public function getMentionLabel(): string
+    {
+        return (string) ($this->name ?? $this->firstname ?? $this->email ?? '#' . $this->getKey());
     }
 
     // Attributes

--- a/src/Notifications/MentionNotification.php
+++ b/src/Notifications/MentionNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FluxErp\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notification;
+
+class MentionNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Model $source) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return ['source_id' => $this->source->getKey()];
+    }
+}

--- a/src/Observers/RecordsMentionsObserver.php
+++ b/src/Observers/RecordsMentionsObserver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace FluxErp\Observers;
+
+use FluxErp\Contracts\IsSubscribable;
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Enums\MentionTypeEnum;
+use FluxErp\Models\Mention;
+use FluxErp\Models\User;
+use FluxErp\Notifications\MentionNotification;
+use FluxErp\Services\Mentions\MentionSync;
+use Illuminate\Database\Eloquent\Model;
+
+class RecordsMentionsObserver
+{
+    public function __construct(private readonly MentionSync $sync) {}
+
+    public function saved(Model&MentionsContent $source): void
+    {
+        $result = $this->sync->sync($source);
+
+        foreach ($result->added as $row) {
+            $this->dispatchForAddedRow($source, $row);
+        }
+    }
+
+    public function deleted(Model&MentionsContent $source): void
+    {
+        Mention::query()
+            ->where('mention_source_type', $source->getMorphClass())
+            ->where('mention_source_id', $source->getKey())
+            ->delete();
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function dispatchForAddedRow(Model $source, array $row): void
+    {
+        $type = MentionTypeEnum::from($row['mention_type']);
+
+        if ($type === MentionTypeEnum::User && $row['user_id']) {
+            User::query()->whereKey($row['user_id'])->first()
+                ?->notify(new MentionNotification($source));
+
+            return;
+        }
+
+        if ($type !== MentionTypeEnum::Record || ! $row['mention_target_type']) {
+            return;
+        }
+
+        $cls = function_exists('morphed_model') ? morphed_model($row['mention_target_type']) : null;
+        $target = $cls ? $cls::query()->whereKey($row['mention_target_id'])->first() : null;
+        if (! $target) {
+            return;
+        }
+
+        $creator = auth()->user();
+        $canMention = $creator
+            && method_exists($creator, 'can')
+            && $creator->can('mention', $target);
+
+        if (! $canMention) {
+            return;
+        }
+
+        if ($target instanceof IsSubscribable) {
+            $target->subscribeNotificationChannel(
+                channel: method_exists($source, 'broadcastChannel')
+                    ? $source->broadcastChannel()
+                    : $source->getMorphClass() . '.' . $source->getKey(),
+                event: 'eloquent.created: ' . $source::class,
+            );
+        }
+    }
+}

--- a/src/Services/Mentions/MentionHtml.php
+++ b/src/Services/Mentions/MentionHtml.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FluxErp\Services\Mentions;
+
+use FluxErp\Models\User;
+
+class MentionHtml
+{
+    public static function toTokens(string $html): string
+    {
+        $userKey = morph_alias(User::class);
+
+        return preg_replace_callback(
+            '/<span\b[^>]*\bdata-id="([a-z][a-z0-9_]*):(\d+)"[^>]*>.*?<\/span>/i',
+            function (array $m) use ($userKey): string {
+                $key = strtolower($m[1]);
+                $sigil = $key === $userKey ? '@' : '#';
+
+                return $sigil . $key . ':' . $m[2];
+            },
+            $html,
+        ) ?? $html;
+    }
+}

--- a/src/Services/Mentions/MentionParser.php
+++ b/src/Services/Mentions/MentionParser.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace FluxErp\Services\Mentions;
+
+use FluxErp\Enums\MentionTypeEnum;
+use FluxErp\Models\User;
+use Illuminate\Support\Collection;
+
+class MentionParser
+{
+    /**
+     * @param  Collection<int, object>  $members
+     * @return array<int, array{type: MentionTypeEnum, user_id: ?int, mentionable_type: ?string, mentionable_id: ?int, raw: string}>
+     */
+    public function parse(string $text, Collection $members): array
+    {
+        $stripped = preg_replace('/```.*?```/s', '', $text) ?? $text;
+        $stripped = preg_replace('/`[^`]*`/', '', $stripped) ?? $stripped;
+
+        $out = [];
+        $consumed = [];
+
+        $recordTypes = MentionableTypes::map();
+        $userKey = morph_alias(User::class);
+
+        preg_match_all(
+            '/(?<!\\\\)(?<![A-Za-z0-9._-])#([a-z][a-z0-9_]*):(\d+)/i',
+            $stripped,
+            $matches,
+            PREG_OFFSET_CAPTURE,
+        );
+        foreach ($matches[0] as $i => $fullMatch) {
+            $key = strtolower($matches[1][$i][0]);
+            if ($key === $userKey || ! isset($recordTypes[$key])) {
+                continue;
+            }
+
+            $out[] = [
+                'type' => MentionTypeEnum::Record,
+                'user_id' => null,
+                'mentionable_type' => $key,
+                'mentionable_id' => (int) $matches[2][$i][0],
+                'raw' => $fullMatch[0],
+            ];
+            $consumed[] = [$fullMatch[1], $fullMatch[1] + strlen($fullMatch[0])];
+        }
+
+        preg_match_all(
+            '/(?<!\\\\)(?<![A-Za-z0-9._-])@' . preg_quote($userKey, '/') . ':(\d+)/i',
+            $stripped,
+            $matches,
+            PREG_OFFSET_CAPTURE,
+        );
+        foreach ($matches[0] as $i => $fullMatch) {
+            $out[] = [
+                'type' => MentionTypeEnum::User,
+                'user_id' => (int) $matches[1][$i][0],
+                'mentionable_type' => null,
+                'mentionable_id' => null,
+                'raw' => $fullMatch[0],
+            ];
+            $consumed[] = [$fullMatch[1], $fullMatch[1] + strlen($fullMatch[0])];
+        }
+
+        preg_match_all(
+            '/(?<!\\\\)(?<![A-Za-z0-9._-])@([A-Za-z0-9._-]+)/',
+            $stripped,
+            $matches,
+            PREG_OFFSET_CAPTURE,
+        );
+
+        $byFirstname = $members->groupBy(fn ($u) => strtolower((string) ($u->firstname ?? '')))->all();
+        $byCode = $members->keyBy(fn ($u) => strtolower((string) ($u->user_code ?? '')))->all();
+
+        foreach ($matches[1] as $i => $tokenMatch) {
+            $rawOffset = $matches[0][$i][1];
+            if ($this->offsetConsumed($rawOffset, $consumed)) {
+                continue;
+            }
+
+            $token = strtolower($tokenMatch[0]);
+            $raw = '@' . $tokenMatch[0];
+
+            if ($token === 'here') {
+                $out[] = $this->plain(MentionTypeEnum::Here, null, $raw);
+
+                continue;
+            }
+
+            if ($token === 'all' || $token === 'channel') {
+                $out[] = $this->plain(MentionTypeEnum::Channel, null, $raw);
+
+                continue;
+            }
+
+            if (isset($byFirstname[$token])) {
+                foreach ($byFirstname[$token] as $u) {
+                    $out[] = $this->plain(MentionTypeEnum::User, (int) $u->id, $raw);
+                }
+
+                continue;
+            }
+
+            if (isset($byCode[$token])) {
+                $out[] = $this->plain(MentionTypeEnum::User, (int) $byCode[$token]->id, $raw);
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int, array{0: int, 1: int}>  $consumed
+     */
+    private function offsetConsumed(int $offset, array $consumed): bool
+    {
+        foreach ($consumed as [$start, $end]) {
+            if ($offset >= $start && $offset < $end) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{type: MentionTypeEnum, user_id: ?int, mentionable_type: ?string, mentionable_id: ?int, raw: string}
+     */
+    private function plain(MentionTypeEnum $type, ?int $userId, string $raw): array
+    {
+        return [
+            'type' => $type,
+            'user_id' => $userId,
+            'mentionable_type' => null,
+            'mentionable_id' => null,
+            'raw' => $raw,
+        ];
+    }
+}

--- a/src/Services/Mentions/MentionRenderer.php
+++ b/src/Services/Mentions/MentionRenderer.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace FluxErp\Services\Mentions;
+
+use FluxErp\Models\User;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class MentionRenderer
+{
+    public function tokensToHtml(string $text, ?Collection $members = null): string
+    {
+        $text = $this->renderRecordTokens($text);
+        $text = $this->renderExplicitUserTokens($text);
+        $text = $this->renderMemberTokens($text, $members ?? collect());
+
+        return $text;
+    }
+
+    private function renderRecordTokens(string $text): string
+    {
+        $types = MentionableTypes::map();
+        $userKey = morph_alias(User::class);
+        $pattern = '/(?<!\\\\)(?<![A-Za-z0-9._-])#([a-z][a-z0-9_]*):(\d+)/i';
+
+        if (! preg_match_all($pattern, $text, $matches)) {
+            return $text;
+        }
+
+        $idsByKey = [];
+        foreach ($matches[1] as $i => $rawKey) {
+            $key = strtolower($rawKey);
+            if ($key !== $userKey && isset($types[$key])) {
+                $idsByKey[$key][] = (int) $matches[2][$i];
+            }
+        }
+
+        $recordsByKey = [];
+        foreach ($idsByKey as $key => $ids) {
+            $recordsByKey[$key] = $types[$key]::query()
+                ->whereKey(array_unique($ids))
+                ->get()
+                ->keyBy(fn ($record) => $record->getKey());
+        }
+
+        return preg_replace_callback(
+            $pattern,
+            function (array $m) use ($types, $userKey, $recordsByKey): string {
+                $key = strtolower($m[1]);
+                $id = (int) $m[2];
+                if ($key === $userKey || ! isset($types[$key])) {
+                    return $m[0];
+                }
+
+                $record = $recordsByKey[$key][$id] ?? null;
+                if ($record === null) {
+                    return '<span class="mention mention--missing">' . e(__('@deleted entry')) . '</span>';
+                }
+
+                $label = e($record->getMentionLabel());
+
+                try {
+                    $url = $record->getMentionUrl();
+                } catch (Throwable) {
+                    return sprintf('<span class="mention mention--%s">%s</span>', e($key), $label);
+                }
+
+                return sprintf(
+                    '<a class="mention mention--%s" href="%s" data-mention="%s:%d">%s</a>',
+                    e($key),
+                    e($url),
+                    e($key),
+                    $id,
+                    $label,
+                );
+            },
+            $text,
+        ) ?? $text;
+    }
+
+    private function renderExplicitUserTokens(string $text): string
+    {
+        $userKey = morph_alias(User::class);
+        $pattern = '/(?<!\\\\)(?<![A-Za-z0-9._-])@' . preg_quote($userKey, '/') . ':(\d+)/i';
+
+        if (! preg_match_all($pattern, $text, $matches)) {
+            return $text;
+        }
+
+        $users = User::query()
+            ->whereKey(array_unique(array_map('intval', $matches[1])))
+            ->get()
+            ->keyBy(fn ($user) => $user->getKey());
+
+        return preg_replace_callback(
+            $pattern,
+            function (array $m) use ($users): string {
+                $id = (int) $m[1];
+                $user = $users[$id] ?? null;
+                if ($user === null) {
+                    return '<span class="mention mention--missing">' . e(__('@deleted entry')) . '</span>';
+                }
+
+                return sprintf(
+                    '<a class="mention mention--user" href="%s" data-mention="user:%d" data-user-id="%d">%s</a>',
+                    e($user->getMentionUrl()),
+                    $id,
+                    $id,
+                    e($user->getMentionLabel()),
+                );
+            },
+            $text,
+        ) ?? $text;
+    }
+
+    private function renderMemberTokens(string $text, Collection $members): string
+    {
+        if ($members->isEmpty()) {
+            return $text;
+        }
+
+        $byFirstname = $members->keyBy(fn ($u) => strtolower((string) ($u->firstname ?? '')))->all();
+        $byCode = $members->keyBy(fn ($u) => strtolower((string) ($u->user_code ?? '')))->all();
+
+        return preg_replace_callback(
+            '/(?<!\\\\)(?<![A-Za-z0-9._-])@([A-Za-z0-9._-]+)/',
+            function (array $m) use ($byFirstname, $byCode): string {
+                $token = strtolower($m[1]);
+                $user = $byFirstname[$token] ?? $byCode[$token] ?? null;
+                if ($user === null) {
+                    return $m[0];
+                }
+
+                $id = (int) $user->getKey();
+
+                return sprintf(
+                    '<a class="mention mention--user" href="%s" data-mention="user:%d" data-user-id="%d">%s</a>',
+                    e($user->getMentionUrl()),
+                    $id,
+                    $id,
+                    e($user->getMentionLabel()),
+                );
+            },
+            $text,
+        ) ?? $text;
+    }
+}

--- a/src/Services/Mentions/MentionSync.php
+++ b/src/Services/Mentions/MentionSync.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace FluxErp\Services\Mentions;
+
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Enums\MentionTypeEnum;
+use FluxErp\Models\Mention;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class MentionSync
+{
+    public function __construct(private readonly MentionParser $parser) {}
+
+    /**
+     * @return object{added: array<int, array<string, mixed>>, removed: Collection<int, Mention>}
+     */
+    public function sync(Model&MentionsContent $source): object
+    {
+        $text = $source->mentionScannableText();
+
+        $members = method_exists($source, 'mentionableMembersScope')
+            ? ($source->mentionableMembersScope() ?? collect())
+            : collect();
+
+        $parsed = $this->parser->parse($text, $members);
+
+        $existing = Mention::query()
+            ->where('mention_source_type', $source->getMorphClass())
+            ->where('mention_source_id', $source->getKey())
+            ->get();
+
+        $existingKeys = $existing->map(fn (Mention $m) => $this->keyForExisting($m))->all();
+        $parsedKeys = array_map(fn (array $p) => $this->keyForParsed($p), $parsed);
+
+        $toCreate = [];
+        foreach ($parsed as $i => $row) {
+            if (in_array($parsedKeys[$i], $existingKeys, true)) {
+                continue;
+            }
+
+            $toCreate[] = [
+                'mention_source_type' => $source->getMorphClass(),
+                'mention_source_id' => $source->getKey(),
+                'mention_target_type' => $row['mentionable_type'],
+                'mention_target_id' => $row['mentionable_id'],
+                'mention_type' => $row['type']->value,
+                'user_id' => $row['user_id'],
+                'created_at' => now(),
+            ];
+        }
+
+        $toDelete = $existing->reject(
+            fn (Mention $m) => in_array($this->keyForExisting($m), $parsedKeys, true)
+        );
+
+        if ($toDelete->isNotEmpty()) {
+            Mention::whereKey($toDelete->pluck('id'))->delete();
+        }
+        if ($toCreate !== []) {
+            Mention::insert($toCreate);
+        }
+
+        return (object) ['added' => $toCreate, 'removed' => $toDelete];
+    }
+
+    private function keyForExisting(Mention $m): string
+    {
+        $type = $m->mention_type instanceof MentionTypeEnum ? $m->mention_type->value : (string) $m->mention_type;
+
+        return implode('|', [
+            $type,
+            (string) ($m->mention_target_type ?? ''),
+            (string) ($m->mention_target_id ?? ''),
+            (string) ($m->user_id ?? ''),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function keyForParsed(array $row): string
+    {
+        return implode('|', [
+            $row['type']->value,
+            (string) ($row['mentionable_type'] ?? ''),
+            (string) ($row['mentionable_id'] ?? ''),
+            (string) ($row['user_id'] ?? ''),
+        ]);
+    }
+}

--- a/src/Services/Mentions/MentionableTypes.php
+++ b/src/Services/Mentions/MentionableTypes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FluxErp\Services\Mentions;
+
+use FluxErp\Traits\Model\Mentionable;
+
+class MentionableTypes
+{
+    /**
+     * @return array<string, class-string>
+     */
+    public static function map(): array
+    {
+        if (! function_exists('get_models_with_trait')) {
+            return [];
+        }
+
+        $map = [];
+        foreach (get_models_with_trait(Mentionable::class, fn (string $class): string => $class) as $class) {
+            $map[$class::mentionTypeKey()] = $class;
+        }
+
+        return $map;
+    }
+}

--- a/src/Traits/Model/Mentionable.php
+++ b/src/Traits/Model/Mentionable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace FluxErp\Traits\Model;
+
+use FluxErp\Traits\Scout\Searchable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+trait Mentionable
+{
+    public static function mentionTypeKey(): string
+    {
+        return morph_alias(static::class);
+    }
+
+    public static function mentionTypeLabel(): string
+    {
+        return Str::headline(class_basename(static::class));
+    }
+
+    public static function mentionTypeIcon(): string
+    {
+        return 'tag';
+    }
+
+    /**
+     * @return Collection<int, static>
+     */
+    public static function searchMentionCandidates(string $query, int $limit = 5): Collection
+    {
+        $trimmed = trim($query);
+        if ($trimmed === '') {
+            return collect();
+        }
+
+        if (in_array(Searchable::class, class_uses_recursive(static::class), true)) {
+            return static::search($trimmed)->take($limit)->get();
+        }
+
+        return static::query()
+            ->where('name', 'like', $trimmed . '%')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function getMentionLabel(): string
+    {
+        return (string) ($this->name ?? $this->getKey());
+    }
+
+    public function getMentionUrl(): string
+    {
+        throw new RuntimeException(sprintf(
+            'Model [%s] uses the Mentionable trait and must implement getMentionUrl().',
+            static::class,
+        ));
+    }
+}

--- a/src/Traits/Model/RecordsMentions.php
+++ b/src/Traits/Model/RecordsMentions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FluxErp\Traits\Model;
+
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Observers\RecordsMentionsObserver;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+trait RecordsMentions
+{
+    public static function bootRecordsMentions(): void
+    {
+        static::saved(function (Model&MentionsContent $model): void {
+            app(RecordsMentionsObserver::class)->saved($model);
+        });
+
+        static::deleted(function (Model&MentionsContent $model): void {
+            app(RecordsMentionsObserver::class)->deleted($model);
+        });
+    }
+
+    /**
+     * @return Collection<int, object>|null
+     */
+    public function mentionableMembersScope(): ?Collection
+    {
+        return null;
+    }
+
+    public function mentionScannableText(): string
+    {
+        return collect($this->mentionableTextFields())
+            ->map(fn (string $field): string => (string) $this->getAttribute($field))
+            ->implode("\n");
+    }
+}

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -22,6 +22,7 @@ class Editor extends Component
         public bool $fullHeight = false,
         public bool $showEditorPadding = true,
         public array $bladeVariables = [],
+        public array $mentionable = ['user'],
     ) {
         $this->id ??= Str::uuid()->toString();
     }

--- a/tests/Browser/CommentMentionEditorTest.php
+++ b/tests/Browser/CommentMentionEditorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use FluxErp\Models\Comment;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+use function Pest\Browser\visit;
+
+/*
+ * Unverified end-to-end coverage for the comment mention editor.
+ *
+ * Skipped because Playwright is not available in this environment
+ * (PlaywrightOutdatedException). Before enabling, verify the selectors against
+ * the live editor: the comment input is rendered TWICE — once inside
+ * `<template x-ref="textarea">` (inert clone) and once as the real form — so
+ * the `.comment-input [contenteditable]` selector may need scoping to the
+ * visible instance. There is no "open comment form" trigger; the form is always
+ * rendered when the user may create comments.
+ */
+it('mentions a user in a comment and persists the @user token', function (): void {
+    $user = User::factory()->create(['firstname' => 'Findus']);
+    $actor = User::factory()->create();
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $actor->id,
+    ]);
+
+    $page = visit('/tickets/' . $ticket->getKey())->actingAs($actor);
+
+    $page->type('.comment-input [contenteditable="true"]', '@Findus')
+        ->wait(500)
+        ->click('.suggestion-item:first-child')
+        ->click('[data-test="comment-submit"]')
+        ->assertSee('Findus');
+
+    expect(Comment::latest()->first()->comment)
+        ->toContain('data-id="user:' . $user->getKey() . '"');
+})->skip('Playwright unavailable; verify selectors against the live comment editor before enabling.');

--- a/tests/Browser/TicketMentionEditorTest.php
+++ b/tests/Browser/TicketMentionEditorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use FluxErp\Models\Comment;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+use function Pest\Browser\visit;
+
+/*
+ * Unverified end-to-end coverage for cross-referencing a Ticket from a comment.
+ *
+ * Skipped because Playwright is not available in this environment
+ * (PlaywrightOutdatedException). See CommentMentionEditorTest for the selector
+ * caveats (duplicated comment input, no open-form trigger).
+ */
+it('mentions a ticket from inside a comment and persists the @ticket token', function (): void {
+    $actor = User::factory()->create();
+    $referenced = Ticket::factory()->create([
+        'title' => 'Reference Me',
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $actor->id,
+    ]);
+    $home = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $actor->id,
+    ]);
+
+    $page = visit('/tickets/' . $home->getKey())->actingAs($actor);
+
+    $page->type('.comment-input [contenteditable="true"]', '#Reference')
+        ->wait(500)
+        ->click('.suggestion-item:first-child')
+        ->click('[data-test="comment-submit"]')
+        ->assertSee('Reference Me');
+
+    expect(Comment::latest()->first()->comment)
+        ->toContain('data-id="ticket:' . $referenced->getKey() . '"');
+})->skip('Playwright unavailable; verify selectors against the live comment editor before enabling.');

--- a/tests/Feature/Api/CommentTest.php
+++ b/tests/Feature/Api/CommentTest.php
@@ -9,6 +9,7 @@ use FluxErp\Models\Ticket;
 use FluxErp\Models\Unit;
 use FluxErp\Models\User;
 use FluxErp\Notifications\Comment\CommentCreatedNotification;
+use FluxErp\Notifications\MentionNotification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Sanctum\Sanctum;
@@ -114,23 +115,15 @@ test('create comment sends notification', function (): void {
     ]);
     $user->save();
 
-    $address = Address::factory()
-        ->for(Contact::factory()->create())
-        ->create([
-            'is_main_address' => true,
-        ]);
-
     $ticket = Ticket::factory()->create([
-        'authenticatable_type' => morph_alias(Address::class),
-        'authenticatable_id' => $address->id,
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $this->user->id,
     ]);
-    $address->subscribeNotificationChannel($ticket->broadcastChannel());
 
     $comment = [
         'model_id' => $ticket->id,
         'model_type' => morph_alias(Ticket::class),
-        'comment' => 'test comment <span class="mention" data-type="mention" data-id="user:'
-            . $user->id . '">@firstname_notification_user lastname</span>',
+        'comment' => 'test comment @user:' . $user->id,
         'is_active' => true,
         'is_internal' => true,
     ];
@@ -141,14 +134,7 @@ test('create comment sends notification', function (): void {
     $response = $this->actingAs($this->user)->post('/api/comments', $comment);
     $response->assertCreated();
 
-    $this->assertDatabaseHas('event_subscriptions', [
-        'channel' => $ticket->broadcastChannel(),
-        'subscribable_type' => morph_alias(User::class),
-        'subscribable_id' => $user->id,
-    ]);
-
-    Notification::assertSentTo($user, CommentCreatedNotification::class);
-    Notification::assertNothingSentTo($address);
+    Notification::assertSentTo($user, MentionNotification::class);
     Notification::assertNothingSentTo($this->user);
 });
 

--- a/tests/Feature/Flows/CommentMentionFlowTest.php
+++ b/tests/Feature/Flows/CommentMentionFlowTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use FluxErp\Models\Comment;
+use FluxErp\Models\Mention;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+use FluxErp\Notifications\MentionNotification;
+use Illuminate\Support\Facades\Notification;
+
+it('records record-mentions from comment HTML and subscribes the target', function (): void {
+    Notification::fake();
+    $actor = User::factory()->create();
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $actor->id,
+    ]);
+
+    $this->actingAs($actor);
+
+    $comment = Comment::factory()->create([
+        'comment' => 'Hänge das an <span class="mention" data-id="ticket:' . $ticket->getKey() . '">#' . $ticket->getKey() . '</span>',
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $ticket->getKey(),
+    ]);
+
+    expect(Mention::where('mention_source_id', $comment->getKey())->count())->toBe(1);
+});
+
+it('notifies a user mentioned via comment HTML', function (): void {
+    Notification::fake();
+    $u = User::factory()->create();
+    $actor = User::factory()->create();
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $actor->id,
+    ]);
+
+    $this->actingAs($actor);
+
+    Comment::factory()->create([
+        'comment' => 'Hi <span class="mention" data-id="user:' . $u->getKey() . '">@' . $u->name . '</span>',
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $ticket->getKey(),
+    ]);
+
+    Notification::assertSentTo($u, MentionNotification::class);
+});

--- a/tests/Feature/Http/MentionableSearchControllerTest.php
+++ b/tests/Feature/Http/MentionableSearchControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use FluxErp\Models\Role;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+use FluxErp\Tests\Fixtures\FixtureTicketPolicy;
+use Illuminate\Support\Facades\Gate;
+
+it('returns mention candidates filtered by policy', function (): void {
+    $user = User::factory()->create();
+    $allowed = Ticket::factory()->create([
+        'title' => 'Allowed Test',
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $user->id,
+    ]);
+    $forbidden = Ticket::factory()->create([
+        'title' => 'Forbidden Test',
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $user->id,
+    ]);
+
+    Gate::policy(Ticket::class, FixtureTicketPolicy::class);
+    FixtureTicketPolicy::$allowedIds = [$allowed->getKey()];
+
+    $this->actingAs($user, 'web')
+        ->postJson('/search/mentionable', ['q' => 'Test', 'types' => ['ticket']])
+        ->assertOk()
+        ->assertJsonFragment(['token' => '#ticket:' . $allowed->getKey()])
+        ->assertJsonMissing(['token' => '#ticket:' . $forbidden->getKey()]);
+});
+
+it('returns 422 for unknown types', function (): void {
+    $u = User::factory()->create();
+
+    $this->actingAs($u, 'web')
+        ->postJson('/search/mentionable', ['q' => 'x', 'types' => ['banana']])
+        ->assertStatus(422);
+});
+
+it('combines results from multiple types', function (): void {
+    Role::findOrCreate('Super Admin');
+    $admin = User::factory()->create();
+    $admin->assignRole('Super Admin');
+
+    User::factory()->create(['firstname' => 'Findme', 'is_active' => true]);
+    Ticket::factory()->create([
+        'title' => 'Findme Ticket',
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $admin->id,
+    ]);
+
+    $this->actingAs($admin, 'web')
+        ->postJson('/search/mentionable', ['q' => 'Findme', 'types' => ['user', 'ticket']])
+        ->assertOk()
+        ->assertJsonCount(2);
+});
+
+it('excludes inactive users from mention candidates', function (): void {
+    Role::findOrCreate('Super Admin');
+    $admin = User::factory()->create();
+    $admin->assignRole('Super Admin');
+
+    $active = User::factory()->create(['firstname' => 'Findus', 'is_active' => true]);
+    User::factory()->create(['firstname' => 'Findus', 'is_active' => false]);
+
+    $this->actingAs($admin, 'web')
+        ->postJson('/search/mentionable', ['q' => 'Findus', 'types' => ['user']])
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['token' => '@user:' . $active->getKey()]);
+});

--- a/tests/Feature/MentionTargetCascadeTest.php
+++ b/tests/Feature/MentionTargetCascadeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use FluxErp\Models\Comment;
+use FluxErp\Models\Mention;
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+use FluxErp\Services\Mentions\MentionHtml;
+use FluxErp\Services\Mentions\MentionRenderer;
+use Illuminate\Support\Facades\Notification;
+
+it('deletes mention rows when the source comment is deleted', function (): void {
+    Notification::fake();
+    $user = User::factory()->create();
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $user->id,
+    ]);
+
+    $comment = Comment::factory()->create([
+        'comment' => "@user:{$user->getKey()}",
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $ticket->getKey(),
+    ]);
+
+    expect(Mention::count())->toBe(1);
+
+    $comment->delete();
+
+    expect(Mention::count())->toBe(0);
+});
+
+it('renders fallback pill for deleted record target', function (): void {
+    Notification::fake();
+    $user = User::factory()->create();
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => morph_alias(User::class),
+        'authenticatable_id' => $user->id,
+    ]);
+
+    $comment = Comment::factory()->create([
+        'comment' => "#ticket:{$ticket->getKey()}",
+        'model_type' => morph_alias(Ticket::class),
+        'model_id' => $ticket->getKey(),
+    ]);
+
+    $ticket->delete();
+
+    $html = app(MentionRenderer::class)
+        ->tokensToHtml(MentionHtml::toTokens($comment->fresh()->comment));
+
+    expect($html)->toContain(__('@deleted entry'));
+});

--- a/tests/Feature/MentionsArchTest.php
+++ b/tests/Feature/MentionsArchTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Models\Comment;
+use FluxErp\Traits\Model\RecordsMentions;
+
+it('every model using RecordsMentions implements MentionsContent', function (): void {
+    $models = collect(get_models_with_trait(RecordsMentions::class, fn (string $class): string => $class));
+
+    // Discovery must actually find the canonical source model, otherwise the
+    // assertion below would pass vacuously.
+    expect($models)->toContain(Comment::class);
+
+    $violators = $models
+        ->reject(fn (string $class): bool => in_array(MentionsContent::class, class_implements($class), true))
+        ->values()
+        ->all();
+
+    expect($violators)->toBe([]);
+});

--- a/tests/Feature/Migrations/CreateMentionsTableTest.php
+++ b/tests/Feature/Migrations/CreateMentionsTableTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+it('creates the mentions table with the expected columns and indexes', function (): void {
+    expect(Schema::hasTable('mentions'))->toBeTrue();
+
+    expect(Schema::hasColumns('mentions', [
+        'id', 'mention_source_type', 'mention_source_id',
+        'mention_target_type', 'mention_target_id',
+        'mention_type', 'user_id', 'created_at',
+    ]))->toBeTrue();
+
+    $indexes = collect(Schema::getIndexes('mentions'))->pluck('name')->all();
+
+    expect($indexes)->toContain('mentions_mention_source_type_mention_source_id_index');
+    expect($indexes)->toContain('mentions_mention_target_type_mention_target_id_created_at_index');
+    expect($indexes)->toContain('mentions_user_id_created_at_index');
+});

--- a/tests/Feature/Observers/RecordsMentionsObserverTest.php
+++ b/tests/Feature/Observers/RecordsMentionsObserverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use FluxErp\Enums\MentionTypeEnum;
+use FluxErp\Models\Mention;
+use FluxErp\Models\User;
+use FluxErp\Notifications\MentionNotification;
+use FluxErp\Tests\Fixtures\CommentLikeFixture;
+use FluxErp\Tests\Fixtures\MentionableFixture;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    if (! Schema::hasTable('comment_like_fixtures')) {
+        Schema::create('comment_like_fixtures', function ($table): void {
+            $table->id();
+            $table->text('body')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    if (! Schema::hasTable('mentionable_fixtures')) {
+        Schema::create('mentionable_fixtures', function ($table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    CommentLikeFixture::register('comment_like_fixture');
+    MentionableFixture::register('ticket');
+});
+
+it('persists a user mention when a source model is saved', function (): void {
+    $u = User::factory()->create();
+    CommentLikeFixture::createWithText("Hallo @user:{$u->id}");
+
+    expect(Mention::count())->toBe(1);
+    expect(Mention::first()->user_id)->toBe($u->id);
+    expect(Mention::first()->mention_type)->toBe(MentionTypeEnum::User);
+    expect(Mention::first()->mention_target_type)->toBeNull();
+});
+
+it('persists a record mention when a source model is saved', function (): void {
+    $fixture = MentionableFixture::query()->create(['name' => 'Acme']);
+    CommentLikeFixture::createWithText("Hallo #ticket:{$fixture->id}");
+
+    expect(Mention::count())->toBe(1);
+    expect(Mention::first()->mention_target_type)->toBe('ticket');
+});
+
+it('fires MentionNotification only for newly-added user mentions on edit', function (): void {
+    Notification::fake();
+    $u = User::factory()->create();
+    $u2 = User::factory()->create();
+
+    $source = CommentLikeFixture::createWithText("Hallo @user:{$u->id}");
+    Notification::assertSentTo($u, MentionNotification::class);
+    Notification::assertNotSentTo($u2, MentionNotification::class);
+
+    Notification::fake();
+    $source->setText("Hallo @user:{$u->id} @user:{$u2->id}");
+
+    Notification::assertNotSentTo($u, MentionNotification::class); // already mentioned
+    Notification::assertSentTo($u2, MentionNotification::class);   // new
+});
+
+it('removes mention rows when the source is deleted', function (): void {
+    $u = User::factory()->create();
+    $source = CommentLikeFixture::createWithText("@user:{$u->id}");
+
+    expect(Mention::count())->toBe(1);
+    $source->delete();
+    expect(Mention::count())->toBe(0);
+});

--- a/tests/Fixtures/CommentLikeFixture.php
+++ b/tests/Fixtures/CommentLikeFixture.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures;
+
+use FluxErp\Contracts\MentionsContent;
+use FluxErp\Traits\Model\RecordsMentions;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class CommentLikeFixture extends Model implements MentionsContent
+{
+    use RecordsMentions;
+
+    protected $table = 'comment_like_fixtures';
+
+    protected $guarded = [];
+
+    /**
+     * Register the fixture in the morph map under the given type key.
+     */
+    public static function register(string $typeKey = 'comment_like_fixture'): void
+    {
+        Relation::morphMap([
+            $typeKey => static::class,
+        ]);
+    }
+
+    public static function createWithText(string $text): static
+    {
+        return static::query()->create(['body' => $text]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function mentionableTextFields(): array
+    {
+        return ['body'];
+    }
+
+    public function setText(string $text): static
+    {
+        $this->forceFill(['body' => $text])->save();
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/FixtureTicketPolicy.php
+++ b/tests/Fixtures/FixtureTicketPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures;
+
+use FluxErp\Models\Ticket;
+use FluxErp\Models\User;
+
+class FixtureTicketPolicy
+{
+    /**
+     * @var array<int, int>
+     */
+    public static array $allowedIds = [];
+
+    public function view(User $user, Ticket $ticket): bool
+    {
+        return in_array($ticket->getKey(), static::$allowedIds, true);
+    }
+}

--- a/tests/Fixtures/MentionableFixture.php
+++ b/tests/Fixtures/MentionableFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures;
+
+use FluxErp\Traits\Model\Mentionable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+class MentionableFixture extends Model
+{
+    use Mentionable;
+
+    protected $table = 'mentionable_fixtures';
+
+    protected $guarded = [];
+
+    /**
+     * Register the fixture (or any class) in the morph map under the given
+     * type key so the `Mentionable` trait + `get_models_with_trait()` helper
+     * pick it up. This is the equivalent of calling `Relation::morphMap([...])`
+     * manually.
+     */
+    public static function register(string $typeKey, ?string $class = null): void
+    {
+        Relation::morphMap([
+            $typeKey => $class ?? static::class,
+        ]);
+
+        Cache::forget('models_with_trait:' . Mentionable::class);
+    }
+
+    /**
+     * @return Collection<int, static>
+     */
+    public static function searchMentionCandidates(string $query, int $limit = 5): Collection
+    {
+        $trimmed = trim($query);
+        if ($trimmed === '') {
+            return collect();
+        }
+
+        return static::query()
+            ->where('name', 'like', $trimmed . '%')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function getMentionUrl(): string
+    {
+        return '/fixtures/' . $this->getKey();
+    }
+}

--- a/tests/Unit/Services/Mentions/MentionHtmlTest.php
+++ b/tests/Unit/Services/Mentions/MentionHtmlTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use FluxErp\Services\Mentions\MentionHtml;
+
+it('converts a user mention span to a token', function (): void {
+    $html = 'Hi <span class="mention" data-type="mention" data-id="user:42">@Max</span>!';
+
+    expect(MentionHtml::toTokens($html))->toBe('Hi @user:42!');
+});
+
+it('converts a record mention span to a token', function (): void {
+    $html = 'See <span data-id="ticket:7">#7</span>';
+
+    expect(MentionHtml::toTokens($html))->toBe('See #ticket:7');
+});
+
+it('converts multiple spans in one body', function (): void {
+    $html = '<span data-id="user:1">@a</span> and <span data-id="order:9">O-9</span>';
+
+    expect(MentionHtml::toTokens($html))->toBe('@user:1 and #order:9');
+});
+
+it('leaves existing plain tokens and unrelated markup untouched', function (): void {
+    $html = '<p>plain @user:5 and <strong>bold</strong></p>';
+
+    expect(MentionHtml::toTokens($html))->toBe('<p>plain @user:5 and <strong>bold</strong></p>');
+});
+
+it('is idempotent', function (): void {
+    $html = '<span data-id="user:42">@Max</span>';
+    $once = MentionHtml::toTokens($html);
+
+    expect($once)->toBe('@user:42');
+    expect(MentionHtml::toTokens($once))->toBe($once);
+});
+
+it('leaves spans whose data-id is not a key:id mention untouched', function (): void {
+    $html = '<span data-id="foo">x</span> and <span data-id="user:abc">y</span>';
+
+    expect(MentionHtml::toTokens($html))->toBe($html);
+});

--- a/tests/Unit/Services/Mentions/MentionParserTest.php
+++ b/tests/Unit/Services/Mentions/MentionParserTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use FluxErp\Enums\MentionTypeEnum;
+use FluxErp\Services\Mentions\MentionParser;
+use FluxErp\Tests\Fixtures\MentionableFixture;
+
+beforeEach(function (): void {
+    $this->parser = new MentionParser();
+});
+
+it('parses #key:id record tokens', function (): void {
+    MentionableFixture::register('ticket');
+
+    $result = $this->parser->parse('Schau #ticket:1234 an', collect());
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['type'])->toBe(MentionTypeEnum::Record);
+    expect($result[0]['mentionable_type'])->toBe('ticket');
+    expect($result[0]['mentionable_id'])->toBe(1234);
+});
+
+it('parses #key:id as a record mention', function (): void {
+    MentionableFixture::register('ticket');
+
+    $out = $this->parser->parse('see #ticket:7', collect());
+
+    expect($out)->toHaveCount(1);
+    expect($out[0]['type'])->toBe(MentionTypeEnum::Record);
+    expect($out[0]['mentionable_type'])->toBe('ticket');
+    expect($out[0]['mentionable_id'])->toBe(7);
+});
+
+it('parses @user:id as an explicit user mention', function (): void {
+    $out = $this->parser->parse('hi @user:42', collect());
+
+    expect($out)->toHaveCount(1);
+    expect($out[0]['type'])->toBe(MentionTypeEnum::User);
+    expect($out[0]['user_id'])->toBe(42);
+    expect($out[0]['mentionable_type'])->toBeNull();
+});
+
+it('ignores #user:id (users are @, not #)', function (): void {
+    MentionableFixture::register('ticket');
+
+    expect($this->parser->parse('nope #user:1', collect()))->toBe([]);
+});
+
+it('parses @firstname user tokens via member scope', function (): void {
+    $member = (object) ['id' => 42, 'firstname' => 'Martin', 'user_code' => 'MS'];
+
+    $result = $this->parser->parse('Hallo @martin', collect([$member]));
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['type'])->toBe(MentionTypeEnum::User);
+    expect($result[0]['user_id'])->toBe(42);
+});
+
+it('parses @all and @channel into Channel mentions', function (): void {
+    foreach (['all', 'channel'] as $token) {
+        $result = $this->parser->parse("@{$token}", collect());
+
+        expect($result[0]['type'])->toBe(MentionTypeEnum::Channel);
+    }
+});
+
+it('parses @here into a Here mention', function (): void {
+    $result = $this->parser->parse('@here', collect());
+
+    expect($result[0]['type'])->toBe(MentionTypeEnum::Here);
+});
+
+it('ignores mentions inside code fences', function (): void {
+    MentionableFixture::register('ticket');
+
+    $text = "Normal #ticket:1\n```\n#ticket:2\n```\n#ticket:3";
+
+    $result = $this->parser->parse($text, collect());
+
+    expect(collect($result)->pluck('mentionable_id')->all())->toEqual([1, 3]);
+});
+
+it('ignores escaped \\# tokens', function (): void {
+    MentionableFixture::register('ticket');
+
+    $result = $this->parser->parse('\\#ticket:1 ist nicht gemeint, aber #ticket:2 schon', collect());
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['mentionable_id'])->toBe(2);
+});
+
+it('does not double-parse a record token as a user token', function (): void {
+    MentionableFixture::register('ticket');
+    $member = (object) ['id' => 5, 'firstname' => 'ticket', 'user_code' => 'TKT'];
+
+    $result = $this->parser->parse('#ticket:1', collect([$member]));
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['type'])->toBe(MentionTypeEnum::Record);
+});

--- a/tests/Unit/Services/Mentions/MentionRendererTest.php
+++ b/tests/Unit/Services/Mentions/MentionRendererTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use FluxErp\Services\Mentions\MentionRenderer;
+use FluxErp\Tests\Fixtures\MentionableFixture;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    if (! Schema::hasTable('mentionable_fixtures')) {
+        Schema::create('mentionable_fixtures', function ($table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    $this->renderer = app(MentionRenderer::class);
+});
+
+it('replaces #key:id tokens with anchor pills', function (): void {
+    MentionableFixture::register('mentionable_fixture');
+    $record = MentionableFixture::create(['name' => 'RMA 1234']);
+    $key = $record::mentionTypeKey();
+
+    $html = $this->renderer->tokensToHtml("Schau #{$key}:{$record->getKey()} an");
+
+    expect($html)->toContain('<a');
+    expect($html)->toContain("data-mention=\"{$key}:{$record->getKey()}\"");
+    expect($html)->toContain('class="mention');
+    expect($html)->toContain('RMA 1234');
+});
+
+it('replaces @user:id tokens with user pills', function (): void {
+    $user = FluxErp\Models\User::factory()->create();
+
+    $html = $this->renderer->tokensToHtml("Ping @user:{$user->getKey()} bitte");
+
+    expect($html)->toContain('<a');
+    expect($html)->toContain('class="mention mention--user');
+    expect($html)->toContain("data-user-id=\"{$user->getKey()}\"");
+});
+
+it('falls back to plain text for deleted targets', function (): void {
+    MentionableFixture::register('mentionable_fixture');
+
+    $html = $this->renderer->tokensToHtml('#mentionable_fixture:999999');
+
+    expect($html)->toContain(__('@deleted entry'));
+    expect($html)->not->toContain('<a');
+});
+
+it('leaves unknown type keys untouched', function (): void {
+    $html = $this->renderer->tokensToHtml('#unknowntype:1');
+
+    expect($html)->toBe('#unknowntype:1');
+});
+
+it('escapes label HTML', function (): void {
+    MentionableFixture::register('mentionable_fixture');
+    $record = MentionableFixture::create(['name' => '<script>alert(1)</script>']);
+    $key = $record::mentionTypeKey();
+
+    $html = $this->renderer->tokensToHtml("#{$key}:{$record->getKey()}");
+
+    expect($html)->not->toContain('<script>');
+    expect($html)->toContain('&lt;script&gt;');
+});

--- a/tests/Unit/Services/Mentions/MentionSyncDiffTest.php
+++ b/tests/Unit/Services/Mentions/MentionSyncDiffTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use FluxErp\Models\Mention;
+use FluxErp\Services\Mentions\MentionSync;
+use FluxErp\Tests\Fixtures\CommentLikeFixture;
+use FluxErp\Tests\Fixtures\MentionableFixture;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    if (! Schema::hasTable('comment_like_fixtures')) {
+        Schema::create('comment_like_fixtures', function ($table): void {
+            $table->id();
+            $table->text('body')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    if (! Schema::hasTable('mentionable_fixtures')) {
+        Schema::create('mentionable_fixtures', function ($table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    CommentLikeFixture::register('comment_like_fixture');
+    MentionableFixture::register('ticket');
+});
+
+it('inserts new mention rows on first sync', function (): void {
+    $source = CommentLikeFixture::createWithText('Hi @user:' . $this->user->getKey());
+    app(MentionSync::class)->sync($source);
+
+    expect(Mention::count())->toBe(1);
+});
+
+it('is idempotent when content is unchanged', function (): void {
+    $source = CommentLikeFixture::createWithText('Hi @user:' . $this->user->getKey());
+    app(MentionSync::class)->sync($source);
+    app(MentionSync::class)->sync($source);
+
+    expect(Mention::count())->toBe(1);
+});
+
+it('removes obsolete rows when a mention is edited away', function (): void {
+    $source = CommentLikeFixture::createWithText('#ticket:1 #ticket:2');
+    app(MentionSync::class)->sync($source);
+
+    $source->setText('#ticket:1');
+    app(MentionSync::class)->sync($source);
+
+    expect(Mention::pluck('mention_target_id')->all())->toEqual([1]);
+});
+
+it('returns the delta of added rows', function (): void {
+    $source = CommentLikeFixture::withoutEvents(
+        fn () => CommentLikeFixture::createWithText('#ticket:1'),
+    );
+    app(MentionSync::class)->sync($source);
+
+    CommentLikeFixture::withoutEvents(
+        fn () => $source->setText('#ticket:1 #ticket:2'),
+    );
+    $result = app(MentionSync::class)->sync($source);
+
+    expect($result->added)->toHaveCount(1);
+    expect($result->added[0]['mention_target_id'])->toBe(2);
+});


### PR DESCRIPTION
- Generische `mentions`-Tabelle + `Mentionable`/`RecordsMentions`-Traits (User/Ticket/Order als Targets), generische `MentionNotification`.
- Comments: indexieren ihre Mentions über `RecordsMentions` durch In-Memory-Extraktion aus dem `data-id`-HTML (Storage bleibt rich HTML, kein Backfill); neuer `/search/mentionable`-Endpoint + Tiptap-Picker ermöglichen @user/@ticket/@order-Cross-Refs.
- Voraussetzung für nuxbe-chat Phase 2 (eigener Draft-PR, wartet auf flux-core-Release).

## Summary by Sourcery

Introduce a generic mention infrastructure across flux-core and wire it into comments and mentionable models.

New Features:
- Add a reusable Mentionable trait and MentionsContent contract to support generic @-mentions for users, tickets, and orders, including token parsing and HTML rendering.
- Expose a /search/mentionable endpoint and Tiptap mention configuration to power typeahead selection of mentionable records in the editor.
- Persist mentions in a dedicated mentions table with a RecordsMentions trait and observer that track mention tokens on source models and dispatch MentionNotification events to mentioned users.

Enhancements:
- Update Comment, User, Ticket, and Order models to participate in the new mention system, including mention pills styling and per-type icons and labels.
- Refine comment input and editor configuration to pass mentionable types, adjust mention suggestion rendering, and ensure missing avatars and deleted mention targets degrade gracefully.

Tests:
- Add unit, feature, browser, and migration tests covering mention parsing, syncing, rendering, controller behavior, database schema, and end-to-end comment mention flows.