### PR TITLE
fix(mail-account): allow null port in the mail account form

### DIFF
--- a/src/Livewire/Forms/MailAccountForm.php
+++ b/src/Livewire/Forms/MailAccountForm.php
@@ -16,7 +16,7 @@ class MailAccountForm extends FluxForm
 {
     public ?string $email = null;
 
-    public string $encryption = 'ssl';
+    public ?string $encryption = 'ssl';
 
     public bool $has_valid_certificate = true;
 

--- a/src/Livewire/Forms/MailAccountForm.php
+++ b/src/Livewire/Forms/MailAccountForm.php
@@ -33,7 +33,7 @@ class MailAccountForm extends FluxForm
 
     public ?string $password = null;
 
-    public int $port = 993;
+    public ?int $port = 993;
 
     public ?string $protocol = 'imap';
 


### PR DESCRIPTION
Msgraph accounts store no host/port/encryption (columns are nullable), but two `MailAccountForm` properties were typed non-nullable - opening any msgraph account in the edit modal crashed with `Cannot assign null to property ... of type int` (Flare 8701333).

- `port`: `int` → `?int`
- `encryption`: `string` → `?string`

`smtp_port`/`smtp_encryption` and all other string properties were already nullable; booleans are not-null columns with defaults. Verified against a real msgraph row on a customer instance.