### PR TITLE
use nullsafe operator for priceList in CartItem calculations

### DIFF
--- a/src/Models/CartItem.php
+++ b/src/Models/CartItem.php
@@ -22,10 +22,10 @@ class CartItem extends FluxModel implements Sortable
             ]);
 
             $cartItem->total = bcmul($cartItem->amount, $cartItem->price);
-            $cartItem->total_net = $cartItem->cart->priceList->is_net
+            $cartItem->total_net = $cartItem->cart->priceList?->is_net
                 ? $cartItem->total
                 : gross_to_net($cartItem->total, $cartItem->vatRate->rate_percentage);
-            $cartItem->total_gross = $cartItem->cart->priceList->is_net
+            $cartItem->total_gross = $cartItem->cart->priceList?->is_net
                 ? net_to_gross($cartItem->total, $cartItem->vatRate->rate_percentage)
                 : $cartItem->total;
         });


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent errors when calculating cart item totals if the associated price list is null by using a nullsafe operator on the price list net flag.