### PR TITLE
fix(transaction-assignments): payment amount quick-fill and mobile sum layout

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -387,6 +387,7 @@
     "Apply Balance Amount": "Saldo-Betrag anwenden",
     "Apply Discount Amount": "Skonto-Betrag anwenden",
     "Apply Gross Total": "Bruttosumme anwenden",
+    "Apply Payment Amount": "Zahlbetrag anwenden",
     "Approval": "Genehmigung",
     "Approval Required": "Genehmigung erforderlich",
     "Approval User": "Freigabeberechtigter",

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -159,6 +159,35 @@
                             >)
                         </x-slot:text>
                     </x-button>
+                    <x-button
+                        sm
+                        color="secondary"
+                        x-cloak
+                        x-show="
+                            $wire.orderTransactionForm.transactionAmount !==
+                                null &&
+                            $wire.orderTransactionForm.transactionAmount !==
+                                $wire.orderTransactionForm.orderGrossTotal &&
+                            $wire.orderTransactionForm.transactionAmount !==
+                                $wire.orderTransactionForm.orderBalance
+                        "
+                        x-on:click="
+                            $wire.orderTransactionForm.amount =
+                                $wire.orderTransactionForm.transactionAmount
+                        "
+                    >
+                        <x-slot:text>
+                            {{ __('Apply Payment Amount') }} (<span
+                                x-html="
+                                    $nuxbe.format.money(
+                                        $wire.orderTransactionForm
+                                            .transactionAmount,
+                                    )
+                                "
+                            ></span
+                            >)
+                        </x-slot:text>
+                    </x-button>
                 </div>
             </div>
             <div
@@ -417,9 +446,7 @@
                                             class="flex w-full justify-between rounded bg-slate-100 p-2 font-semibold"
                                         >
                                             <div class="flex gap-2">
-                                                <div
-                                                    class="block overflow-hidden transition-all duration-200 lg:hidden lg:group-hover:block"
-                                                >
+                                                <div class="block">
                                                     <x-button
                                                         class="h-full"
                                                         color="secondary"
@@ -491,9 +518,7 @@
                                                         ></span>
                                                     </div>
                                                 </div>
-                                                <div
-                                                    class="block overflow-hidden transition-all duration-200 lg:hidden lg:group-hover:block"
-                                                >
+                                                <div class="block">
                                                     <x-button
                                                         class="h-full"
                                                         color="secondary"
@@ -509,9 +534,11 @@
                                 <div class="px-2 pt-2">
                                     <div class="flex flex-col">
                                         <div
-                                            class="flex flex-row items-center justify-between border-t border-slate-200 pt-2"
+                                            class="flex flex-col-reverse gap-2 border-t border-slate-200 pt-2 lg:flex-row lg:items-center lg:justify-between"
                                         >
-                                            <div class="flex flex-row gap-2">
+                                            <div
+                                                class="flex flex-row flex-wrap gap-2"
+                                            >
                                                 <x-button
                                                     sm
                                                     x-cloak
@@ -586,7 +613,7 @@
                                                 />
                                             </div>
                                             <div
-                                                class="flex flex-row items-center gap-4 pr-2"
+                                                class="flex flex-col items-end gap-y-1 lg:pr-2"
                                             >
                                                 <div
                                                     x-cloak

--- a/src/Livewire/Forms/OrderTransactionForm.php
+++ b/src/Livewire/Forms/OrderTransactionForm.php
@@ -33,6 +33,9 @@ class OrderTransactionForm extends FluxForm
     #[ExcludeFromActionData]
     public ?float $orderBalance = null;
 
+    #[ExcludeFromActionData]
+    public ?float $transactionAmount = null;
+
     #[Locked]
     public ?int $pivot_id = null;
 
@@ -61,11 +64,11 @@ class OrderTransactionForm extends FluxForm
             $order = resolve_static(Order::class, 'query')
                 ->whereKey($this->order_id)
                 ->first(['id', 'currency_id', 'total_gross_price', 'balance']);
-            $transactionCurrencyId = resolve_static(Transaction::class, 'query')
+            $transaction = resolve_static(Transaction::class, 'query')
                 ->whereKey($this->transaction_id)
-                ->value('currency_id');
+                ->first(['currency_id', 'amount']);
 
-            $this->orderCurrencyIso = $order?->currency_id !== $transactionCurrencyId
+            $this->orderCurrencyIso = $order?->currency_id !== $transaction?->currency_id
                 ? resolve_static(Currency::class, 'query')->whereKey($order?->currency_id)->value('iso')
                 : null;
             $this->orderGrossTotal = ! is_null($order?->total_gross_price)
@@ -74,10 +77,14 @@ class OrderTransactionForm extends FluxForm
             $this->orderBalance = ! is_null($order?->balance)
                 ? (float) $order->balance
                 : null;
+            $this->transactionAmount = ! is_null($transaction?->amount)
+                ? (float) $transaction->amount
+                : null;
         } else {
             $this->orderCurrencyIso = null;
             $this->orderGrossTotal = null;
             $this->orderBalance = null;
+            $this->transactionAmount = null;
         }
     }
 

--- a/tests/Livewire/Accounting/TransactionAssignmentsTest.php
+++ b/tests/Livewire/Accounting/TransactionAssignmentsTest.php
@@ -104,3 +104,38 @@ test('editOrderTransaction populates form with order gross total and balance', f
         ->assertSet('orderTransactionForm.orderGrossTotal', 250.0)
         ->assertSet('orderTransactionForm.orderBalance', 100.0);
 });
+
+test('editOrderTransaction populates the transaction payment amount', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'amount' => 175.5,
+    ]);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create();
+    $order = Order::factory()->create([
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => Tenant::default()->getKey(),
+        'language_id' => Language::default()->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'total_gross_price' => 250,
+        'balance' => 100,
+    ]);
+
+    $orderTransaction = OrderTransaction::query()->create([
+        'transaction_id' => $transaction->getKey(),
+        'order_id' => $order->getKey(),
+        'amount' => 50,
+        'is_accepted' => false,
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('editOrderTransaction', $orderTransaction->getAttribute('pivot_id'))
+        ->assertSet('orderTransactionForm.transactionAmount', 175.5);
+});


### PR DESCRIPTION
Follow-up to the transaction assignments rework.

- Adds an **Apply Payment Amount** quick-fill button to the order transaction modal that fills the amount with the transaction's own amount, next to the existing gross total and balance buttons. `OrderTransactionForm` now exposes `transactionAmount` for it.
- Keeps the per-assignment **edit** and **detail** buttons visible on desktop instead of only revealing them on row hover, so the edit modal stays reachable without hovering.
- Stacks the **suggested** and **open** sums vertically and right-aligns them, and lets the transaction action bar wrap on small screens so the sums no longer overflow horizontally on mobile.

Covered by a feature test asserting the form populates the transaction payment amount.

## Summary by Sourcery

Improve transaction assignment order payment workflow and mobile layout for transaction details and summaries.

New Features:
- Add an Apply Payment Amount quick-fill option that populates the order transaction amount from the transaction's own amount.

Bug Fixes:
- Ensure per-assignment edit and detail actions remain accessible on desktop without requiring row hover.

Enhancements:
- Adjust transaction action bar and summary layout to stack and wrap correctly on small screens, preventing horizontal overflow of suggested and open sums.

Tests:
- Add a feature test verifying that editing an order transaction populates the transaction payment amount in the form.