### PR TITLE
fix(printing): allow page breaks inside order position descriptions

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -698,3 +698,102 @@ if (! function_exists('render_editor_blade')) {
         return new Illuminate\Support\HtmlString(Illuminate\Support\Facades\Blade::render($converted, $data));
     }
 }
+
+if (! function_exists('split_html_for_print')) {
+    /**
+     * Splits rendered HTML into top-level chunks so the PDF renderer can
+     * insert page breaks between them - dompdf cannot break a single table
+     * row across pages. Lists are split into one list element per item,
+     * keeping ordered list numbering via the start attribute.
+     *
+     * @return array<int, string>
+     */
+    function split_html_for_print(?string $html): array
+    {
+        $html = trim($html ?? '');
+
+        if ($html === '') {
+            return [];
+        }
+
+        $dom = new DOMDocument();
+        $previousErrorSetting = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML(
+            '<?xml encoding="utf-8"?><div>' . $html . '</div>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousErrorSetting);
+
+        $root = $dom->documentElement;
+
+        if (! $loaded || is_null($root)) {
+            return [$html];
+        }
+
+        $chunks = [];
+
+        foreach ($root->childNodes as $node) {
+            if ($node instanceof DOMText) {
+                if (trim($node->textContent) !== '') {
+                    $chunks[] = $dom->saveHTML($node);
+                }
+
+                continue;
+            }
+
+            if (! $node instanceof DOMElement) {
+                continue;
+            }
+
+            $nodeName = strtolower($node->nodeName);
+
+            if (! in_array($nodeName, ['ul', 'ol'], true)) {
+                $chunks[] = $dom->saveHTML($node);
+
+                continue;
+            }
+
+            $items = [];
+            foreach ($node->childNodes as $child) {
+                if ($child instanceof DOMElement && strtolower($child->nodeName) === 'li') {
+                    $items[] = $child;
+                }
+            }
+
+            if (count($items) < 2) {
+                $chunks[] = $dom->saveHTML($node);
+
+                continue;
+            }
+
+            $isOrdered = $nodeName === 'ol';
+            $start = max((int) ($node->getAttribute('start') ?: 1), 1);
+            $lastIndex = count($items) - 1;
+
+            foreach ($items as $index => $item) {
+                /** @var DOMElement $wrapper */
+                $wrapper = $node->cloneNode();
+                $wrapper->appendChild($item->cloneNode(true));
+
+                if ($isOrdered) {
+                    $wrapper->setAttribute('start', (string) ($start + $index));
+                }
+
+                $styles = array_filter([
+                    rtrim($node->getAttribute('style'), '; '),
+                    $index > 0 ? 'margin-top: 0' : null,
+                    $index < $lastIndex ? 'margin-bottom: 0' : null,
+                ]);
+
+                if ($styles) {
+                    $wrapper->setAttribute('style', implode('; ', $styles));
+                }
+
+                $chunks[] = $dom->saveHTML($wrapper);
+            }
+        }
+
+        return $chunks;
+    }
+}

--- a/helpers.php
+++ b/helpers.php
@@ -703,97 +703,12 @@ if (! function_exists('split_html_for_print')) {
     /**
      * Splits rendered HTML into top-level chunks so the PDF renderer can
      * insert page breaks between them - dompdf cannot break a single table
-     * row across pages. Lists are split into one list element per item,
-     * keeping ordered list numbering via the start attribute.
+     * row across pages.
      *
      * @return array<int, string>
      */
     function split_html_for_print(?string $html): array
     {
-        $html = trim($html ?? '');
-
-        if ($html === '') {
-            return [];
-        }
-
-        $dom = new DOMDocument();
-        $previousErrorSetting = libxml_use_internal_errors(true);
-        $loaded = $dom->loadHTML(
-            '<?xml encoding="utf-8"?><div>' . $html . '</div>',
-            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
-        );
-        libxml_clear_errors();
-        libxml_use_internal_errors($previousErrorSetting);
-
-        $root = $dom->documentElement;
-
-        if (! $loaded || is_null($root)) {
-            return [$html];
-        }
-
-        $chunks = [];
-
-        foreach ($root->childNodes as $node) {
-            if ($node instanceof DOMText) {
-                if (trim($node->textContent) !== '') {
-                    $chunks[] = $dom->saveHTML($node);
-                }
-
-                continue;
-            }
-
-            if (! $node instanceof DOMElement) {
-                continue;
-            }
-
-            $nodeName = strtolower($node->nodeName);
-
-            if (! in_array($nodeName, ['ul', 'ol'], true)) {
-                $chunks[] = $dom->saveHTML($node);
-
-                continue;
-            }
-
-            $items = [];
-            foreach ($node->childNodes as $child) {
-                if ($child instanceof DOMElement && strtolower($child->nodeName) === 'li') {
-                    $items[] = $child;
-                }
-            }
-
-            if (count($items) < 2) {
-                $chunks[] = $dom->saveHTML($node);
-
-                continue;
-            }
-
-            $isOrdered = $nodeName === 'ol';
-            $start = max((int) ($node->getAttribute('start') ?: 1), 1);
-            $lastIndex = count($items) - 1;
-
-            foreach ($items as $index => $item) {
-                /** @var DOMElement $wrapper */
-                $wrapper = $node->cloneNode();
-                $wrapper->appendChild($item->cloneNode(true));
-
-                if ($isOrdered) {
-                    $wrapper->setAttribute('start', (string) ($start + $index));
-                }
-
-                $styles = array_filter([
-                    rtrim($node->getAttribute('style'), '; '),
-                    $index > 0 ? 'margin-top: 0' : null,
-                    $index < $lastIndex ? 'margin-bottom: 0' : null,
-                ]);
-
-                if ($styles) {
-                    $wrapper->setAttribute('style', implode('; ', $styles));
-                }
-
-                $chunks[] = $dom->saveHTML($wrapper);
-            }
-        }
-
-        return $chunks;
+        return app(FluxErp\Printing\HtmlPrintChunker::class)->chunk($html);
     }
 }

--- a/resources/views/components/print/order/order-position.blade.php
+++ b/resources/views/components/print/order/order-position.blade.php
@@ -1,25 +1,30 @@
 @use(Illuminate\Support\Facades\Blade; use Illuminate\Support\Number)
+@php
+    $descriptionChunks = split_html_for_print(
+        render_editor_blade($position->description, ['position' => $position])->toHtml()
+    );
+    $rowBackground = ($loop ?? false) && $loop->odd ? 'background: #f2f4f7;' : '';
+    $rowBottomPadding = $descriptionChunks === [] ? 'padding-bottom: 8px;' : '';
+@endphp
 <tbody>
     <tr
-        @if ($loop ?? false)
-            @if ($loop->odd)
-                style="background: #f2f4f7"
-            @endif
+        @if ($rowBackground)
+            style="{{ $rowBackground }}"
         @endif
     >
         <td
             class="pos"
             style="
                 padding-top: 8px;
-                padding-bottom: 8px;
                 padding-right: 32px;
                 vertical-align: top;
+                {{ $rowBottomPadding }}
             "
         >
             {{ $position->total_net_price ? $position->slug_position : '' }}
         </td>
         <td
-            style="padding-top: 8px; padding-bottom: 8px; padding-right: 32px; vertical-align: top; padding-left: {{ $position->depth * 15 }}px;"
+            style="padding-top: 8px; padding-right: 32px; vertical-align: top; {{ $rowBottomPadding }} padding-left: {{ $position->depth * 15 }}px;"
         >
             @if ($position->is_alternative)
                 <x-badge
@@ -41,17 +46,14 @@
             <p style="font-weight: 600; margin: 0; padding: 0">
                 {{ render_editor_blade($position->name, ['position' => $position]) }}
             </p>
-            <div style="font-size: 12px; line-height: 16px">
-                {{ render_editor_blade($position->description, ['position' => $position]) }}
-            </div>
         </td>
         <td
             style="
                 padding-top: 8px;
-                padding-bottom: 8px;
                 padding-right: 32px;
                 text-align: center;
                 vertical-align: top;
+                {{ $rowBottomPadding }}
             "
         >
             @if (! $position->is_free_text && ! $position->is_bundle_position)
@@ -62,9 +64,9 @@
         <td
             style="
                 padding-top: 8px;
-                padding-bottom: 8px;
                 text-align: right;
                 vertical-align: top;
+                {{ $rowBottomPadding }}
             "
         >
             @if (bccomp($position->total_base_net_price ?? 0, $position->total_net_price ?? 0, 2) === 1)
@@ -81,4 +83,20 @@
             {{ $position->total_net_price ? Number::currency($isNet ? $position->total_net_price : $position->total_gross_price) : null }}
         </td>
     </tr>
+    @foreach ($descriptionChunks as $chunk)
+        <tr
+            @if ($rowBackground)
+                style="{{ $rowBackground }}"
+            @endif
+        >
+            <td class="pos"></td>
+            <td
+                style="font-size: 12px; line-height: 16px; vertical-align: top; padding-right: 32px; {{ $loop->last ? 'padding-bottom: 8px;' : '' }} padding-left: {{ $position->depth * 15 }}px;"
+            >
+                {!! $chunk !!}
+            </td>
+            <td></td>
+            <td></td>
+        </tr>
+    @endforeach
 </tbody>

--- a/src/Printing/HtmlPrintChunker.php
+++ b/src/Printing/HtmlPrintChunker.php
@@ -9,11 +9,6 @@ use DOMText;
 
 class HtmlPrintChunker
 {
-    protected function render(DOMNode $node): string
-    {
-        return (string) $node->ownerDocument->saveHTML($node);
-    }
-
     /**
      * Split rendered HTML into top-level chunks so the PDF renderer can
      * insert page breaks between them - dompdf cannot break a single
@@ -43,6 +38,11 @@ class HtmlPrintChunker
         return $chunks;
     }
 
+    protected function renderNode(DOMNode $node): string
+    {
+        return (string) $node->ownerDocument->saveHTML($node);
+    }
+
     protected function parse(string $html): ?DOMElement
     {
         $dom = new DOMDocument();
@@ -63,7 +63,7 @@ class HtmlPrintChunker
     protected function chunkNode(DOMNode $node): array
     {
         if ($node instanceof DOMText) {
-            return trim($node->textContent) === '' ? [] : [$this->render($node)];
+            return trim($node->textContent) === '' ? [] : [$this->renderNode($node)];
         }
 
         if (! $node instanceof DOMElement) {
@@ -74,7 +74,7 @@ class HtmlPrintChunker
             return $this->splitList($node);
         }
 
-        return [$this->render($node)];
+        return [$this->renderNode($node)];
     }
 
     /**
@@ -88,11 +88,11 @@ class HtmlPrintChunker
         $items = $this->listItems($list);
 
         if (count($items) < 2) {
-            return [$this->render($list)];
+            return [$this->renderNode($list)];
         }
 
         $isOrdered = strtolower($list->nodeName) === 'ol';
-        $start = max((int) ($list->getAttribute('start') ?: 1), 1);
+        $number = max((int) ($list->getAttribute('start') ?: 1), 1);
         $lastIndex = count($items) - 1;
 
         $chunks = [];
@@ -102,14 +102,21 @@ class HtmlPrintChunker
             $wrapper->appendChild($item->cloneNode(true));
 
             if ($isOrdered) {
-                $wrapper->setAttribute('start', (string) ($start + $index));
+                // Continue from an explicit <li value> so author-defined
+                // numbering survives the split instead of being flattened.
+                if (($value = $item->getAttribute('value')) !== '') {
+                    $number = (int) $value;
+                }
+
+                $wrapper->setAttribute('start', (string) $number);
+                $number++;
             }
 
             if ($style = $this->chunkStyle($list, $index, $lastIndex)) {
                 $wrapper->setAttribute('style', $style);
             }
 
-            $chunks[] = $this->render($wrapper);
+            $chunks[] = $this->renderNode($wrapper);
         }
 
         return $chunks;

--- a/src/Printing/HtmlPrintChunker.php
+++ b/src/Printing/HtmlPrintChunker.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace FluxErp\Printing;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+
+class HtmlPrintChunker
+{
+    protected function render(DOMNode $node): string
+    {
+        return (string) $node->ownerDocument->saveHTML($node);
+    }
+
+    /**
+     * Split rendered HTML into top-level chunks so the PDF renderer can
+     * insert page breaks between them - dompdf cannot break a single
+     * table row across pages.
+     *
+     * @return array<int, string>
+     */
+    public function chunk(?string $html): array
+    {
+        $html = trim($html ?? '');
+
+        if ($html === '') {
+            return [];
+        }
+
+        $root = $this->parse($html);
+
+        if (is_null($root)) {
+            return [$html];
+        }
+
+        $chunks = [];
+        foreach ($root->childNodes as $node) {
+            $chunks = array_merge($chunks, $this->chunkNode($node));
+        }
+
+        return $chunks;
+    }
+
+    protected function parse(string $html): ?DOMElement
+    {
+        $dom = new DOMDocument();
+        $previousErrorSetting = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML(
+            '<?xml encoding="utf-8"?><div>' . $html . '</div>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousErrorSetting);
+
+        return $loaded ? $dom->documentElement : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function chunkNode(DOMNode $node): array
+    {
+        if ($node instanceof DOMText) {
+            return trim($node->textContent) === '' ? [] : [$this->render($node)];
+        }
+
+        if (! $node instanceof DOMElement) {
+            return [];
+        }
+
+        if (in_array(strtolower($node->nodeName), ['ul', 'ol'], true)) {
+            return $this->splitList($node);
+        }
+
+        return [$this->render($node)];
+    }
+
+    /**
+     * Split a list into one list element per item, keeping ordered list
+     * numbering via the start attribute.
+     *
+     * @return array<int, string>
+     */
+    protected function splitList(DOMElement $list): array
+    {
+        $items = $this->listItems($list);
+
+        if (count($items) < 2) {
+            return [$this->render($list)];
+        }
+
+        $isOrdered = strtolower($list->nodeName) === 'ol';
+        $start = max((int) ($list->getAttribute('start') ?: 1), 1);
+        $lastIndex = count($items) - 1;
+
+        $chunks = [];
+        foreach ($items as $index => $item) {
+            /** @var DOMElement $wrapper */
+            $wrapper = $list->cloneNode();
+            $wrapper->appendChild($item->cloneNode(true));
+
+            if ($isOrdered) {
+                $wrapper->setAttribute('start', (string) ($start + $index));
+            }
+
+            if ($style = $this->chunkStyle($list, $index, $lastIndex)) {
+                $wrapper->setAttribute('style', $style);
+            }
+
+            $chunks[] = $this->render($wrapper);
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    protected function listItems(DOMElement $list): array
+    {
+        $items = [];
+        foreach ($list->childNodes as $child) {
+            if ($child instanceof DOMElement && strtolower($child->nodeName) === 'li') {
+                $items[] = $child;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Keep the original list style and remove the vertical margins between
+     * the resulting chunks, so they still read as one list.
+     */
+    protected function chunkStyle(DOMElement $list, int $index, int $lastIndex): ?string
+    {
+        $styles = array_filter([
+            rtrim($list->getAttribute('style'), '; '),
+            $index > 0 ? 'margin-top: 0' : null,
+            $index < $lastIndex ? 'margin-bottom: 0' : null,
+        ]);
+
+        return $styles ? implode('; ', $styles) : null;
+    }
+}

--- a/tests/Unit/Helpers/SplitHtmlForPrintTest.php
+++ b/tests/Unit/Helpers/SplitHtmlForPrintTest.php
@@ -1,0 +1,108 @@
+<?php
+
+test('split_html_for_print returns empty array for null input', function (): void {
+    expect(split_html_for_print(null))->toBe([]);
+});
+
+test('split_html_for_print returns empty array for blank input', function (): void {
+    expect(split_html_for_print('   '))->toBe([]);
+});
+
+test('split_html_for_print keeps a single paragraph as one chunk', function (): void {
+    $chunks = split_html_for_print('<p>Hello World</p>');
+
+    expect($chunks)->toHaveCount(1)
+        ->and($chunks[0])->toContain('Hello World');
+});
+
+test('split_html_for_print splits top level elements into separate chunks', function (): void {
+    $chunks = split_html_for_print('<p>First</p><p>Second</p><div>Third</div>');
+
+    expect($chunks)->toHaveCount(3)
+        ->and($chunks[0])->toContain('First')
+        ->and($chunks[1])->toContain('Second')
+        ->and($chunks[2])->toContain('Third');
+});
+
+test('split_html_for_print preserves utf8 characters', function (): void {
+    $chunks = split_html_for_print('<p>Größenänderung für Allgäuer Straße</p>');
+
+    expect($chunks)->toHaveCount(1)
+        ->and($chunks[0])->toContain('Größenänderung für Allgäuer Straße');
+});
+
+test('split_html_for_print keeps top level text nodes as chunks', function (): void {
+    $chunks = split_html_for_print('Loose text<p>Paragraph</p>');
+
+    expect($chunks)->toHaveCount(2)
+        ->and($chunks[0])->toContain('Loose text')
+        ->and($chunks[1])->toContain('Paragraph');
+});
+
+test('split_html_for_print splits unordered lists into one chunk per item', function (): void {
+    $chunks = split_html_for_print('<ul><li>One</li><li>Two</li><li>Three</li></ul>');
+
+    expect($chunks)->toHaveCount(3)
+        ->and($chunks[0])->toContain('<ul')
+        ->and($chunks[0])->toContain('One')
+        ->and($chunks[1])->toContain('Two')
+        ->and($chunks[2])->toContain('Three');
+});
+
+test('split_html_for_print removes vertical margins between list chunks', function (): void {
+    $chunks = split_html_for_print('<ul><li>One</li><li>Two</li><li>Three</li></ul>');
+
+    expect($chunks[0])->toContain('margin-bottom: 0')
+        ->and($chunks[0])->not->toContain('margin-top: 0')
+        ->and($chunks[1])->toContain('margin-top: 0')
+        ->and($chunks[1])->toContain('margin-bottom: 0')
+        ->and($chunks[2])->toContain('margin-top: 0')
+        ->and($chunks[2])->not->toContain('margin-bottom: 0');
+});
+
+test('split_html_for_print continues ordered list numbering', function (): void {
+    $chunks = split_html_for_print('<ol><li>One</li><li>Two</li><li>Three</li></ol>');
+
+    expect($chunks)->toHaveCount(3)
+        ->and($chunks[1])->toContain('start="2"')
+        ->and($chunks[2])->toContain('start="3"');
+});
+
+test('split_html_for_print respects an existing start attribute on ordered lists', function (): void {
+    $chunks = split_html_for_print('<ol start="5"><li>Five</li><li>Six</li></ol>');
+
+    expect($chunks)->toHaveCount(2)
+        ->and($chunks[0])->toContain('start="5"')
+        ->and($chunks[1])->toContain('start="6"');
+});
+
+test('split_html_for_print keeps single item lists unsplit', function (): void {
+    $chunks = split_html_for_print('<ul><li>Only</li></ul>');
+
+    expect($chunks)->toHaveCount(1)
+        ->and($chunks[0])->toBe('<ul><li>Only</li></ul>');
+});
+
+test('split_html_for_print keeps nested lists inside their item', function (): void {
+    $chunks = split_html_for_print('<ul><li>Parent<ul><li>Child</li></ul></li><li>Second</li></ul>');
+
+    expect($chunks)->toHaveCount(2)
+        ->and($chunks[0])->toContain('Child')
+        ->and($chunks[1])->toContain('Second');
+});
+
+test('split_html_for_print preserves attributes on split lists', function (): void {
+    $chunks = split_html_for_print('<ul class="fancy"><li>One</li><li>Two</li></ul>');
+
+    expect($chunks)->toHaveCount(2)
+        ->and($chunks[0])->toContain('class="fancy"')
+        ->and($chunks[1])->toContain('class="fancy"');
+});
+
+test('split_html_for_print concatenated chunks contain all original text', function (): void {
+    $html = '<p>Intro</p><ul><li>A</li><li>B</li></ul><p>Outro</p>';
+
+    $joined = implode('', split_html_for_print($html));
+
+    expect(strip_tags($joined))->toBe('IntroABOutro');
+});

--- a/tests/Unit/Helpers/SplitHtmlForPrintTest.php
+++ b/tests/Unit/Helpers/SplitHtmlForPrintTest.php
@@ -76,6 +76,15 @@ test('split_html_for_print respects an existing start attribute on ordered lists
         ->and($chunks[1])->toContain('start="6"');
 });
 
+test('split_html_for_print respects explicit li value attributes', function (): void {
+    $chunks = split_html_for_print('<ol><li>One</li><li value="7">Seven</li><li>Eight</li></ol>');
+
+    expect($chunks)->toHaveCount(3)
+        ->and($chunks[0])->toContain('start="1"')
+        ->and($chunks[1])->toContain('start="7"')
+        ->and($chunks[2])->toContain('start="8"');
+});
+
 test('split_html_for_print keeps single item lists unsplit', function (): void {
     $chunks = split_html_for_print('<ul><li>Only</li></ul>');
 

--- a/tests/Unit/Views/PrintOrderPositionTest.php
+++ b/tests/Unit/Views/PrintOrderPositionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use FluxErp\Models\OrderPosition;
+use Illuminate\Support\Facades\Blade;
+
+function renderPrintOrderPosition(array $attributes): string
+{
+    $position = (new OrderPosition())->forceFill(array_merge([
+        'slug_position' => '1',
+        'name' => 'Test Product',
+        'product_number' => 'P-100',
+        'description' => null,
+        'depth' => 0,
+        'amount' => 1,
+        'is_alternative' => false,
+        'is_free_text' => false,
+        'is_bundle_position' => false,
+        'total_net_price' => '10.00',
+        'total_gross_price' => '11.90',
+        'total_base_net_price' => '10.00',
+        'total_base_gross_price' => '11.90',
+    ], $attributes));
+    $position->setRelation('product', null);
+
+    return Blade::render(
+        '<x-flux::print.order.order-position :position="$position" :is-net="true" />',
+        ['position' => $position]
+    );
+}
+
+test('print order position renders a single row without description', function (): void {
+    $html = renderPrintOrderPosition(['description' => null]);
+
+    expect(substr_count($html, '<tr'))->toBe(1)
+        ->and($html)->toContain('Test Product')
+        ->and($html)->toContain('padding-bottom: 8px;');
+});
+
+test('print order position renders one row per description chunk', function (): void {
+    $html = renderPrintOrderPosition([
+        'description' => '<p>First paragraph</p><p>Second paragraph</p><ul><li>One</li><li>Two</li></ul>',
+    ]);
+
+    // 1 main row + 2 paragraph rows + 2 list item rows
+    expect(substr_count($html, '<tr'))->toBe(5)
+        ->and($html)->toContain('First paragraph')
+        ->and($html)->toContain('Second paragraph')
+        ->and($html)->toContain('<li>One</li>')
+        ->and($html)->toContain('<li>Two</li>');
+});
+
+test('print order position keeps bottom padding only on the last description row', function (): void {
+    $html = renderPrintOrderPosition([
+        'description' => '<p>First</p><p>Last</p>',
+    ]);
+
+    expect(substr_count($html, 'padding-bottom: 8px;'))->toBe(1)
+        ->and(strrpos($html, 'padding-bottom: 8px;'))->toBeGreaterThan(strpos($html, 'First'));
+});


### PR DESCRIPTION
## Summary

Order positions with long descriptions were pushed entirely to the next page in printed PDFs (offers, order confirmations, invoices), often leaving the first page partially or completely blank. dompdf cannot break a single table row across pages, so a position rendered as one row was atomic.

## Changes

- New `split_html_for_print()` helper that splits rendered HTML into top-level chunks. Lists are split into one list element per item, ordered list numbering is kept via the `start` attribute and vertical margins between list chunks are removed so they still read as one list.
- The `print.order.order-position` component now renders the position meta data (number, name, amount, price) in one row and each description chunk in its own table row, so dompdf can insert page breaks between them.
- Positions without a description render exactly as before. The zebra background and paddings are preserved across the chunk rows.

A single top-level element that is taller than one page still cannot be broken, but realistic descriptions consist of multiple paragraphs and list items.