### PR TITLE
Fix dead subfolder creation button in folder tree under Livewire v4

### DIFF
--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -183,12 +183,20 @@
                                         color="secondary"
                                         light
                                         :text="__('Add folder')"
-                                        wire:click="saveFolder({
-                                        parent_id: selection.id,
-                                        name: '{{ __('New folder') }}',
-                                        is_new: true,
-                                        children: []
-                                    }).then((folder) => { if (folder) addFolder(selectionProxy, folder); })"
+                                        x-on:click="
+                                            $wire
+                                                .saveFolder({
+                                                    parent_id: selection.id,
+                                                    name: '{{ __('New folder') }}',
+                                                    is_new: true,
+                                                    children: [],
+                                                })
+                                                .then((folder) => {
+                                                    if (folder) {
+                                                        addFolder(selectionProxy, folder)
+                                                    }
+                                                })
+                                        "
                                     />
                                 @endcanAction
                                 @canAction(\FluxErp\Actions\Media\DownloadMultipleMedia::class)

--- a/tests/Browser/Features/Media/FolderTreeSubfolderTest.php
+++ b/tests/Browser/Features/Media/FolderTreeSubfolderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\MediaFolder;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+    Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $this->rootFolder = MediaFolder::create([
+        'name' => 'Wurzelordner',
+        'model_type' => morph_alias(Contact::class),
+        'model_id' => $this->contact->getKey(),
+    ]);
+    $this->contact->mediaFolders()->attach($this->rootFolder->getKey());
+});
+
+test('subfolder can be created below a selected folder in the attachments tree', function (): void {
+    $page = visit('/contacts/contacts/' . $this->contact->getKey())
+        ->assertNoSmoke();
+
+    waitForElement($page, '[data-tab-name*="attachment"]');
+
+    $page->script(<<<'JS'
+        () => document.querySelector('[data-tab-name*="attachment"]').click()
+    JS);
+
+    waitForCondition($page, <<<'JS'
+        () => Array.from(document.querySelectorAll('li, span, div'))
+            .some(el => el.childElementCount === 0 && el.textContent?.trim() === 'Wurzelordner')
+    JS, 15000);
+
+    $page->script(<<<'JS'
+        () => {
+            const node = Array.from(document.querySelectorAll('li, span, div'))
+                .find(el => el.childElementCount === 0 && el.textContent?.trim() === 'Wurzelordner');
+            node.click();
+        }
+    JS);
+
+    // the subfolder button lives in the selection action area, uniquely
+    // identified by its x-show binding on multipleFileUpload
+    waitForCondition($page, <<<'JS'
+        () => {
+            const btn = document.querySelector('button[x-show*="multipleFileUpload"]');
+            return btn && btn.offsetParent !== null;
+        }
+    JS);
+
+    $page->script(<<<'JS'
+        () => document.querySelector('button[x-show*="multipleFileUpload"]').click()
+    JS);
+
+    waitForCondition($page, <<<'JS'
+        () => Array.from(document.querySelectorAll('li, span, div'))
+            .some(el => el.childElementCount === 0 && /^(Neuer Ordner|New folder)$/.test(el.textContent?.trim()))
+    JS, 10000);
+
+    $page->assertNoJavascriptErrors();
+
+    expect(
+        MediaFolder::query()
+            ->where('parent_id', $this->rootFolder->getKey())
+            ->exists()
+    )->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- The **Add folder** button in the folder tree's selection action area used `wire:click` with an inline object literal and a `.then()` arrow callback. Livewire v4 runs `wire:*` action expressions through `contextualizeExpression()`, which prefixes bare identifiers with `$wire.` — including the arrow parameter, producing `($wire.folder) => ...`. That is not a valid binding target, so the handler failed to compile with `SyntaxError: Invalid destructuring assignment target` and the click did nothing. Creating folders on root level kept working because that button already used `x-on:click`.
- Convert the subfolder button to `x-on:click` with an explicit `$wire.saveFolder(...)` call, matching the root-level button.
- Add a browser test that selects a folder in the contact attachments tree, clicks the subfolder button, and asserts the subfolder is persisted without console errors.

## Summary by Sourcery

Fix subfolder creation in the media folder tree under Livewire v4 and add a browser test to prevent regressions.

Bug Fixes:
- Restore the functionality of the "Add folder" button for creating subfolders in the folder tree selection actions when a folder is selected.

Tests:
- Add a browser test that verifies a subfolder can be created under a selected folder in the contact attachments tree without JavaScript errors.