### PR TITLE
add bulk validate and execute to FluxAction

### DIFF
--- a/src/Actions/FluxAction.php
+++ b/src/Actions/FluxAction.php
@@ -212,36 +212,9 @@ abstract class FluxAction
         // transaction counter — breaking RefreshDatabase rollback in tests and
         // risking inconsistent state on deadlock retry in production.
         if (DB::transactionLevel() === 0) {
-            DB::transaction(
-                function () use ($isBulk) {
-                    if ($isBulk) {
-                        $bulk = $this->data;
-
-                        foreach ($bulk as $data) {
-                            $this->data = $data;
-                            $this->result[] = $this->performAction();
-                        }
-
-                        $this->data = $bulk;
-                    } else {
-                        $this->result = $this->performAction();
-                    }
-                },
-                5
-            );
+            DB::transaction(fn () => $this->bulkPerformAction($isBulk), 5);
         } else {
-            if ($isBulk) {
-                $bulk = $this->data;
-
-                foreach ($bulk as $data) {
-                    $this->data = $data;
-                    $this->result[] = $this->performAction();
-                }
-
-                $this->data = $bulk;
-            } else {
-                $this->result = $this->performAction();
-            }
+            $this->bulkPerformAction($isBulk);
         }
 
         if ($current) {
@@ -352,7 +325,7 @@ abstract class FluxAction
             $data[] = $this->data;
         }
 
-        $this->data = $isBulk ? $data : array_first($this->data);
+        $this->data = $isBulk ? $data : array_first($data);
 
         return $this;
     }
@@ -383,5 +356,22 @@ abstract class FluxAction
     protected function validateData(): void
     {
         $this->data = Validator::validate($this->getData(), $this->getRules());
+    }
+
+    final protected function bulkPerformAction(bool $isBulk): void
+    {
+        if ($isBulk) {
+            $bulk = $this->data;
+            $this->result = [];
+
+            foreach ($bulk as $data) {
+                $this->data = $data;
+                $this->result[] = $this->performAction();
+            }
+
+            $this->data = $bulk;
+        } else {
+            $this->result = $this->performAction();
+        }
     }
 }

--- a/src/Actions/FluxAction.php
+++ b/src/Actions/FluxAction.php
@@ -204,7 +204,9 @@ abstract class FluxAction
             }
         }
 
-        $isBulk = $this instanceof SupportsBulkExecution && array_is_list($this->data);
+        $isBulk = $this instanceof SupportsBulkExecution
+            && count($this->data) > 0
+            && array_is_list($this->data);
 
         // Only wrap in a transaction if not already inside one. Nested actions
         // (e.g. CreateOrder calling CreateOrderPosition) would otherwise create
@@ -303,16 +305,30 @@ abstract class FluxAction
             $this->setRulesFromRulesets();
         }
 
-        if ($isBulk = $this instanceof SupportsBulkExecution && array_is_list($this->data)) {
+        if ($this instanceof SupportsBulkExecution
+            && count($this->data) > 0
+            && array_is_list($this->data)
+        ) {
             $bulk = $this->data;
+            $data = [];
+
+            foreach ($bulk as $item) {
+                $this->data = $item;
+
+                $this->fireActionEvent(event: 'preparingForValidation');
+                $this->prepareForValidation();
+
+                if ($this->fireActionEvent(event: 'validating') !== false) {
+                    $this->validateData();
+
+                    $this->fireActionEvent(event: 'validated', halt: false);
+                }
+
+                $data[] = $this->data;
+            }
+
+            $this->data = $data;
         } else {
-            $bulk = [$this->data];
-        }
-
-        $data = [];
-        foreach ($bulk as $item) {
-            $this->data = $item;
-
             $this->fireActionEvent(event: 'preparingForValidation');
             $this->prepareForValidation();
 
@@ -321,11 +337,7 @@ abstract class FluxAction
 
                 $this->fireActionEvent(event: 'validated', halt: false);
             }
-
-            $data[] = $this->data;
         }
-
-        $this->data = $isBulk ? $data : array_first($data);
 
         return $this;
     }

--- a/src/Actions/FluxAction.php
+++ b/src/Actions/FluxAction.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Actions;
 
+use FluxErp\Contracts\SupportsBulkExecution;
 use FluxErp\Models\Permission;
 use FluxErp\Rulesets\FluxRuleset;
 use FluxErp\Traits\Action\HasActionEvents;
@@ -203,15 +204,44 @@ abstract class FluxAction
             }
         }
 
+        $isBulk = $this instanceof SupportsBulkExecution && array_is_list($this->data);
+
         // Only wrap in a transaction if not already inside one. Nested actions
         // (e.g. CreateOrder calling CreateOrderPosition) would otherwise create
         // deeply nested savepoints whose retry logic can desynchronize Laravel's
         // transaction counter — breaking RefreshDatabase rollback in tests and
         // risking inconsistent state on deadlock retry in production.
         if (DB::transactionLevel() === 0) {
-            DB::transaction(fn () => $this->result = $this->performAction(), 5);
+            DB::transaction(
+                function () use ($isBulk) {
+                    if ($isBulk) {
+                        $bulk = $this->data;
+
+                        foreach ($bulk as $data) {
+                            $this->data = $data;
+                            $this->result[] = $this->performAction();
+                        }
+
+                        $this->data = $bulk;
+                    } else {
+                        $this->result = $this->performAction();
+                    }
+                },
+                5
+            );
         } else {
-            $this->result = $this->performAction();
+            if ($isBulk) {
+                $bulk = $this->data;
+
+                foreach ($bulk as $data) {
+                    $this->data = $data;
+                    $this->result[] = $this->performAction();
+                }
+
+                $this->data = $bulk;
+            } else {
+                $this->result = $this->performAction();
+            }
         }
 
         if ($current) {
@@ -300,14 +330,29 @@ abstract class FluxAction
             $this->setRulesFromRulesets();
         }
 
-        $this->fireActionEvent(event: 'preparingForValidation');
-        $this->prepareForValidation();
-
-        if ($this->fireActionEvent(event: 'validating') !== false) {
-            $this->validateData();
-
-            $this->fireActionEvent(event: 'validated', halt: false);
+        if ($isBulk = $this instanceof SupportsBulkExecution && array_is_list($this->data)) {
+            $bulk = $this->data;
+        } else {
+            $bulk = [$this->data];
         }
+
+        $data = [];
+        foreach ($bulk as $item) {
+            $this->data = $item;
+
+            $this->fireActionEvent(event: 'preparingForValidation');
+            $this->prepareForValidation();
+
+            if ($this->fireActionEvent(event: 'validating') !== false) {
+                $this->validateData();
+
+                $this->fireActionEvent(event: 'validated', halt: false);
+            }
+
+            $data[] = $this->data;
+        }
+
+        $this->data = $isBulk ? $data : array_first($this->data);
 
         return $this;
     }


### PR DESCRIPTION
## Summary by Sourcery

Add bulk-aware validation and execution behavior to FluxAction when actions implement bulk execution support and receive list data.

New Features:
- Support executing actions in bulk when the action implements bulk execution and input data is a list.
- Support validating multiple payloads in bulk by iterating over each item and aggregating the prepared/validated data.

Enhancements:
- Ensure bulk executions and validations respect existing transaction handling and action event lifecycle while restoring original data structure after processing.