### PR TITLE
fix(queue): scope job auth to the dispatching context and restore after

### DIFF
--- a/src/Http/Middleware/SetJobAuthenticatedUserMiddleware.php
+++ b/src/Http/Middleware/SetJobAuthenticatedUserMiddleware.php
@@ -11,16 +11,31 @@ class SetJobAuthenticatedUserMiddleware
 {
     public function handle($job, Closure $next)
     {
+        $previous = auth()->user();
         $user = morph_to(Context::get('user'));
 
-        if (
-            (! auth()->check() || auth()->user()->isNot($user))
-            && $user
-            && $user instanceof Authenticatable
-        ) {
-            Auth::setUser($user);
+        if ($user instanceof Authenticatable) {
+            if (! $previous || $previous->isNot($user)) {
+                Auth::setUser($user);
+            }
+        } elseif ($previous) {
+            // Queue workers are long-running processes. Without a reset, a job
+            // dispatched without a user context (e.g. by the scheduler) would
+            // run as whatever user the previous job authenticated.
+            auth()->forgetUser();
         }
 
-        return $next($job);
+        try {
+            return $next($job);
+        } finally {
+            // Restore the dispatcher state: queue workers stay clean between
+            // jobs, sync dispatches don't leak the job user into the
+            // surrounding request or test.
+            if ($previous) {
+                Auth::setUser($previous);
+            } elseif (auth()->check()) {
+                auth()->forgetUser();
+            }
+        }
     }
 }

--- a/tests/Feature/Http/Middleware/SetJobAuthenticatedUserMiddlewareTest.php
+++ b/tests/Feature/Http/Middleware/SetJobAuthenticatedUserMiddlewareTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use FluxErp\Http\Middleware\SetJobAuthenticatedUserMiddleware;
+use FluxErp\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Context;
+
+test('job runs unauthenticated when job context has no user', function (): void {
+    Auth::setUser($this->user);
+    Context::forget('user');
+
+    $authInsideJob = false;
+    app(SetJobAuthenticatedUserMiddleware::class)
+        ->handle(new stdClass(), function (object $job) use (&$authInsideJob): object {
+            $authInsideJob = auth()->check();
+
+            return $job;
+        });
+
+    expect($authInsideJob)->toBeFalse();
+});
+
+test('job runs as the user from job context', function (): void {
+    $other = User::factory()->create();
+
+    Context::add('user', $other->getMorphClass() . ':' . $other->getKey());
+
+    $authIdInsideJob = null;
+    app(SetJobAuthenticatedUserMiddleware::class)
+        ->handle(new stdClass(), function (object $job) use (&$authIdInsideJob): object {
+            $authIdInsideJob = auth()->id();
+
+            return $job;
+        });
+
+    expect($authIdInsideJob)->toBe($other->getKey());
+});
+
+test('restores the previous authenticated user after the job', function (): void {
+    $other = User::factory()->create();
+
+    Auth::setUser($this->user);
+    Context::add('user', $other->getMorphClass() . ':' . $other->getKey());
+
+    app(SetJobAuthenticatedUserMiddleware::class)
+        ->handle(new stdClass(), fn (object $job) => $job);
+
+    expect(auth()->id())->toBe($this->user->getKey());
+});
+
+test('stays unauthenticated after the job when nobody was authenticated before', function (): void {
+    $other = User::factory()->create();
+
+    auth()->forgetUser();
+    Context::add('user', $other->getMorphClass() . ':' . $other->getKey());
+
+    app(SetJobAuthenticatedUserMiddleware::class)
+        ->handle(new stdClass(), fn (object $job) => $job);
+
+    expect(auth()->user())->toBeNull();
+});


### PR DESCRIPTION
## Problem

`SetJobAuthenticatedUserMiddleware` (applied via `Bus::pipeThrough`) only ever **set** a user from the job context, never cleared one. Queue workers are long-running processes, so the auth state of the previous job leaked into subsequent jobs:

1. A user-triggered job authenticates that user in the worker.
2. A scheduled job without a user context runs next in the same worker - still authenticated as that user.
3. Jobs dispatched from within it (e.g. `SyncAllMailAccountsJob` dispatching one `SyncMailAccountJob` per account) fire `JobQueued` in the worker, and `QueueMonitor::created` attaches the monitor to the stale `auth()->user()`.

Observable symptom: users receive queue monitor toasts for cron runs they never triggered. Beyond toasts, any auth-dependent behavior (`created_by`/`updated_by` stamping, `UserTenantScope`) was affected for context-less jobs running in a "stamped" worker.

## Fix

The middleware now authenticates the context user only for the duration of the job and restores the previous auth state in a `finally` block:

- Jobs with a user context run as that user.
- Jobs without a user context run unauthenticated - even in a worker that processed an authenticated job before.
- Workers stay clean between jobs, so `JobQueued` listeners during a job see the correct dispatcher.
- Synchronous dispatches no longer leak the job auth state into the surrounding request or test.

Full unit suite passes (382 tests) - the restore semantics keep tests working that authenticate via `actingAs()` without a job context.

## Summary by Sourcery

Scope queue job authentication to the job context and restore the previous auth state after each job.

Bug Fixes:
- Prevent leakage of authenticated users between queued jobs by clearing or restoring auth state when a job lacks or changes user context.

Tests:
- Add feature tests to verify jobs run with the correct context user, unauthenticated when no user is present, and that the previous auth state is restored after middleware execution.