### PR TITLE
fix(media): verify file on its own disk when downloading

### DIFF
--- a/src/Traits/Livewire/SupportsFileDownloads.php
+++ b/src/Traits/Livewire/SupportsFileDownloads.php
@@ -8,6 +8,7 @@ use FluxErp\Models\Media;
 use FluxErp\Models\MediaFolder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
@@ -20,7 +21,7 @@ trait SupportsFileDownloads
     #[Renderless]
     public function download(Media $media): void
     {
-        if (! file_exists($media->getPath())) {
+        if (! Storage::disk($media->disk)->exists($media->getPathRelativeToRoot())) {
             $this->toast()
                 ->error(__('The file does not exist anymore.'))
                 ->send();

--- a/tests/Livewire/Media/DownloadRemoteDiskTest.php
+++ b/tests/Livewire/Media/DownloadRemoteDiskTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use FluxErp\Livewire\Task\Media as MediaComponent;
+use FluxErp\Models\Media;
+use FluxErp\Models\Task;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use League\Flysystem\Filesystem as Flysystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    // A disk that stores files locally but reports a non-local (relative) path the
+    // way an S3-compatible disk does: getRootOfDisk() resolves to '', so
+    // $media->getPath() is a relative string and file_exists() on it is always
+    // false even though the file is present on the disk.
+    $root = sys_get_temp_dir() . '/flux-remote-' . Str::random(8);
+    $adapter = new LocalFilesystemAdapter($root);
+
+    $disk = new class(new Flysystem($adapter), $adapter, ['root' => $root]) extends FilesystemAdapter
+    {
+        public function path($path): string
+        {
+            return ltrim((string) $path, '/');
+        }
+    };
+
+    Storage::set('remote', $disk);
+});
+
+test('download redirects for a file on a remote disk where the local path does not exist', function (): void {
+    $task = Task::factory()->create();
+
+    $media = Media::query()->forceCreate([
+        'model_type' => morph_alias(Task::class),
+        'model_id' => $task->getKey(),
+        'uuid' => (string) Str::uuid(),
+        'collection_name' => 'default',
+        'name' => 'sample',
+        'file_name' => 'sample.xlsx',
+        'mime_type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'disk' => 'remote',
+        'conversions_disk' => 'remote',
+        'size' => 1024,
+        'manipulations' => '[]',
+        'custom_properties' => '[]',
+        'generated_conversions' => '[]',
+        'responsive_images' => '[]',
+    ]);
+
+    Storage::disk('remote')->put($media->getPathRelativeToRoot(), 'content');
+
+    // bug trigger: the local path check fails while the file is present on the disk
+    expect(file_exists($media->getPath()))->toBeFalse();
+    expect(Storage::disk('remote')->exists($media->getPathRelativeToRoot()))->toBeTrue();
+
+    Livewire::test(MediaComponent::class, ['modelId' => $task->getKey()])
+        ->call('download', $media->getKey())
+        ->assertRedirect();
+});


### PR DESCRIPTION
## Problem

`SupportsFileDownloads::download()` guarded against a missing file with:

```php
if (! file_exists($media->getPath())) { /* "The file does not exist anymore." */ }
```

`getPath()` resolves to `Storage::disk($media->disk)->path('/') . getPathRelativeToRoot()`. For the local driver that is an absolute path and `file_exists()` works. For remote disks (S3 and compatible) `path('/')` is empty, so `getPath()` is a relative object key and `file_exists()` is **always false** — even when the object exists on the disk. Downloading a file stored on a remote disk therefore failed with "The file does not exist anymore" (preview kept working because it goes through a generated URL).

## Fix

Check the file on its own disk:

```php
if (! Storage::disk($media->disk)->exists($media->getPathRelativeToRoot())) { ... }
```

This matches what the `media.show` route and `CloudDownloadController` already do.

## Test

Adds a regression test that registers a disk reporting non-local (relative) paths — reproducing the condition where `file_exists($media->getPath())` is false while the file is present on the disk — and asserts `download()` redirects instead of erroring.

## Summary by Sourcery

Ensure media downloads verify file existence using the configured storage disk instead of local filesystem paths.

Bug Fixes:
- Fix media downloads failing for files stored on non-local (e.g., S3-style) disks by checking existence via the disk driver rather than PHP file system functions.

Tests:
- Add a regression test covering downloads from a disk that returns non-local paths to ensure downloads redirect instead of erroring when the file exists on its storage disk.