### PR TITLE
fix(frontend-assets): make asset route closures route:cache safe under Octane

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -293,17 +293,22 @@ class FrontendAssets
 
     protected function registerRoutes(): void
     {
-        Route::get('/flux/flux.css', fn () => $this->returnCssAsFile())
+        // Closures must not capture $this — route:cache serializes them and a
+        // stale bound instance unserializes as __PHP_Incomplete_Class after deploys.
+        Route::get('/flux/flux.css', static fn () => app(static::class)->returnCssAsFile())
             ->name('flux.assets.css');
 
-        Route::get('/flux/flux.js', fn () => $this->returnJsAsFile())
+        Route::get('/flux/flux.js', static fn () => app(static::class)->returnJsAsFile())
             ->name('flux.assets.js');
 
-        Route::get('/flux/packages/{package}/{file}', fn (string $package, string $file) => $this->returnPackageAssetFile($package, $file))
+        Route::get(
+            '/flux/packages/{package}/{file}',
+            static fn (string $package, string $file) => app(static::class)->returnPackageAssetFile($package, $file)
+        )
             ->where('file', '.+')
             ->name('flux.assets.package');
 
-        Route::get('/flux/{file}', fn (string $file) => $this->returnAssetFile($file))
+        Route::get('/flux/{file}', static fn (string $file) => app(static::class)->returnAssetFile($file))
             ->where('file', '.+')
             ->name('flux.assets.file');
     }

--- a/tests/Feature/Mechanisms/FrontendAssetsTest.php
+++ b/tests/Feature/Mechanisms/FrontendAssetsTest.php
@@ -3,6 +3,8 @@
 use FluxErp\Mechanisms\FrontendAssets\FrontendAssets;
 use FluxErp\Mechanisms\FrontendAssets\SupportAutoInjectedAssets;
 use Illuminate\Support\Facades\Route;
+use Laravel\SerializableClosure\SerializableClosure;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
 
 beforeEach(function (): void {
     $this->frontendAssets = app(FrontendAssets::class);
@@ -275,6 +277,32 @@ describe('Octane Compatibility', function (): void {
         $response2 = $this->actingAsGuest()->get(route('login'));
         $response2->assertOk();
         expect($response2->getContent())->toContain('<link rel="stylesheet"');
+    });
+});
+
+describe('Route Cache Compatibility', function (): void {
+    test('asset route closures do not capture the frontend assets instance', function (string $routeName): void {
+        $closure = Route::getRoutes()->getByName($routeName)->getAction('uses');
+
+        $reflection = new ReflectionClosure($closure);
+
+        expect($reflection->isBindingRequired())->toBeFalse();
+    })->with([
+        'flux.assets.css',
+        'flux.assets.js',
+        'flux.assets.package',
+        'flux.assets.file',
+    ]);
+
+    test('asset route closures survive serialization round-trip', function (): void {
+        $closure = Route::getRoutes()->getByName('flux.assets.css')->getAction('uses');
+
+        $rehydrated = unserialize(serialize(new SerializableClosure($closure)))
+            ->getClosure();
+
+        $response = $rehydrated();
+
+        expect($response->headers->get('Content-Type'))->toBe('text/css; charset=utf-8');
     });
 });
 


### PR DESCRIPTION
## Problem

`FrontendAssets::registerRoutes()` registered the four `/flux/*` asset routes with closures capturing `$this`. When `php artisan route:cache` runs, Laravel serializes these closures together with the bound `FrontendAssets` instance. After a deploy (`composer install` rewrites the class file) the cached routes file still contains the old serialized instance, which unserializes as `__PHP_Incomplete_Class` under Octane. Every `/flux/*` asset request then fails with:

```
The script tried to call a method on an incomplete object.
Please ensure that the class definition "FluxErp\Mechanisms\FrontendAssets\FrontendAssets"
of the object you are trying to operate on was loaded _before_ unserialize() gets called
```

This hit production after every deploy on Octane-served instances, breaking all CSS/JS assets until the route cache was manually cleared.

## Fix

The route closures are now `static` and resolve the `FrontendAssets` singleton (bound in `ViewServiceProvider`) from the container at request time via `app(static::class)`. Serialized closures only carry the class name string, which is safe across deploys and Octane reloads.

## Tests

- Asserts via `ReflectionClosure::isBindingRequired()` that none of the four asset route closures capture the instance (failed before the fix).
- Asserts that a route closure survives a `SerializableClosure` round-trip and still serves the asset.

## Summary by Sourcery

Make frontend asset routes compatible with Laravel route caching and Octane by avoiding instance-bound closures for flux asset endpoints.

Bug Fixes:
- Prevent frontend /flux/* asset routes from failing after deploys when route closures are deserialized under Octane.

Enhancements:
- Resolve the FrontendAssets singleton from the container at request time in asset routes instead of capturing the instance in route closures.

Tests:
- Add feature tests ensuring flux asset route closures do not capture the FrontendAssets instance and remain functional after a SerializableClosure serialization round-trip.