### PR TITLE
fix(tests): pin default language to de for deterministic locale

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -54,6 +54,7 @@ pest()
         ]);
 
         $this->defaultLanguage = Language::default() ?? Language::factory()->create([
+            'language_code' => 'de',
             'is_default' => true,
         ]);
 


### PR DESCRIPTION
## Summary

The test bootstrap in `tests/Pest.php` created the default language with a random faker language code. That code becomes the authenticated user's language and therefore the `html lang` attribute, which `$nuxbe.format.*` uses for `Intl.NumberFormat`. Locales with non-latin numerals (e.g. `hi` rendering Devanagari digits) made browser tests like `NuxbeHelperTest` fail randomly.

## Changes

- Pin the default language in the shared test setup to `de`, so number and date formatting in tests is deterministic.

## Summary by Sourcery

Bug Fixes:
- Fix non-deterministic browser test failures caused by random default language codes affecting locale-dependent number and date formatting.