### PR TITLE
Add folder-tree-file-actions stack for selected-file actions

### DIFF
--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -441,6 +441,9 @@
                                             })
                                     "
                                 />
+
+                                @stack('folder-tree-file-actions')
+
                                 @canAction(\FluxErp\Actions\Media\DeleteMedia::class)
                                     <div
                                         x-cloak


### PR DESCRIPTION
Adds a `@stack('folder-tree-file-actions')` inside the selected-file action bar (next to Download / Copy link / Delete) so packages can register per-file actions (e.g. an "Edit" button).

The existing `folder-tree-selection-actions` stack lives in the folder block (rendered only when no file is selected), so it cannot be used for per-file actions.