### PR TITLE
Add order-detail-action-card-actions blade stack

### DIFF
--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -964,7 +964,7 @@
                                         @foreach ($additionalModelActions as $modelAction)
                                             {{ $modelAction }}
                                         @endforeach
-
+                                        @stack('order-detail-action-card-actions')
                                     @show
                                 </div>
                             </x-card>


### PR DESCRIPTION
## Summary
- Adds `@stack('order-detail-action-card-actions')` inside the `@section('actions')` block of `resources/views/livewire/order/order.blade.php`.
- Lets plugins push additional buttons / Livewire components into the sidebar action card on the order detail view via `@push('order-detail-action-card-actions')` without overriding the view or extending the Order Livewire component.

## Summary by Sourcery

New Features:
- Introduce an order-detail-action-card-actions Blade stack in the order detail view to let plugins inject additional sidebar action card content without overriding the core view or component.