### PR TITLE
Prevent child amount reset when parent amount is cleared

### DIFF
--- a/src/Actions/OrderPosition/UpdateOrderPosition.php
+++ b/src/Actions/OrderPosition/UpdateOrderPosition.php
@@ -89,24 +89,26 @@ class UpdateOrderPosition extends FluxAction
         unset($orderPosition->discounts, $orderPosition->unit_price);
         $orderPosition->save();
 
-        if ($orderPosition->wasChanged('amount')) {
+        if ($orderPosition->wasChanged('amount') && bccomp($orderPosition->amount ?? 0, 0) === 1) {
             $children = resolve_static(OrderPosition::class, 'query')
                 ->where('parent_id', $orderPosition->getKey())
                 ->whereNotNull('amount')
                 ->get();
 
-            $previousAmount = data_get($orderPosition->getPrevious(), 'amount') ?? 1;
-            $previousAmount = bccomp($previousAmount, 0) === 0 ? 1 : $previousAmount;
+            $previousAmount = data_get($orderPosition->getPrevious(), 'amount');
+            $hasPreviousAmount = ! is_null($previousAmount) && bccomp($previousAmount, 0) === 1;
 
             foreach ($children as $child) {
-                $amountBundle = $child->amount_bundle ?? bcdiv($child->amount, $previousAmount);
+                $amountBundle = $child->amount_bundle
+                    ?? ($hasPreviousAmount ? bcdiv($child->amount, $previousAmount) : null);
+
+                if (is_null($amountBundle)) {
+                    continue;
+                }
 
                 UpdateOrderPosition::make([
                     'id' => $child->getKey(),
-                    'amount' => bcmul(
-                        $amountBundle,
-                        bccomp($orderPosition->amount, 0) === 0 ? 1 : $orderPosition->amount
-                    ),
+                    'amount' => bcmul($amountBundle, $orderPosition->amount),
                 ])
                     ->validate()
                     ->execute();

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -197,3 +197,164 @@ test('amount validation only runs when origin position exists in parent order', 
         'amount' => 999,
     ], 'origin_position_id');
 });
+
+test('clearing amount on free text group parent keeps child amounts', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+        'amount' => 4,
+        'discount_percentage' => null,
+    ]);
+
+    $children = collect([4, 16])->map(fn (int $amount) => OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => $amount,
+        'amount_bundle' => null,
+        'discount_percentage' => null,
+    ]));
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'name' => 'Changed Group Title',
+        'amount' => 0,
+    ])->validate()->execute();
+
+    expect($children[0]->refresh()->amount)->toEqual(4.0)
+        ->and($children[1]->refresh()->amount)->toEqual(16.0);
+});
+
+test('setting amount to null on free text group parent keeps child amounts', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+        'amount' => 4,
+        'discount_percentage' => null,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => 4,
+        'amount_bundle' => null,
+        'discount_percentage' => null,
+    ]);
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'name' => 'Changed Group Title',
+        'amount' => null,
+    ])->validate()->execute();
+
+    expect($child->refresh()->amount)->toEqual(4.0);
+});
+
+test('changing amount on free text group parent rescales child amounts proportionally', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+        'amount' => 4,
+        'discount_percentage' => null,
+    ]);
+
+    $children = collect([4, 16])->map(fn (int $amount) => OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => $amount,
+        'amount_bundle' => null,
+        'discount_percentage' => null,
+    ]));
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'amount' => 8,
+    ])->validate()->execute();
+
+    expect($children[0]->refresh()->amount)->toEqual(8.0)
+        ->and($children[1]->refresh()->amount)->toEqual(32.0);
+});
+
+test('clearing amount on bundle parent keeps bundle child amounts', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => 2,
+        'discount_percentage' => null,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'is_bundle_position' => true,
+        'amount' => 6,
+        'amount_bundle' => 3,
+        'discount_percentage' => null,
+    ]);
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'amount' => 0,
+    ])->validate()->execute();
+
+    expect($child->refresh()->amount)->toEqual(6.0);
+});
+
+test('changing amount on bundle parent rescales bundle children by amount bundle', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => 2,
+        'discount_percentage' => null,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'is_bundle_position' => true,
+        'amount' => 6,
+        'amount_bundle' => 3,
+        'discount_percentage' => null,
+    ]);
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'amount' => 5,
+    ])->validate()->execute();
+
+    expect($child->refresh()->amount)->toEqual(15.0);
+});

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -358,3 +358,65 @@ test('changing amount on bundle parent rescales bundle children by amount bundle
 
     expect($child->refresh()->amount)->toEqual(15.0);
 });
+
+test('setting negative amount on free text group parent keeps child amounts', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+        'amount' => 4,
+        'discount_percentage' => null,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => 16,
+        'amount_bundle' => null,
+        'discount_percentage' => null,
+    ]);
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'amount' => -1,
+    ])->validate()->execute();
+
+    expect($child->refresh()->amount)->toEqual(16.0);
+});
+
+test('rescale uses positive previous amount as baseline only', function (): void {
+    $parent = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => true,
+        'is_alternative' => false,
+        'amount' => -2,
+        'discount_percentage' => null,
+    ]);
+
+    $child = OrderPosition::factory()->create([
+        'order_id' => $this->order->getKey(),
+        'parent_id' => $parent->getKey(),
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'amount' => 16,
+        'amount_bundle' => null,
+        'discount_percentage' => null,
+    ]);
+
+    UpdateOrderPosition::make([
+        'id' => $parent->getKey(),
+        'amount' => 4,
+    ])->validate()->execute();
+
+    expect($child->refresh()->amount)->toEqual(16.0);
+});


### PR DESCRIPTION
## Problem

Clearing the amount on a free-text group parent position (or setting it to 0/null) divided all child position amounts by the previous parent amount. The propagation introduced in 80028a2a4 coerces a zero/empty new amount to 1 and recalculates ratio-based children from `child amount / previous amount`, effectively shrinking every child. Example: parent amount 4 with children 4/4/16 ends up with children 1/1/4 after the parent amount is cleared.

## Fix

`UpdateOrderPosition` now only propagates amount changes to children when the new amount is positive. Ratio-based children (no `amount_bundle`) are only rescaled when a positive previous amount exists as a baseline; otherwise they are left untouched. Negative amounts never trigger a rescale.

## Tests

- clearing amount (0 and null) on a free-text group parent keeps child amounts
- proportional rescale on positive amount change still works
- bundle children with `amount_bundle` still rescale, but not on cleared amount
- negative new amount and non-positive previous amount never rescale children

## Summary by Sourcery

Adjust order position amount propagation so child positions are only rescaled when the parent amount changes to a positive value, avoiding unintended shrinking when amounts are cleared or non-positive.

Bug Fixes:
- Prevent child order position amounts from being reduced when a free-text group parent amount is cleared or set to zero or null.
- Ensure negative parent amounts and non-positive previous amounts do not trigger proportional rescaling of child positions.

Tests:
- Add feature tests covering clearing and changing amounts on free-text group parents and verifying proportional rescaling only occurs for positive amounts.
- Add feature tests ensuring bundle children rescale based on amount_bundle only on positive parent amount changes and remain unchanged when the parent amount is cleared.
- Add feature tests covering negative and non-positive previous amounts to confirm they do not act as a baseline for rescaling.