### PR TITLE
fix(communication): allow string message_uid in validation rules

### DIFF
--- a/src/Rulesets/Communication/CreateCommunicationRuleset.php
+++ b/src/Rulesets/Communication/CreateCommunicationRuleset.php
@@ -41,7 +41,7 @@ class CreateCommunicationRuleset extends FluxRuleset
                 app(ModelExists::class, ['model' => MailFolder::class]),
             ],
             'message_id' => 'nullable|string|max:255',
-            'message_uid' => 'integer',
+            'message_uid' => 'nullable|string|max:255',
             'from' => 'nullable|string|max:255',
             'to' => 'nullable|array',
             'cc' => 'nullable|array',

--- a/src/Rulesets/Communication/UpdateCommunicationRuleset.php
+++ b/src/Rulesets/Communication/UpdateCommunicationRuleset.php
@@ -36,7 +36,7 @@ class UpdateCommunicationRuleset extends FluxRuleset
                 'nullable',
                 app(ModelExists::class, ['model' => MailFolder::class]),
             ],
-            'message_uid' => 'nullable|integer',
+            'message_uid' => 'nullable|string|max:255',
             'from' => 'nullable|string|max:255',
             'to' => 'array',
             'cc' => 'array',


### PR DESCRIPTION
## Summary

\`communications.message_uid\` was widened from integer to string in v1.2.9 so non-numeric provider ids (Microsoft Graph, Gmail history ids, …) fit. The create/update rulesets still required \`integer\`, which blocked every Graph mail import with \`Nachrichten-UID muss eine ganze Zahl sein\`.

Relax both rules to \`nullable|string|max:255\` to match the column.

## Summary by Sourcery

Bug Fixes:
- Align create and update communication rulesets with the database schema by allowing nullable string message_uid values up to 255 characters.