### PR TITLE
Make order_types order_column migration sqlite compatible

### DIFF
--- a/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
+++ b/database/migrations/2026_04_17_000001_add_order_column_to_order_types_table.php
@@ -13,12 +13,15 @@ return new class() extends Migration
             $table->unsignedInteger('order_column')->nullable()->after('order_type_enum');
         });
 
-        DB::table('order_types')
-            ->whereRaw('0 = (@rownum := 0)')
-            ->orderBy('id')
-            ->update([
-                'order_column' => DB::raw('@rownum := @rownum + 1'),
-            ]);
+        // Session variables are mysql-only and break sqlite installations,
+        // number the rows driver-agnostically instead.
+        $position = 1;
+
+        foreach (DB::table('order_types')->orderBy('id')->pluck('id') as $id) {
+            DB::table('order_types')
+                ->where('id', $id)
+                ->update(['order_column' => $position++]);
+        }
     }
 
     public function down(): void


### PR DESCRIPTION
## Summary

The `2026_04_17_000001_add_order_column_to_order_types_table` migration numbers existing rows with the `@rownum` session variable, which is mysql-only:

```
SQLSTATE[HY000]: General error: 1 unrecognized token: ":"
(SQL: update "order_types" set "order_column" = @rownum := @rownum + 1 where 0 = (@rownum := 0))
```

Every package test suite that boots flux with an in-memory sqlite database (testbench + RefreshDatabase, e.g. nuxbe-cal-dav and flux-office365) fails on this migration since April.

This replaces the session-variable trick with a driver-agnostic per-row update. Databases that already ran the migration are unaffected.

## Summary by Sourcery

Bug Fixes:
- Fix failure of the order_types order_column migration when running tests against in-memory SQLite databases by avoiding MySQL-only session variables.