### PR TITLE
feat(mail-account): add @stack hooks to mail account form for package extension

### DIFF
--- a/resources/views/livewire/settings/mail-accounts.blade.php
+++ b/resources/views/livewire/settings/mail-accounts.blade.php
@@ -128,12 +128,14 @@
                         :label="__('oAuth')"
                     />
                 </div>
+                @stack('mail-account-form-inbound-extra')
                 <x-toggle
                     wire:model.boolean="mailAccount.has_auto_assign"
                     :label="__('Auto assign mails')"
                 />
             </div>
             <x-slot:footer>
+                @stack('mail-account-form-inbound-footer-actions')
                 <x-button
                     loading
                     color="indigo"
@@ -188,8 +190,10 @@
                         ['value' => 'tls', 'label' => __('TLS')],
                     ]"
                 />
+                @stack('mail-account-form-smtp-extra')
             </div>
             <x-slot:footer>
+                @stack('mail-account-form-smtp-footer-actions')
                 <x-button
                     color="secondary"
                     light


### PR DESCRIPTION
## Summary

- Adds four `@stack(...)` hooks to the MailAccount edit modal so external packages can inject UI without overriding the view.
- Hooks: `mail-account-form-inbound-extra`, `mail-account-form-inbound-footer-actions`, `mail-account-form-smtp-extra`, `mail-account-form-smtp-footer-actions`.
- No behavior change. Used by `flux-office365` to render a delegated Microsoft sign-in button next to the protocol selector.

## Summary by Sourcery

Add extension hooks to the mail account edit form to allow external packages to inject additional inbound and SMTP UI sections without overriding the view.

New Features:
- Expose stack hooks around inbound mail settings to allow extra content and footer actions to be injected by extensions.
- Expose stack hooks around SMTP settings to allow extra content and footer actions to be injected by extensions.