### PR TITLE
Block known Livewire deserialization gadget payloads at the edge

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -10,6 +10,7 @@ use FluxErp\Helpers\Livewire\Features\SupportFormObjects;
 use FluxErp\Helpers\MediaLibraryDownloader;
 use FluxErp\Http\Controllers\AuthenticateUsingPasskeyController;
 use FluxErp\Http\Middleware\AuthContextMiddleware;
+use FluxErp\Http\Middleware\BlockLivewireExploitPayloads;
 use FluxErp\Http\Middleware\EnsureTwoFactorSetup;
 use FluxErp\Http\Middleware\Localization;
 use FluxErp\Http\Middleware\Permissions;
@@ -282,6 +283,9 @@ class FluxServiceProvider extends ServiceProvider
         /** @var Kernel $kernel */
         $kernel = $this->app->make(Kernel::class);
         $kernel->prependMiddlewareToGroup('api', EnsureFrontendRequestsAreStateful::class);
+
+        $kernel->prependMiddlewareToGroup('web', BlockLivewireExploitPayloads::class);
+        $kernel->prependMiddlewareToGroup('api', BlockLivewireExploitPayloads::class);
 
         $kernel->appendMiddlewareToGroup('web', Localization::class);
         $kernel->appendMiddlewareToGroup('web', AuthContextMiddleware::class);

--- a/src/Http/Middleware/BlockLivewireExploitPayloads.php
+++ b/src/Http/Middleware/BlockLivewireExploitPayloads.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace FluxErp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class BlockLivewireExploitPayloads
+{
+    /**
+     * Class names that are part of known PHP deserialization gadget chains
+     * abused to escalate a Livewire snapshot into RCE. None of them belong
+     * in a legitimate Livewire component snapshot.
+     */
+    protected const array GADGET_SIGNATURES = [
+        'Illuminate\\Broadcasting\\PendingBroadcast',
+        'Illuminate\\Broadcasting\\BroadcastEvent',
+        'Illuminate\\Queue\\QueueManager',
+        'Illuminate\\Auth\\RequestGuard',
+        'Laravel\\SerializableClosure\\Serializers\\Signed',
+        'GuzzleHttp\\Psr7\\FnStream',
+        'League\\Flysystem\\UrlGeneration\\ShardedPrefixPublicUrlGenerator',
+        'Laravel\\Prompts\\Terminal',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $body = $request->getContent();
+
+        if ($body === '' || ! str_contains($body, '\\\\')) {
+            return $next($request);
+        }
+
+        foreach (self::GADGET_SIGNATURES as $signature) {
+            if (! str_contains($body, str_replace('\\', '\\\\', $signature))) {
+                continue;
+            }
+
+            Log::channel(config('flux.attack_log_channel', 'stack'))->warning(
+                'Blocked Livewire RCE gadget payload',
+                [
+                    'ip' => $request->ip(),
+                    'url' => $request->fullUrl(),
+                    'user_agent' => $request->userAgent(),
+                    'signature' => $signature,
+                ]
+            );
+
+            throw new AccessDeniedHttpException('Forbidden');
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Http/Middleware/BlockLivewireExploitPayloadsTest.php
+++ b/tests/Feature/Http/Middleware/BlockLivewireExploitPayloadsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use FluxErp\Http\Middleware\BlockLivewireExploitPayloads;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+test('passes legitimate Livewire snapshot through', function (): void {
+    $body = json_encode([
+        '_token' => 'abc',
+        'components' => [[
+            'snapshot' => '{"data":{"email":null},"memo":{"name":"auth.login"},"checksum":"deadbeef"}',
+            'updates' => ['email' => 'test@example.com'],
+            'calls' => [],
+        ]],
+    ]);
+
+    $request = Request::create('/livewire-abc/update', 'POST', [], [], [], [], $body);
+    $request->headers->set('content-type', 'application/json');
+
+    $called = false;
+    app(BlockLivewireExploitPayloads::class)->handle($request, function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+});
+
+test('blocks PendingBroadcast gadget chain', function (): void {
+    $body = '{"components":[{"snapshot":"{\\"data\\":{\\"email\\":[{\\"a\\":[{\\"close\\":[[[{\\"chained\\":[\\"O:40:\\\\\\"Illuminate\\\\\\\\Broadcasting\\\\\\\\PendingBroadcast\\\\\\":1:{}\\"]}]]]]]]}}"}]}';
+
+    $request = Request::create('/livewire-abc/update', 'POST', [], [], [], [], $body);
+
+    expect(function () use ($request): void {
+        app(BlockLivewireExploitPayloads::class)->handle($request, fn () => response('ok'));
+    })->toThrow(AccessDeniedHttpException::class);
+});
+
+test('blocks SerializableClosure Signed gadget', function (): void {
+    $body = '{"updates":{"x":{"class":"Laravel\\\\SerializableClosure\\\\Serializers\\\\Signed"}}}';
+
+    $request = Request::create('/livewire-abc/update', 'POST', [], [], [], [], $body);
+
+    expect(function () use ($request): void {
+        app(BlockLivewireExploitPayloads::class)->handle($request, fn () => response('ok'));
+    })->toThrow(AccessDeniedHttpException::class);
+});
+
+test('blocks ShardedPrefixPublicUrlGenerator gadget', function (): void {
+    $body = '{"x":{"class":"League\\\\Flysystem\\\\UrlGeneration\\\\ShardedPrefixPublicUrlGenerator"}}';
+
+    $request = Request::create('/livewire-abc/update', 'POST', [], [], [], [], $body);
+
+    expect(function () use ($request): void {
+        app(BlockLivewireExploitPayloads::class)->handle($request, fn () => response('ok'));
+    })->toThrow(AccessDeniedHttpException::class);
+});
+
+test('ignores requests without escaped backslashes', function (): void {
+    $body = '{"plain":"text without escapes"}';
+
+    $request = Request::create('/api/whatever', 'POST', [], [], [], [], $body);
+
+    $called = false;
+    app(BlockLivewireExploitPayloads::class)->handle($request, function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Livewire's checksum verification already throws `CorruptComponentPayloadException` when a tampered snapshot reaches `Checksum::verify()`, so the standard exploit chain (`Illuminate\Broadcasting\PendingBroadcast` → `SerializableClosure\Signed` → `GuzzleHttp\Psr7\FnStream` → `League\Flysystem\UrlGeneration\ShardedPrefixPublicUrlGenerator`) is blocked today. However:

- Every attempt still hits the application, allocates a request, fills the `livewire-checksum-failures` rate limiter bucket, and floods the error tracker with `CorruptComponentPayloadException` noise.
- A future `unserialize()` somewhere in the stack could turn these payloads into real RCE.

This middleware short-circuits any request whose body contains a known gadget-chain class name (escaped form, since the payload arrives JSON-encoded). It runs first on both the `web` and `api` middleware groups, returns 403, and logs a structured warning that operations can hook into for firewall/fail2ban automation.

## Detection

- Matches the exact escaped class signatures observed in production scans (one source IP, ~979 hits across 12 tenants over the past 2 weeks).
- Skips the early-return when the body has no `\\` to avoid scanning every plain JSON/form-encoded request.

## Tests

Feature tests cover legitimate snapshots passing through and each gadget signature triggering the 403 path.

## Summary by Sourcery

Block known Livewire deserialization gadget payloads early in the request pipeline for web and API traffic.

New Features:
- Introduce middleware that inspects request bodies for known Livewire deserialization gadget signatures and blocks matching requests with a 403 response.

Enhancements:
- Log structured warnings to a dedicated attack log channel when exploit-like Livewire payloads are detected to aid monitoring and automation.

Tests:
- Add feature tests to ensure legitimate Livewire snapshots pass through while known gadget signatures and irrelevant requests are correctly allowed or denied.