### PR TITLE
fix(mail): cast IMAP message uid to string before communication validation

### DIFF
--- a/src/Mail/ImapMessageBuilder.php
+++ b/src/Mail/ImapMessageBuilder.php
@@ -270,7 +270,7 @@ class ImapMessageBuilder
             UpdateCommunication::make([
                 'id' => $existing->getKey(),
                 'mail_folder_id' => $this->folder->getKey(),
-                'message_uid' => $imapMessage->uid,
+                'message_uid' => (string) $imapMessage->uid,
                 'communication_type_enum' => 'mail',
                 'is_seen' => $imapMessage->isSeen,
             ])
@@ -287,7 +287,7 @@ class ImapMessageBuilder
             'mail_account_id' => $this->folder->mailAccount->getKey(),
             'mail_folder_id' => $this->folder->getKey(),
             'message_id' => $imapMessage->messageId,
-            'message_uid' => $imapMessage->uid,
+            'message_uid' => (string) $imapMessage->uid,
             'from' => $imapMessage->from,
             'to' => $imapMessage->to,
             'cc' => $imapMessage->cc,

--- a/tests/Unit/Mail/ImapMessageBuilderTest.php
+++ b/tests/Unit/Mail/ImapMessageBuilderTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use Carbon\CarbonImmutable;
+use FluxErp\Mail\ImapMessage;
 use FluxErp\Mail\ImapMessageBuilder;
+use FluxErp\Models\Communication;
+use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
 
 it('can be instantiated from a mail folder', function (): void {
@@ -26,3 +30,74 @@ it('returns empty collection before fetch', function (): void {
     expect($builder->get())->toBeEmpty()
         ->and($builder->count())->toBe(0);
 });
+
+it('creates a communication from an imap message with integer uid', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory())
+        ->create();
+    $folder = $mailAccount->mailFolders->first();
+
+    makeTestableBuilder($folder)
+        ->pushMessage(makeImapMessage(uid: 42, messageId: '<create-uid@example.com>'))
+        ->store();
+
+    $this->assertDatabaseHas('communications', [
+        'mail_account_id' => $mailAccount->getKey(),
+        'mail_folder_id' => $folder->getKey(),
+        'message_id' => '<create-uid@example.com>',
+        'message_uid' => '42',
+    ]);
+});
+
+it('updates an existing communication from an imap message with integer uid', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory())
+        ->create();
+    $folder = $mailAccount->mailFolders->first();
+
+    $communication = Communication::factory()->create([
+        'mail_account_id' => $mailAccount->getKey(),
+        'mail_folder_id' => $folder->getKey(),
+        'message_id' => '<update-uid@example.com>',
+        'message_uid' => '41',
+        'communication_type_enum' => 'mail',
+    ]);
+
+    makeTestableBuilder($folder)
+        ->pushMessage(makeImapMessage(uid: 42, messageId: '<update-uid@example.com>'))
+        ->store();
+
+    expect($communication->refresh()->message_uid)->toBe('42');
+});
+
+function makeTestableBuilder(MailFolder $folder): ImapMessageBuilder
+{
+    return new class($folder) extends ImapMessageBuilder
+    {
+        public function pushMessage(ImapMessage $message): static
+        {
+            $this->messages->push($message);
+
+            return $this;
+        }
+    };
+}
+
+function makeImapMessage(int $uid, string $messageId): ImapMessage
+{
+    return new ImapMessage(
+        messageId: $messageId,
+        uid: $uid,
+        subject: 'Test Subject',
+        from: 'sender@example.com',
+        to: [],
+        cc: [],
+        bcc: [],
+        textBody: 'Hello World',
+        htmlBody: null,
+        date: CarbonImmutable::now(),
+        isSeen: true,
+        flags: [],
+        attachments: [],
+    );
+}


### PR DESCRIPTION
## Problem

Since #1785 changed the `message_uid` validation rule from `integer` to `nullable|string|max:255`, every IMAP mail import fails with:

```
Illuminate\Validation\ValidationException: The Message UID must be a string.
```

The IMAP driver receives the uid as integer from webklex (`ImapMessage::$uid` is typed `int`) and passes it unchanged to `CreateMailMessage` / `UpdateCommunication`. Laravel's `string` rule strictly rejects integers, so `SyncMailAccountJob` dies before storing any message — no mails are imported on IMAP accounts.

Timeline of the regression:
- #1761 widened the `communications.message_uid` column to string but kept the `integer` rule → Graph imports broken, IMAP still working
- #1785 relaxed the rule to `string` → Graph imports fixed, IMAP imports broken

## Fix

Cast the uid to string at both action call sites in `ImapMessageBuilder` (`storeMessage` and `createMessage`). The `ImapMessage` DTO keeps the integer type since the uid is used for arithmetic (`getByUidGreater`) and integer-based queries (`whereIntegerInRaw`).

## Tests

Added two regression tests that drive `ImapMessageBuilder::store()` with an integer uid through the real actions and validation, covering both the create and the update path. Both fail with the production error before the fix and pass after.