### PR TITLE
fix(media): ASCII filename fallback for Content-Disposition

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -125,6 +125,7 @@ use FluxErp\Livewire\Task\Task;
 use FluxErp\Livewire\Task\TaskList;
 use FluxErp\Livewire\Ticket\Ticket;
 use FluxErp\Models\Address;
+use FluxErp\Support\MediaLibrary\ContentDisposition;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
@@ -384,7 +385,7 @@ Route::middleware('web')
                 ->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {
-                $disposition = HeaderUtils::makeDisposition(
+                $disposition = ContentDisposition::make(
                     request()->boolean('download')
                         ? HeaderUtils::DISPOSITION_ATTACHMENT
                         : HeaderUtils::DISPOSITION_INLINE,

--- a/src/Http/Controllers/PrivateMediaController.php
+++ b/src/Http/Controllers/PrivateMediaController.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Http\Controllers;
 
 use FluxErp\Models\Media;
+use FluxErp\Support\MediaLibrary\ContentDisposition;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -31,7 +32,7 @@ class PrivateMediaController extends Controller
 
         $fileName = basename($relativePath);
 
-        $disposition = HeaderUtils::makeDisposition(
+        $disposition = ContentDisposition::make(
             HeaderUtils::DISPOSITION_INLINE,
             $fileName,
         );

--- a/src/Support/MediaLibrary/ContentDisposition.php
+++ b/src/Support/MediaLibrary/ContentDisposition.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FluxErp\Support\MediaLibrary;
+
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+
+class ContentDisposition
+{
+    public static function make(string $disposition, string $filename): string
+    {
+        return HeaderUtils::makeDisposition($disposition, $filename, static::asciiFallback($filename));
+    }
+
+    public static function asciiFallback(string $filename): string
+    {
+        $fallback = preg_replace('/[^\x20-\x7e]|[%\/\\\\]/', '_', Str::ascii($filename));
+
+        return $fallback === '' ? 'file' : $fallback;
+    }
+}

--- a/tests/Feature/Web/MediaTest.php
+++ b/tests/Feature/Web/MediaTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Models\Permission;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 
 beforeEach(function (): void {
@@ -18,6 +19,25 @@ test('download media', function (): void {
     $this->actingAs($this->user, 'web')->get('/media/' . $this->media->id . '/' . $this->filename)
         ->assertOk()
         ->assertDownload();
+});
+
+test('download media with non ascii filename keeps the umlaut', function (): void {
+    $media = $this->user->addMedia(UploadedFile::fake()->image('TestFile.png'))
+        ->usingFileName('Develon_Dozer_Polen-Militär-1.png')
+        ->toMediaCollection();
+
+    $url = URL::signedRoute('media.show', [
+        'media' => $media->getKey(),
+        'download' => 1,
+    ]);
+
+    $disposition = $this->get($url)
+        ->assertOk()
+        ->headers->get('Content-Disposition');
+
+    expect($disposition)
+        ->toContain("filename*=utf-8''Develon_Dozer_Polen-Milit%C3%A4r-1.png")
+        ->toContain('filename=Develon_Dozer_Polen-Militar-1.png');
 });
 
 test('download media media not found', function (): void {


### PR DESCRIPTION
Downloading a media file whose name contains non-ASCII characters (for example German umlauts) threw `InvalidArgumentException: The filename fallback must only contain ASCII characters.` The media download route and the private media controller built the `Content-Disposition` header by passing the raw file name to `HeaderUtils::makeDisposition()` without an ASCII fallback, which Symfony requires whenever the name is not ASCII-only.

This adds a `ContentDisposition` helper that transliterates the file name into an ASCII-only fallback (replacing any remaining disallowed characters) while keeping the original UTF-8 name as the `filename*` part, and uses it in both the `media.show` route and `PrivateMediaController`.

A feature test covers downloading a media file with an umlaut in its name.

## Summary by Sourcery

Ensure media downloads generate safe Content-Disposition headers for filenames with non-ASCII characters by introducing a reusable helper and updating media responses to use it.

Bug Fixes:
- Prevent exceptions when downloading media files with non-ASCII filenames by providing an ASCII-only fallback for Content-Disposition headers.

Enhancements:
- Introduce a ContentDisposition helper to consistently build Content-Disposition headers with UTF-8 filenames and ASCII fallbacks for media responses.

Tests:
- Add a feature test verifying that media with a non-ASCII filename can be successfully downloaded via the signed media route.