### PR TITLE
fix(search-bar): skip detail widget for a missing model

### DIFF
--- a/src/Livewire/Widgets/SearchBar.php
+++ b/src/Livewire/Widgets/SearchBar.php
@@ -53,6 +53,13 @@ class SearchBar extends Component
             return;
         }
 
+        if (! resolve_static($model, 'query')->whereKey($modelId)->exists()) {
+            $this->skipRender();
+            $this->show = false;
+
+            return;
+        }
+
         $this->widgetComponent = $component;
         $this->widgetId = $modelId;
         $this->show = true;

--- a/tests/Livewire/Widgets/SearchBarTest.php
+++ b/tests/Livewire/Widgets/SearchBarTest.php
@@ -18,3 +18,12 @@ test('renderSearchBarWidget refuses models the user has no detail route permissi
         ->assertSet('show', false)
         ->assertSet('widgetComponent', null);
 });
+
+test('renderSearchBarWidget does not show a widget for a model that no longer exists', function (): void {
+    $this->user->givePermissionTo(Permission::findOrCreate('orders.{id}.get', 'web'));
+
+    Livewire::test(SearchBar::class)
+        ->dispatch('renderSearchBarWidget', model: Order::class, modelId: 999999999)
+        ->assertSet('show', false)
+        ->assertSet('widgetComponent', null);
+});


### PR DESCRIPTION
The search bar (and recently viewed entries) dispatch `renderSearchBarWidget` to show a model detail widget. It validated permission and that a widget component exists, but never checked that the referenced record still exists. When an entry points at a record that has since been deleted, the mounted detail widget fails while loading the missing model, throwing `Call to a member function toArray() on null` (seen in production from the contacts page via the Address detail widget).

This adds an existence check in `renderSearchBarWidget`: if the record no longer exists, the widget is not shown (same graceful skip as the permission and component checks). A test covers dispatching the event for a non-existent model id.

## Summary by Sourcery

Prevent search bar detail widgets from rendering when the referenced model record no longer exists.

Bug Fixes:
- Avoid errors when search bar or recently viewed entries reference records that have been deleted by skipping the corresponding detail widget.

Tests:
- Add a test ensuring renderSearchBarWidget does not show a widget when dispatched with a non-existent model ID.