### PR TITLE
Fall back to default price list in OrderForm::getPriceList()

### DIFF
--- a/src/Livewire/Forms/OrderForm.php
+++ b/src/Livewire/Forms/OrderForm.php
@@ -192,7 +192,7 @@ class OrderForm extends FluxForm
 
     protected ?string $modelClass = Order::class;
 
-    protected PriceList $priceList;
+    protected ?PriceList $priceList = null;
 
     public function fill($values): void
     {
@@ -275,7 +275,8 @@ class OrderForm extends FluxForm
                 'rounding_number',
                 'rounding_mode',
                 'is_net',
-            ]);
+            ])
+            ?? resolve_static(PriceList::class, 'default');
     }
 
     public function save(): void

--- a/tests/Unit/Forms/OrderFormTest.php
+++ b/tests/Unit/Forms/OrderFormTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use FluxErp\Livewire\Forms\OrderForm;
+use FluxErp\Livewire\Settings\Units;
+use FluxErp\Models\PriceList;
+use Livewire\Livewire;
+
+test('getPriceList falls back to the default price list for an unknown price list id', function (): void {
+    $form = new OrderForm(Livewire::test(Units::class)->instance(), 'order');
+    $form->price_list_id = null;
+
+    expect($form->getPriceList())
+        ->toBeInstanceOf(PriceList::class)
+        ->getKey()->toBe(PriceList::default()->getKey());
+});
+
+test('getPriceList returns the price list of the form', function (): void {
+    $priceList = PriceList::factory()->create();
+
+    $form = new OrderForm(Livewire::test(Units::class)->instance(), 'order');
+    $form->price_list_id = $priceList->getKey();
+
+    expect($form->getPriceList()->getKey())->toBe($priceList->getKey());
+});


### PR DESCRIPTION
## Summary

Editing an order whose `price_list_id` is null or points to a deleted price list threw

> Cannot assign null to property FluxErp\Livewire\Forms\OrderForm::$priceList of type FluxErp\Models\PriceList

making the order impossible to edit in the backend (390 occurrences on a production instance, see Flare error [8586873](https://flareapp.io/errors/8586873/latest)).

## Changes
- `OrderForm::getPriceList()` now falls back to the default price list when no price list is found, mirroring the behavior of `PriceHelper`
- `$priceList` property is nullable as a defensive measure
- Unit tests for both the fallback and the regular lookup

## Summary by Sourcery

Ensure order forms can be edited when their associated price list is missing by falling back to the default price list.

Bug Fixes:
- Prevent backend editing of orders from failing when the order has a null or invalid price list by using the default price list instead.

Enhancements:
- Allow the order form price list property to be nullable as a defensive measure against missing price lists.

Tests:
- Add unit tests verifying that OrderForm::getPriceList falls back to the default price list and returns the explicitly assigned price list when present.