### PR TITLE
Improve employee select components

### DIFF
--- a/resources/views/components/employee/general.blade.php
+++ b/resources/views/components/employee/general.blade.php
@@ -259,13 +259,14 @@
                     ]
                 ]"
             />
-            <x-select.native
-                :label="__('Salary Type')"
-                wire:model="employee.salary_type"
-                :options="\FluxErp\Enums\SalaryTypeEnum::valuesLocalized()"
-                :hint="__('For hourly employees no negative balance is accumulated; positive overtime is still tracked.')"
-                x-bind:disabled="!isEditing"
-            />
+            <div x-bind:class="!isEditing && 'pointer-events-none'">
+                <x-select.styled
+                    :label="__('Salary Type')"
+                    wire:model="employee.salary_type"
+                    :options="\FluxErp\Enums\SalaryTypeEnum::valuesLocalized()"
+                    :hint="__('For hourly employees no negative balance is accumulated; positive overtime is still tracked.')"
+                />
+            </div>
         </div>
     </x-card>
 

--- a/resources/views/livewire/settings/employee-departments.blade.php
+++ b/resources/views/livewire/settings/employee-departments.blade.php
@@ -63,8 +63,10 @@
                     'url' => route('search', \FluxErp\Models\Employee::class),
                     'method' => 'POST',
                     'params' => [
-                        'searchFields' => ['name', 'email']
-                    ]
+                        'where' => [
+                            ['is_active', '=', true],
+                        ],
+                    ],
                 ]"
             />
 


### PR DESCRIPTION
## Summary
- Department manager select (settings): dropped redundant `searchFields` so Scout handles the search (preserves typo tolerance/relevance), added `is_active = true` filter so inactive/terminated employees are no longer selectable as managers.
- Salary type field (employee general view): converted from `x-select.native` to `x-select.styled` for consistent UI; wrapped in a `pointer-events-none` div to preserve the read-only behavior outside edit mode.

## Summary by Sourcery

Update employee selection UX to improve manager eligibility and salary type editing behavior.

Bug Fixes:
- Exclude inactive employees from being selectable as department managers.

Enhancements:
- Switch the salary type field to the styled select component while preserving its read-only behavior outside edit mode.
- Rely on the default search behavior for employee manager selection while adding an active-status filter.