### PR TITLE
fix(addresses): listen for address echo events on the stable contact channel

### DIFF
--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -154,21 +154,15 @@ class Addresses extends Component
     #[Renderless]
     public function getListeners(): array
     {
-        $model = app(Address::class);
-
-        $listeners = [];
-        foreach ($this->addresses as $address) {
-            $model->id = $address['id'];
-            $channel = 'echo-private:' . $model->broadcastChannel();
-            $listeners[$channel . ',.AddressUpdated'] = 'addressUpdated';
-            $listeners[$channel . ',.AddressDeleted'] = 'addressDeleted';
-        }
-
         $contactModel = app(Contact::class);
         $contactModel->id = $this->contact->id;
-        $listeners['echo-private:' . $contactModel->broadcastChannel() . ',.AddressCreated'] = 'loadAddresses';
+        $channel = 'echo-private:' . $contactModel->broadcastChannel();
 
-        return $listeners;
+        return [
+            $channel . ',.AddressCreated' => 'loadAddresses',
+            $channel . ',.AddressUpdated' => 'addressUpdated',
+            $channel . ',.AddressDeleted' => 'addressDeleted',
+        ];
     }
 
     public function getTabs(): array
@@ -221,25 +215,15 @@ class Addresses extends Component
 
     public function loadAddresses(): void
     {
-        $addresses = resolve_static(Address::class, 'query')
+        $this->addresses = resolve_static(Address::class, 'query')
             ->where('contact_id', $this->contact->id)
             ->orderByDesc('is_main_address')
             ->orderByDesc('is_invoice_address')
             ->orderByDesc('is_delivery_address')
             ->orderByDesc('is_active')
             ->get()
-            ->each(fn (Address $address) => $address->append('postal_address'));
-
-        foreach ($addresses as $address) {
-            $this->listeners[
-                'echo-private:' . $address->broadcastChannel(false) . ',.AddressUpdated'
-            ] = 'addressUpdated';
-            $this->listeners[
-                'echo-private:' . $address->broadcastChannel(false) . ',.AddressDeleted'
-            ] = 'addressDeleted';
-        }
-
-        $this->addresses = $addresses->toArray();
+            ->each(fn (Address $address) => $address->append('postal_address'))
+            ->toArray();
     }
 
     #[Renderless]

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -63,3 +63,64 @@ test('switch tabs', function (): void {
         ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
         ->cycleTabs();
 });
+
+test('address updated event on the contact channel reloads the selected address', function (): void {
+    $component = Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm]);
+
+    Address::query()
+        ->whereKey($this->addressForm->id)
+        ->update(['street' => $street = Str::uuid()->toString()]);
+
+    $component
+        ->dispatch(
+            'echo-private:contact.' . $this->contactForm->id . ',.AddressUpdated',
+            ['model' => ['id' => $this->addressForm->id]]
+        )
+        ->assertOk()
+        ->assertSet('address.street', $street);
+});
+
+test('address deleted event on the contact channel removes the address from the list', function (): void {
+    $secondAddress = Address::factory()->create([
+        'contact_id' => $this->contactForm->id,
+    ]);
+
+    $component = Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm]);
+
+    expect(collect($component->get('addresses'))->pluck('id'))->toContain($secondAddress->getKey());
+
+    $secondAddress->delete();
+
+    $component
+        ->dispatch(
+            'echo-private:contact.' . $this->contactForm->id . ',.AddressDeleted',
+            ['model' => ['id' => $secondAddress->getKey()]]
+        )
+        ->assertOk();
+
+    expect(collect($component->get('addresses'))->pluck('id'))->not->toContain($secondAddress->getKey());
+});
+
+test('listeners stay stable when the address list changes', function (): void {
+    $secondAddress = Address::factory()->create([
+        'contact_id' => $this->contactForm->id,
+    ]);
+
+    $component = Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm]);
+
+    $listenersOnMount = $component->instance()->getListeners();
+
+    $secondAddress->delete();
+
+    $component->dispatch(
+        'echo-private:contact.' . $this->contactForm->id . ',.AddressDeleted',
+        ['model' => ['id' => $secondAddress->getKey()]]
+    );
+
+    // client echo subscriptions are frozen at mount - every listener that existed
+    // on mount has to stay valid for the whole component lifetime
+    expect($component->instance()->getListeners())->toBe($listenersOnMount);
+});


### PR DESCRIPTION
## Summary
- Production (e.g. flux-sbm-verlag-de) logs `Livewire\Exceptions\EventHandlerDoesNotExist: Handler for event echo-private:address.{id},.AddressUpdated does not exist` on the contact view. The `Addresses` component built one echo listener per address from its mutable `addresses` array, while the client freezes its echo subscriptions at mount time. Once the address list changed during the component lifetime (address deleted in another session/tab, address moved to another contact), the next broadcast for that address hit a listener the server no longer announced and Livewire threw.
- The `Address` model already broadcasts all its events on the parent contact channel (`Address::broadcastOn()`), which is stable for the lifetime of the page. The component now listens for `AddressUpdated` and `AddressDeleted` there too — next to the existing `AddressCreated` listener — so the announced listeners can never diverge from the client subscriptions. As a side effect, addresses created while the page is open now receive live updates as well; previously the client never subscribed to their channels.
- Remove the dead `$this->listeners` writes in `loadAddresses()`; they had no effect at runtime.
- Covered by Livewire tests: update and delete events arriving on the contact channel are handled (selected address reloads, deleted address leaves the list), and the listener list stays identical across address-list mutations.

## Summary by Sourcery

Handle address Livewire events on the stable contact broadcast channel instead of per-address channels and keep listener definitions stable across address list changes.

Bug Fixes:
- Prevent Livewire event handler errors by listening for address update and delete events on the contact channel rather than dynamically building per-address listeners.

Enhancements:
- Ensure newly created addresses receive live updates by handling all address events on the contact channel.
- Simplify listener configuration by returning a fixed listener map for address create, update, and delete events.
- Remove dead writes to the listeners property when reloading addresses and streamline address loading logic.

Tests:
- Add Livewire tests verifying that address update and delete events on the contact channel reload or remove addresses correctly.
- Add a regression test ensuring the component's listener list remains stable even when the address list changes.