### PR TITLE
fix slug positions in order print view

### DIFF
--- a/src/View/Printing/Order/OrderView.php
+++ b/src/View/Printing/Order/OrderView.php
@@ -67,28 +67,33 @@ class OrderView extends PrintableView
     public function prepareModel(): void
     {
         $positions = array_map(
-            fn (array $item) => app(OrderPosition::class)->forceFill($item),
+            fn (array $item) => app(OrderPosition::class)
+                ->forceFill(array_replace($item, ['slug_position' => $item['new_slug_position'] ?? null])),
             to_flat_tree(
-                resolve_static(OrderPosition::class, 'withTemporaryGlobalScopes', [
-                    'scopes' => [
-                        'sorted' => function (Builder $query): void {
-                            $query->ordered()
-                                ->with([
-                                    'tags',
-                                    'product' => fn (BelongsTo $query) => $query->withTrashed()->with('unit:id,name,abbreviation'),
-                                ])
-                                ->when(
-                                    ! $this->showAlternatives,
-                                    fn (Builder $query) => $query->whereNot('is_alternative', true)
-                                );
-                        },
-                        resolve_static(FamilyTreeScope::class, 'class') => app(FamilyTreeScope::class),
-                    ],
-                ])
-                    ->where('order_id', $this->model->getKey())
-                    ->whereNull('parent_id')
-                    ->get()
-                    ->toArray()
+                $this->reorderSlugPositions(
+                    resolve_static(OrderPosition::class, 'withTemporaryGlobalScopes', [
+                        'scopes' => [
+                            'sorted' => function (Builder $query): void {
+                                $query->ordered()
+                                    ->with([
+                                        'tags',
+                                        'product' => fn (BelongsTo $query) => $query
+                                            ->withTrashed()
+                                            ->with('unit:id,name,abbreviation'),
+                                    ])
+                                    ->when(
+                                        ! $this->showAlternatives,
+                                        fn (Builder $query) => $query->whereNot('is_alternative', true)
+                                    );
+                            },
+                            resolve_static(FamilyTreeScope::class, 'class') => app(FamilyTreeScope::class),
+                        ],
+                    ])
+                        ->where('order_id', $this->model->getKey())
+                        ->whereNull('parent_id')
+                        ->get()
+                        ->toArray()
+                )
             )
         );
 
@@ -101,5 +106,27 @@ class OrderView extends PrintableView
         }
 
         $this->model->setRelation('orderPositions', $flattened);
+    }
+
+    protected function reorderSlugPositions(array $positions, ?string $parentSlug = null): array
+    {
+        $index = 0;
+        foreach ($positions as &$position) {
+            $slug = null;
+            if (data_get($position, 'total_net_price')) {
+                $index++;
+                $segment = str_pad((string) $index, 8, '0', STR_PAD_LEFT);
+                $position['new_slug_position'] = $slug = is_null($parentSlug) ? $segment : $parentSlug . '.' . $segment;
+            }
+
+            if (count($position['children'] ?? []) > 0) {
+                $position['children'] = $this->reorderSlugPositions(
+                    $position['children'],
+                    $slug ?? $position['slug_position']
+                );
+            }
+        }
+
+        return $positions;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Recalculate and normalize order position slug values in the order print view so that printed positions have consistent hierarchical slug ordering.

Bug Fixes:
- Ensure slug_position values used in the order print view are recomputed in hierarchical order based on visible positions, fixing incorrect or inconsistent slug placement.

Enhancements:
- Introduce a recursive helper to reorder slug positions for parent and child order positions before flattening them for printing.