### PR TITLE
fix(folder-tree): stop duplicating ancestor segment in getNodePath

### DIFF
--- a/resources/js/components/folders.js
+++ b/resources/js/components/folders.js
@@ -365,6 +365,14 @@ export default function folders(
                 return null;
             }
 
+            // A node's slug already encodes its full dotted path from the root,
+            // so deriving it again by walking ancestors would prepend the parent
+            // segments a second time (e.g. "Berater.1 Update" -> "Berater.Berater.1 Update").
+            // Return the slug as-is instead.
+            if (attribute === 'slug') {
+                return node.slug ?? null;
+            }
+
             const findPath = (node, path = []) => {
                 path.push(node[attribute]);
 
@@ -400,13 +408,7 @@ export default function folders(
                 return null;
             };
 
-            const pathArray = findPath(node);
-
-            if (attribute === 'slug' && pathArray) {
-                return pathArray.join('.');
-            }
-
-            return pathArray;
+            return findPath(node);
         },
     };
 }

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -27,7 +27,7 @@
                                 x-on:click="$wire.saveFolder({name: '{{ __('New folder') }}'}).then((folder) => { if (folder) addFolder(null, folder); })"
                             />
                         @endcanAction
-
+                        @stack('folder-tree-tree-actions')
                     @show
                 </x-slot:afterTree>
                 <div
@@ -210,6 +210,7 @@
                                 @endcanAction
 
                             @show
+                            @stack('folder-tree-selection-actions')
                         </div>
                         @section('folder-tree.upload.attributes')
                             @canAction(\FluxErp\Actions\MediaFolder\UpdateMediaFolder::class)

--- a/tests/Browser/Features/Media/FolderTreeUploadPathTest.php
+++ b/tests/Browser/Features/Media/FolderTreeUploadPathTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function (): void {
+    Storage::fake('local');
+
+    $this->contact = Contact::factory()->create();
+    Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    // A file living in the nested virtual collection "Berater.1 Update" makes the
+    // tree render a "Berater" folder containing a "1 Update" subfolder. The
+    // subfolder node's slug is the full dotted path "Berater.1 Update".
+    $this->contact
+        ->addMedia(UploadedFile::fake()->create('vorlage.xlsx'))
+        ->toMediaCollection('Berater.1 Update');
+});
+
+test('getNodePath returns a nested folder slug without duplicating ancestor segments', function (): void {
+    $page = visit('/contacts/contacts/' . $this->contact->getKey())
+        ->assertNoSmoke();
+
+    waitForElement($page, '[data-tab-name*="attachment"]');
+
+    $page->script(<<<'JS'
+        () => document.querySelector('[data-tab-name*="attachment"]').click()
+    JS);
+
+    // wait until a folder-tree Alpine scope exposing getNodePath has loaded the tree
+    waitForCondition($page, <<<'JS'
+        () => {
+            if (!window.Alpine) return false;
+            return Array.from(document.querySelectorAll('[x-data]')).some((el) => {
+                const data = Alpine.$data(el);
+                return data
+                    && typeof data.getNodePath === 'function'
+                    && Array.isArray(data.tree)
+                    && data.tree.length > 0;
+            });
+        }
+    JS, 15000);
+
+    $path = $page->script(<<<'JS'
+        () => {
+            const host = Array.from(document.querySelectorAll('[x-data]')).find((el) => {
+                const data = Alpine.$data(el);
+                return data && typeof data.getNodePath === 'function' && Array.isArray(data.tree);
+            });
+            const data = Alpine.$data(host);
+            const find = (nodes, slug) => {
+                for (const node of nodes) {
+                    if (node.slug === slug) return node;
+                    if (node.children) {
+                        const hit = find(node.children, slug);
+                        if (hit) return hit;
+                    }
+                }
+                return null;
+            };
+            const node = find(data.tree, 'Berater.1 Update');
+            return data.getNodePath(node, 'slug');
+        }
+    JS);
+
+    expect($path)->toBe('Berater.1 Update');
+});


### PR DESCRIPTION
## Problem

A folder node's `slug` already encodes the full dotted path from the root (e.g. the `1 Update` node under `Berater` has slug `Berater.1 Update`). `getNodePath()` rebuilt that path by walking the ancestors and then `concat`-ed the node's own slug on top, prepending the parent segments a second time:

```
getNodePath(node "1 Update", 'slug') => "Berater.Berater.1 Update"   // expected "Berater.1 Update"
```

That value is persisted as the media `collection_name` on upload, move, download and delete (`submitFiles`, `moveItem`, `downloadCollection`, `deleteCollection`). So uploading into a selected subfolder stored the file one level too deep, and the tree rendered the folder nested under a duplicate of its own parent after reload.

## Fix

For the `slug` attribute, return `node.slug` directly — it is already the complete path. The id/name attributes keep deriving the path via traversal. The now-unreachable `join('.')` branch is removed.

A browser regression test asserts `getNodePath(node, 'slug')` returns the non-duplicated slug for a nested folder.

## Also: action stacks

Adds two `@stack` targets to the folder-tree view so projects can register custom buttons without overriding the whole view:

- `folder-tree-tree-actions` — global, next to "Add folder"
- `folder-tree-selection-actions` — inside the selection action area, with access to the Alpine selection scope