### PR TITLE
feat(mail): broadcast sync progress toast to the triggering user

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1556,6 +1556,7 @@
     "Mail Folders": "Mail-Ordner",
     "Mail Messages": "E-Mail-Nachrichten",
     "Mail Subject": "E-Mail-Betreff",
+    "Mail sync :email": "Mailabruf :email",
     "Mail To": "E-Mail an",
     "mail_opened": "E-Mail geöffnet",
     "Mailbox": "Postfach",

--- a/lang/de.json
+++ b/lang/de.json
@@ -32,6 +32,7 @@
     ":model saved": ":model gespeichert",
     ":order_type :order_number dated :order_date": ":order_type :order_number vom :order_date",
     ":percentage% Deduction": ":percentage% Kürzung",
+    ":processed of :total mails (:folder)": ":processed von :total Mails (:folder)",
     ":rate% present": ":rate% anwesend",
     ":success email(s) sent, :failed failed": ":success E-Mail(s) gesendet, :failed fehlgeschlagen",
     ":success of :total jobs succeeded, :failed failed": ":success von :total Jobs erfolgreich, :failed fehlgeschlagen",

--- a/src/Contracts/ReportsSyncProgress.php
+++ b/src/Contracts/ReportsSyncProgress.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace FluxErp\Contracts;
+
+use Closure;
+
+interface ReportsSyncProgress
+{
+    /**
+     * Register a callback that is invoked with the number of processed
+     * messages and the total message count while syncing a folder.
+     */
+    public function withProgressCallback(?Closure $callback): static;
+}

--- a/src/Jobs/SyncMailAccountJob.php
+++ b/src/Jobs/SyncMailAccountJob.php
@@ -87,28 +87,30 @@ class SyncMailAccountJob implements Repeatable, ShouldBeMonitored, ShouldBeUniqu
             ->get();
         $total = $folders->count();
 
-        $folders->each(function (MailFolder $folder, int $index) use ($driver, $total): void {
+        try {
+            $folders->each(function (MailFolder $folder, int $index) use ($driver, $total): void {
+                if ($driver instanceof ReportsSyncProgress) {
+                    $driver->withProgressCallback(
+                        fn (int $processed, int $totalMessages) => $this->queueUpdate([
+                            'progress' => ($index + ($totalMessages > 0 ? min($processed / $totalMessages, 1) : 1))
+                                / $total
+                                * 100,
+                            'message' => __(':processed of :total mails (:folder)', [
+                                'processed' => $processed,
+                                'total' => $totalMessages,
+                                'folder' => $folder->name,
+                            ]),
+                        ])
+                    );
+                }
+
+                $driver->syncMessages($folder);
+                $this->queueProgressChunk($total, 1);
+            });
+        } finally {
             if ($driver instanceof ReportsSyncProgress) {
-                $driver->withProgressCallback(
-                    fn (int $processed, int $totalMessages) => $this->queueUpdate([
-                        'progress' => ($index + ($totalMessages > 0 ? min($processed / $totalMessages, 1) : 1))
-                            / $total
-                            * 100,
-                        'message' => __(':processed of :total mails (:folder)', [
-                            'processed' => $processed,
-                            'total' => $totalMessages,
-                            'folder' => $folder->name,
-                        ]),
-                    ])
-                );
+                $driver->withProgressCallback(null);
             }
-
-            $driver->syncMessages($folder);
-            $this->queueProgressChunk($total, 1);
-        });
-
-        if ($driver instanceof ReportsSyncProgress) {
-            $driver->withProgressCallback(null);
         }
     }
 

--- a/src/Jobs/SyncMailAccountJob.php
+++ b/src/Jobs/SyncMailAccountJob.php
@@ -4,6 +4,7 @@ namespace FluxErp\Jobs;
 
 use Cron\CronExpression;
 use FluxErp\Console\Scheduling\Repeatable;
+use FluxErp\Contracts\ReportsSyncProgress;
 use FluxErp\Contracts\ShouldBeMonitored;
 use FluxErp\Mail\MailDriverManager;
 use FluxErp\Models\MailAccount;
@@ -86,10 +87,34 @@ class SyncMailAccountJob implements Repeatable, ShouldBeMonitored, ShouldBeUniqu
             ->get();
         $total = $folders->count();
 
-        $folders->each(function (MailFolder $folder) use ($driver, $total): void {
+        $folders->each(function (MailFolder $folder, int $index) use ($driver, $total): void {
+            if ($driver instanceof ReportsSyncProgress) {
+                $driver->withProgressCallback(
+                    fn (int $processed, int $totalMessages) => $this->queueUpdate([
+                        'progress' => ($index + ($totalMessages > 0 ? min($processed / $totalMessages, 1) : 1))
+                            / $total
+                            * 100,
+                        'message' => __(':processed of :total mails (:folder)', [
+                            'processed' => $processed,
+                            'total' => $totalMessages,
+                            'folder' => $folder->name,
+                        ]),
+                    ])
+                );
+            }
+
             $driver->syncMessages($folder);
             $this->queueProgressChunk($total, 1);
         });
+
+        if ($driver instanceof ReportsSyncProgress) {
+            $driver->withProgressCallback(null);
+        }
+    }
+
+    public function progressCooldown(): int
+    {
+        return 2;
     }
 
     public function uniqueId(): string

--- a/src/Jobs/SyncMailAccountJob.php
+++ b/src/Jobs/SyncMailAccountJob.php
@@ -4,9 +4,11 @@ namespace FluxErp\Jobs;
 
 use Cron\CronExpression;
 use FluxErp\Console\Scheduling\Repeatable;
+use FluxErp\Contracts\ShouldBeMonitored;
 use FluxErp\Mail\MailDriverManager;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
+use FluxErp\Traits\IsMonitored;
 use FluxErp\Traits\Job\TracksSchedule;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -15,9 +17,9 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-class SyncMailAccountJob implements Repeatable, ShouldBeUnique, ShouldQueue
+class SyncMailAccountJob implements Repeatable, ShouldBeMonitored, ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, TracksSchedule;
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels, TracksSchedule;
 
     private readonly MailAccount $mailAccount;
 
@@ -64,6 +66,11 @@ class SyncMailAccountJob implements Repeatable, ShouldBeUnique, ShouldQueue
         return true;
     }
 
+    public function getName(): string
+    {
+        return __('Mail sync :email', ['email' => $this->mailAccount->email]);
+    }
+
     public function handle(): void
     {
         $driver = app(MailDriverManager::class)->driver($this->mailAccount->protocol);
@@ -74,9 +81,15 @@ class SyncMailAccountJob implements Repeatable, ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $this->mailAccount->mailFolders()
+        $folders = $this->mailAccount->mailFolders()
             ->where('is_active', true)
-            ->each(fn (MailFolder $folder) => $driver->syncMessages($folder));
+            ->get();
+        $total = $folders->count();
+
+        $folders->each(function (MailFolder $folder) use ($driver, $total): void {
+            $driver->syncMessages($folder);
+            $this->queueProgressChunk($total, 1);
+        });
     }
 
     public function uniqueId(): string

--- a/src/Mail/ImapMailSyncDriver.php
+++ b/src/Mail/ImapMailSyncDriver.php
@@ -2,13 +2,17 @@
 
 namespace FluxErp\Mail;
 
+use Closure;
 use FluxErp\Contracts\MailSyncDriver;
+use FluxErp\Contracts\ReportsSyncProgress;
 use FluxErp\Models\Communication;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
 
-class ImapMailSyncDriver implements MailSyncDriver
+class ImapMailSyncDriver implements MailSyncDriver, ReportsSyncProgress
 {
+    protected ?Closure $progressCallback = null;
+
     public function syncFolders(MailAccount $account): array
     {
         return $account->syncFolders();
@@ -18,7 +22,7 @@ class ImapMailSyncDriver implements MailSyncDriver
     {
         $startUid = $this->resolveStartUid($folder);
 
-        $builder = $folder->messages();
+        $builder = $folder->messages()->onProgress($this->progressCallback);
 
         if (! is_null($startUid)) {
             $builder->newSince($startUid);
@@ -37,6 +41,13 @@ class ImapMailSyncDriver implements MailSyncDriver
     public function testConnection(MailAccount $account): bool
     {
         return ! is_null($account->connect());
+    }
+
+    public function withProgressCallback(?Closure $callback): static
+    {
+        $this->progressCallback = $callback;
+
+        return $this;
     }
 
     protected function resolveStartUid(MailFolder $folder): ?int

--- a/src/Mail/ImapMessageBuilder.php
+++ b/src/Mail/ImapMessageBuilder.php
@@ -23,6 +23,10 @@ class ImapMessageBuilder
 
     protected ?int $sinceUid = null;
 
+    protected ?Closure $progressCallback = null;
+
+    protected int $progressProcessed = 0;
+
     /** @var Collection<int, ImapMessage> */
     protected Collection $messages;
 
@@ -68,12 +72,20 @@ class ImapMessageBuilder
         return $this;
     }
 
+    public function onProgress(?Closure $callback): static
+    {
+        $this->progressCallback = $callback;
+
+        return $this;
+    }
+
     public function reset(): static
     {
         $this->filterSeen = false;
         $this->filterUnseen = false;
         $this->fetchBody = true;
         $this->sinceUid = null;
+        $this->progressProcessed = 0;
         $this->messages = new Collection();
 
         return $this;
@@ -125,8 +137,11 @@ class ImapMessageBuilder
 
     public function store(): static
     {
+        $total = $this->messages->count();
+
         foreach ($this->messages as $imapMessage) {
             $this->storeMessage($imapMessage);
+            $this->progressCallback?->__invoke(++$this->progressProcessed, $total);
         }
 
         return $this;
@@ -216,6 +231,7 @@ class ImapMessageBuilder
 
                 if ($onMessage) {
                     $onMessage($imapMessage);
+                    $this->progressCallback?->__invoke(++$this->progressProcessed, $messages->total());
                 } else {
                     $this->messages->push($imapMessage);
                 }
@@ -250,6 +266,7 @@ class ImapMessageBuilder
 
                 if ($onMessage) {
                     $onMessage($imapMessage);
+                    $this->progressCallback?->__invoke(++$this->progressProcessed, $messages->total());
                 } else {
                     $this->messages->push($imapMessage);
                 }

--- a/tests/Feature/Jobs/SyncMailAccountJobTest.php
+++ b/tests/Feature/Jobs/SyncMailAccountJobTest.php
@@ -1,8 +1,13 @@
 <?php
 
+use FluxErp\Contracts\MailSyncDriver;
+use FluxErp\Contracts\ReportsSyncProgress;
 use FluxErp\Contracts\ShouldBeMonitored;
 use FluxErp\Jobs\SyncMailAccountJob;
+use FluxErp\Mail\ImapMailSyncDriver;
+use FluxErp\Mail\MailDriverManager;
 use FluxErp\Models\MailAccount;
+use FluxErp\Models\MailFolder;
 use FluxErp\Traits\IsMonitored;
 
 test('sync mail account job is monitored', function (): void {
@@ -18,4 +23,51 @@ test('sync mail account job name contains the account email', function (): void 
     $job = new SyncMailAccountJob($mailAccount);
 
     expect($job->getName())->toContain('inbox@example.com');
+});
+
+test('imap mail sync driver reports sync progress', function (): void {
+    expect(is_a(ImapMailSyncDriver::class, ReportsSyncProgress::class, true))->toBeTrue();
+});
+
+test('sync mail account job passes a progress callback to the driver', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory()->state(['is_active' => true]))
+        ->create();
+
+    $spy = new class() implements MailSyncDriver, ReportsSyncProgress
+    {
+        public array $callbacks = [];
+
+        public array $syncedFolders = [];
+
+        public function syncFolders(MailAccount $account): array
+        {
+            return [];
+        }
+
+        public function syncMessages(MailFolder $folder): void
+        {
+            $this->syncedFolders[] = $folder->getKey();
+        }
+
+        public function testConnection(MailAccount $account): bool
+        {
+            return true;
+        }
+
+        public function withProgressCallback(?Closure $callback): static
+        {
+            $this->callbacks[] = $callback;
+
+            return $this;
+        }
+    };
+
+    app(MailDriverManager::class)->extend('imap', fn () => $spy);
+
+    (new SyncMailAccountJob($mailAccount))->handle();
+
+    expect($spy->syncedFolders)->toBe([$mailAccount->mailFolders->first()->getKey()])
+        ->and(array_filter($spy->callbacks))->toHaveCount(1)
+        ->and(end($spy->callbacks))->toBeNull();
 });

--- a/tests/Feature/Jobs/SyncMailAccountJobTest.php
+++ b/tests/Feature/Jobs/SyncMailAccountJobTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use FluxErp\Contracts\ShouldBeMonitored;
+use FluxErp\Jobs\SyncMailAccountJob;
+use FluxErp\Models\MailAccount;
+use FluxErp\Traits\IsMonitored;
+
+test('sync mail account job is monitored', function (): void {
+    expect(is_a(SyncMailAccountJob::class, ShouldBeMonitored::class, true))->toBeTrue()
+        ->and(class_uses_recursive(SyncMailAccountJob::class))->toHaveKey(IsMonitored::class);
+});
+
+test('sync mail account job name contains the account email', function (): void {
+    $mailAccount = MailAccount::factory()->create([
+        'email' => 'inbox@example.com',
+    ]);
+
+    $job = new SyncMailAccountJob($mailAccount);
+
+    expect($job->getName())->toContain('inbox@example.com');
+});

--- a/tests/Unit/Mail/ImapMessageBuilderTest.php
+++ b/tests/Unit/Mail/ImapMessageBuilderTest.php
@@ -70,6 +70,24 @@ it('updates an existing communication from an imap message with integer uid', fu
     expect($communication->refresh()->message_uid)->toBe('42');
 });
 
+it('reports progress for each stored message', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory())
+        ->create();
+    $folder = $mailAccount->mailFolders->first();
+
+    $progress = [];
+    makeTestableBuilder($folder)
+        ->onProgress(function (int $processed, int $total) use (&$progress): void {
+            $progress[] = [$processed, $total];
+        })
+        ->pushMessage(makeImapMessage(uid: 50, messageId: '<progress-1@example.com>'))
+        ->pushMessage(makeImapMessage(uid: 51, messageId: '<progress-2@example.com>'))
+        ->store();
+
+    expect($progress)->toBe([[1, 2], [2, 2]]);
+});
+
 function makeTestableBuilder(MailFolder $folder): ImapMessageBuilder
 {
     return new class($folder) extends ImapMessageBuilder

--- a/tests/Unit/Mail/ImapMessageBuilderTest.php
+++ b/tests/Unit/Mail/ImapMessageBuilderTest.php
@@ -7,14 +7,14 @@ use FluxErp\Models\Communication;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
 
-it('can be instantiated from a mail folder', function (): void {
+test('can be instantiated from a mail folder', function (): void {
     $folder = new MailFolder();
     $builder = new ImapMessageBuilder($folder);
 
     expect($builder)->toBeInstanceOf(ImapMessageBuilder::class);
 });
 
-it('returns itself for chainable filter methods', function (): void {
+test('returns itself for chainable filter methods', function (): void {
     $folder = new MailFolder();
     $builder = new ImapMessageBuilder($folder);
 
@@ -23,7 +23,7 @@ it('returns itself for chainable filter methods', function (): void {
         ->and($builder->newSince(100))->toBe($builder);
 });
 
-it('returns empty collection before fetch', function (): void {
+test('returns empty collection before fetch', function (): void {
     $folder = new MailFolder();
     $builder = new ImapMessageBuilder($folder);
 
@@ -31,7 +31,7 @@ it('returns empty collection before fetch', function (): void {
         ->and($builder->count())->toBe(0);
 });
 
-it('creates a communication from an imap message with integer uid', function (): void {
+test('creates a communication from an imap message with integer uid', function (): void {
     $mailAccount = MailAccount::factory()
         ->has(MailFolder::factory())
         ->create();
@@ -49,7 +49,7 @@ it('creates a communication from an imap message with integer uid', function ():
     ]);
 });
 
-it('updates an existing communication from an imap message with integer uid', function (): void {
+test('updates an existing communication from an imap message with integer uid', function (): void {
     $mailAccount = MailAccount::factory()
         ->has(MailFolder::factory())
         ->create();
@@ -70,7 +70,7 @@ it('updates an existing communication from an imap message with integer uid', fu
     expect($communication->refresh()->message_uid)->toBe('42');
 });
 
-it('reports progress for each stored message', function (): void {
+test('reports progress for each stored message', function (): void {
     $mailAccount = MailAccount::factory()
         ->has(MailFolder::factory())
         ->create();


### PR DESCRIPTION
## What

When a user clicks "get new messages" in the /mail module, the sync jobs were dispatched fire-and-forget with no feedback. This adds the same toast progress feedback that mail sending already has.

## How

`SyncMailAccountJob` now implements `ShouldBeMonitored` and uses the `IsMonitored` trait, so it runs through the existing QueueMonitor pipeline: started, processing (with progress bar and remaining time), and finished toasts are broadcast via the user's private channel.

- One toast per account, matching the one-job-per-account dispatch in `Mail::getNewMessages()`
- `getName()` includes the mail account email so each toast identifies its mailbox
- Progress advances per synced folder via `queueProgressChunk()`
- Scheduled runs have no authenticated user, so the monitor is attached to nobody and no toast is sent

## Summary by Sourcery

Integrate mail account sync jobs with the queue monitoring pipeline to provide user-facing progress feedback for manual mail syncs.

New Features:
- Add monitoring and progress tracking for mail account sync jobs so users see toast notifications when manually triggering mail synchronization.

Tests:
- Add feature tests to verify that mail sync jobs are monitored and that the job name includes the associated mail account email.