### PR TITLE
feat(profile): add integration sections stack hook

### DIFF
--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -686,5 +686,6 @@
             />
             <x-button color="indigo" :text="__('Save')" wire:click="save()" />
         </div>
+        @stack('profile-integration-sections')
     @show
 </div>


### PR DESCRIPTION
## Summary

- Adds `@stack('profile-integration-sections')` at the end of the profile view so packages can inject self-service integration sections (first consumer: flux-office365, letting employees link their own Microsoft 365 account for sending mail without needing /settings access).
- No behavior change.

## Summary by Sourcery

New Features:
- Introduce a Blade stack hook in the profile view for packages to inject integration-related sections.