### PR TITLE
fix(mail-folder): uniqueness check on uuid points at mail_folders table

### DIFF
--- a/src/Rulesets/MailFolder/CreateMailFolderRuleset.php
+++ b/src/Rulesets/MailFolder/CreateMailFolderRuleset.php
@@ -14,7 +14,7 @@ class CreateMailFolderRuleset extends FluxRuleset
     public function rules(): array
     {
         return [
-            'uuid' => 'nullable|string|uuid|unique:mail_accounts,uuid',
+            'uuid' => 'nullable|string|uuid|unique:mail_folders,uuid',
             'mail_account_id' => [
                 'required',
                 'integer',


### PR DESCRIPTION
## Summary

`CreateMailFolderRuleset` declared the uuid uniqueness constraint against `mail_accounts.uuid` instead of `mail_folders.uuid`. That both silenced collisions between mail folders and falsely rejected uuids already present on a mail account.

Point the rule at the correct table.

## Summary by Sourcery

Bug Fixes:
- Fix UUID uniqueness check for mail folders that incorrectly referenced the mail_accounts table instead of mail_folders.