### PR TITLE
feat(login): add auth-login-actions stack below login buttons

### DIFF
--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -149,6 +149,8 @@
                                     ></x-button>
                                 </div>
                             @endif
+
+                            @stack('auth-login-actions')
                         </form>
                         @section('passkey-login')
                             @if (Route::hasMacro('passkeys'))


### PR DESCRIPTION
## Summary
Adds an `@stack('auth-login-actions')` placeholder inside the login form, directly below the magic login link button. This allows packages to push additional login actions onto the login page without overriding the view.