### PR TITLE
fix(tabs): remount tab sub-component when bound model changes

### DIFF
--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -50,19 +50,29 @@
 >
     {{ $prepend ?? '' }}
 
+    @php
+        $tabProperty = $attributes->wire('model')->value();
+        $activeTab = $this->{$tabProperty};
+        $activeTabButton = $tabs[$activeTab] ?? null;
+        $boundModelKey = $activeTabButton?->wireModel;
+        $boundModelValue = $boundModelKey ? data_get($this, $boundModelKey) : null;
+
+        if (! is_scalar($boundModelValue)) {
+            $boundModelValue = data_get($boundModelValue, 'id');
+        }
+    @endphp
+
     <div class="min-w-0 w-full">
         @if ($slot->isNotEmpty())
             {{ $slot }}
-        @elseif ($tabs[$this->{$attributes->wire('model')->value()}]?->isLivewireComponent)
+        @elseif ($activeTabButton?->isLivewireComponent)
             <livewire:dynamic-component
-                wire:model="{{ $tabs[$this->{$attributes->wire('model')->value()}]?->wireModel }}"
-                :is="$this->{$attributes->wire('model')->value()}"
-                wire:key="tab-{{ $attributes->wire('model')->value() }}-{{ $this->{$attributes->wire('model')->value()} }}"
+                wire:model="{{ $boundModelKey }}"
+                :is="$activeTab"
+                wire:key="tab-{{ $tabProperty }}-{{ $activeTab }}{{ is_null($boundModelValue) ? '' : '-' . $boundModelValue }}"
             />
         @else
-            <x-dynamic-component
-                :component="$this->{$attributes->wire('model')->value()}"
-            />
+            <x-dynamic-component :component="$activeTab" />
         @endif
     </div>
     {{ $append ?? '' }}

--- a/tests/Browser/Components/TabsTest.php
+++ b/tests/Browser/Components/TabsTest.php
@@ -45,3 +45,40 @@ test('tab livewire sub-component keeps identity after parent re-render', functio
         'Tab sub-component wire:id changed after parent re-render.'
     );
 });
+
+test('tab livewire sub-component shows fresh content after bound model changes', function (): void {
+    Livewire::component('tabs-fixture', TabsFixture::class);
+    Livewire::component('tabs-fixture-general', TabsFixtureChild::class);
+    Livewire::component('tabs-fixture-child', TabsFixtureChild::class);
+
+    $page = visitLivewire(TabsFixture::class)
+        ->assertNoSmoke()
+        ->assertSee('Tab child loaded model: 1');
+
+    $page->click('Switch Model');
+
+    $page->assertSee('Tab child loaded model: 2');
+});
+
+test('tab livewire sub-component instances are released after bound model changes', function (): void {
+    Livewire::component('tabs-fixture', TabsFixture::class);
+    Livewire::component('tabs-fixture-general', TabsFixtureChild::class);
+    Livewire::component('tabs-fixture-child', TabsFixtureChild::class);
+
+    $page = visitLivewire(TabsFixture::class)
+        ->assertNoSmoke()
+        ->assertSee('Tab child loaded model: 1');
+
+    $componentCountBefore = $page->script('() => window.Livewire.all().length');
+
+    foreach (range(2, 6) as $modelId) {
+        $page->click('Switch Model');
+        $page->assertSee('Tab child loaded model: ' . $modelId);
+    }
+
+    $componentCountAfter = $page->script('() => window.Livewire.all().length');
+
+    expect($componentCountAfter)->toBe($componentCountBefore,
+        'Livewire component registry grew after model switches - old tab sub-components are not released.'
+    );
+});

--- a/tests/Fixtures/Livewire/TabsFixture.php
+++ b/tests/Fixtures/Livewire/TabsFixture.php
@@ -14,7 +14,7 @@ class TabsFixture extends Component
 
     public string $activeTab = 'tabs-fixture-general';
 
-    public ?int $modelId = null;
+    public ?int $modelId = 1;
 
     public function render(): View
     {
@@ -39,6 +39,11 @@ class TabsFixture extends Component
     public function refreshParent(): void
     {
         // Triggers a parent re-render (default Livewire behavior)
+    }
+
+    public function switchModel(): void
+    {
+        $this->modelId++;
     }
 
     public function updatedActiveTab(): void

--- a/tests/Fixtures/Livewire/TabsFixtureChild.php
+++ b/tests/Fixtures/Livewire/TabsFixtureChild.php
@@ -2,14 +2,23 @@
 
 namespace FluxErp\Tests\Fixtures\Livewire;
 
+use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
 class TabsFixtureChild extends Component
 {
-    public $modelId = null;
+    #[Modelable]
+    public ?int $modelId = null;
+
+    public ?int $loadedModelId = null;
 
     public function render(): string
     {
-        return '<div>Tab child content</div>';
+        // mimics load-once children like Support\Activities that only load while empty
+        if (is_null($this->loadedModelId) && $this->modelId) {
+            $this->loadedModelId = $this->modelId;
+        }
+
+        return '<div>Tab child loaded model: {{ $loadedModelId ?? "none" }}</div>';
     }
 }

--- a/tests/Fixtures/views/tabs-fixture.blade.php
+++ b/tests/Fixtures/views/tabs-fixture.blade.php
@@ -1,4 +1,5 @@
 <div data-testid="tabs-fixture">
     <x-flux::tabs wire:model.live="activeTab" :$tabs />
     <button wire:click="refreshParent">Refresh</button>
+    <button wire:click="switchModel">Switch Model</button>
 </div>


### PR DESCRIPTION
## Summary
- Since #1430 the tab content `wire:key` only contains the tab name, so selecting another record (e.g. another address in the contact view) reused the already-mounted tab sub-component. Children that load their data once — attachments (`FolderTree`), activities, comments — kept showing the content of the previously selected record. The `#[Modelable]` binding only seeds the child property at mount time and syncs deferred afterwards, it never reloads already-loaded data.
- Include the bound `wire:model` value in the `wire:key` so the sub-component remounts exactly once per record switch while keeping its identity across regular parent re-renders (no #1430 regression). Object bindings (e.g. `contact` form objects) fall back to their `id`.
- Browser test coverage: fresh content after the bound model changes, and the Livewire component registry stays flat after repeated switches (old instances are released, no uniqid()-style DOM/heap growth).

## Summary by Sourcery

Ensure tab Livewire sub-components remount when the bound model changes so they load fresh data per record and are properly released.

Bug Fixes:
- Fix tab Livewire sub-components reusing stale child content when switching the bound model by including the bound model value in their identity key.

Enhancements:
- Update tab component template and test fixtures to support model-switching scenarios with modelable child properties and deterministic loaded model tracking.

Tests:
- Add browser tests to verify tab sub-components show fresh content after model changes and that Livewire component instances are released instead of accumulating.