### PR TITLE
feat: per-menu unread notification indicator

### DIFF
--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -67,7 +67,7 @@
                                 @endif
                                 class="dark:text-light dark:hover:bg-indigo flex items-center rounded-md py-2 text-gray-500 transition-colors hover:bg-gray-800/50"
                             >
-                                <div class="w-16 flex-none">
+                                <div class="relative w-16 flex-none">
                                     <div
                                         class="flex w-full justify-center text-white"
                                     >
@@ -76,6 +76,13 @@
                                             class="h-4 w-4"
                                         />
                                     </div>
+                                    @if ($notificationCount = data_get($notificationCounts, $key))
+                                        <span
+                                            class="absolute top-1/2 left-3 flex h-4 min-w-4 -translate-y-1/2 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-none font-semibold text-white"
+                                        >
+                                            {{ $notificationCount }}
+                                        </span>
+                                    @endif
                                 </div>
                                 <span class="truncate text-sm text-white">
                                     {{ __($navigation["label"] ?? $key) }}

--- a/src/Livewire/Features/Notifications.php
+++ b/src/Livewire/Features/Notifications.php
@@ -7,6 +7,7 @@ use FluxErp\Traits\Livewire\Actions;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 
@@ -28,12 +29,19 @@ class Notifications extends Component
         return view('flux::livewire.features.notifications');
     }
 
+    #[On('notifications-changed')]
+    public function refreshUnread(): void
+    {
+        $this->unread = auth()->user()->unreadNotifications()->count();
+    }
+
     #[Renderless]
     public function acceptNotify(Notification $notification): void
     {
         $accept = data_get($notification->data, 'accept');
         $notification->markAsRead();
         $this->unread = max(0, $this->unread - 1);
+        $this->dispatch('notifications-changed');
 
         $this->js(<<<'JS'
             $tsui.close.slide('notifications-slide');
@@ -55,6 +63,7 @@ class Notifications extends Component
     {
         auth()->user()->unreadNotifications->markAsRead();
         $this->unread = 0;
+        $this->dispatch('notifications-changed');
 
         $this->js(<<<'JS'
             $tsui.close.slide('notifications-slide');
@@ -67,6 +76,7 @@ class Notifications extends Component
         $notification->markAsRead();
 
         $this->unread = max(0, $this->unread - 1);
+        $this->dispatch('notifications-changed');
         if (! $this->unread) {
             $this->js(<<<'JS'
                 $tsui.close.slide('notifications-slide');
@@ -100,6 +110,8 @@ class Notifications extends Component
         $notification->toast($this)
             ->id(data_get($notify, 'contextId'))
             ->send();
+
+        $this->dispatch('notifications-changed');
     }
 
     #[Renderless]

--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -102,9 +102,8 @@ class Navigation extends Component
         }
 
         return $user->unreadNotifications
-            ->groupBy(fn (Notification $notification): ?string => $notification->menuArea())
+            ->countBy(fn (Notification $notification): ?string => $notification->menuArea())
             ->forget('')
-            ->map->count()
             ->all();
     }
 

--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -3,24 +3,39 @@
 namespace FluxErp\Livewire;
 
 use FluxErp\Facades\Menu;
+use FluxErp\Models\Notification;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class Navigation extends Component
 {
+    public function mount(): void
+    {
+        $this->markAreaRead(Route::currentRouteName());
+    }
+
     public function render(): View|Factory|Application
     {
         return view('flux::livewire.navigation', [
             'navigations' => $this->getMenu(),
             'visits' => $this->getVisits(),
             'favorites' => $this->getFavorites(),
+            'notificationCounts' => $this->getNotificationCounts(),
         ]);
+    }
+
+    #[On('notifications-changed')]
+    public function refreshNotificationCounts(): void
+    {
+        // Re-render so the per-area badges pick up the latest unread counts.
     }
 
     public function addFavorite(string $url, ?string $name = null): void
@@ -47,6 +62,50 @@ class Navigation extends Component
             ->favorites()
             ->whereKey($id)
             ->delete();
+    }
+
+    protected function markAreaRead(?string $routeName): void
+    {
+        $user = auth()->user();
+
+        if (! method_exists($user, 'unreadNotifications')) {
+            return;
+        }
+
+        $area = Str::before($routeName ?? '', '.') ?: null;
+
+        if (blank($area)) {
+            return;
+        }
+
+        $ids = $user->unreadNotifications
+            ->filter(fn (Notification $notification): bool => $notification->menuArea() === $area)
+            ->modelKeys();
+
+        if (blank($ids)) {
+            return;
+        }
+
+        $user->unreadNotifications()
+            ->whereKey($ids)
+            ->update(['read_at' => now()]);
+
+        $this->dispatch('notifications-changed');
+    }
+
+    protected function getNotificationCounts(): array
+    {
+        $user = auth()->user();
+
+        if (! method_exists($user, 'unreadNotifications')) {
+            return [];
+        }
+
+        return $user->unreadNotifications
+            ->groupBy(fn (Notification $notification): ?string => $notification->menuArea())
+            ->forget('')
+            ->map->count()
+            ->all();
     }
 
     protected function getFavorites(): ?array

--- a/src/Models/Notification.php
+++ b/src/Models/Notification.php
@@ -8,6 +8,7 @@ use FluxErp\Traits\Model\ResolvesRelationsThroughContainer;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Str;
 use Livewire\Component;
 
 class Notification extends DatabaseNotification
@@ -15,6 +16,15 @@ class Notification extends DatabaseNotification
     use MassPrunable, ResolvesRelationsThroughContainer;
 
     // Public methods
+    public function menuArea(): ?string
+    {
+        if (data_get($this->data, 'menu_indicator') === false) {
+            return null;
+        }
+
+        return Str::before(data_get($this->data, 'accept.route', ''), '.') ?: null;
+    }
+
     public function prunable(): Builder
     {
         return static::query()

--- a/src/Models/Notification.php
+++ b/src/Models/Notification.php
@@ -22,7 +22,7 @@ class Notification extends DatabaseNotification
             return null;
         }
 
-        return Str::before(data_get($this->data, 'accept.route', ''), '.') ?: null;
+        return Str::before(data_get($this->data, 'accept.route') ?? '', '.') ?: null;
     }
 
     public function prunable(): Builder

--- a/src/Support/Notification/ToastNotification/NotificationAction.php
+++ b/src/Support/Notification/ToastNotification/NotificationAction.php
@@ -17,6 +17,8 @@ class NotificationAction implements Arrayable
 
     protected mixed $params = null;
 
+    protected ?string $routeName = null;
+
     protected ?bool $solid = null;
 
     protected ?string $style = null;
@@ -87,6 +89,8 @@ class NotificationAction implements Arrayable
 
     public function route(string $route, array $params = []): static
     {
+        $this->routeName = $route;
+
         return $this->url(route($route, $params));
     }
 
@@ -111,6 +115,7 @@ class NotificationAction implements Arrayable
             'style' => $this->style,
             'solid' => $this->solid,
             'url' => $this->url,
+            'route' => $this->routeName,
             'download' => $this->download,
             'execute' => $this->execute,
             'method' => $this->method,

--- a/src/Support/Notification/ToastNotification/ToastNotification.php
+++ b/src/Support/Notification/ToastNotification/ToastNotification.php
@@ -28,6 +28,8 @@ class ToastNotification extends Toast implements Arrayable
 
     protected bool $markAsRead = false;
 
+    protected bool $menuIndicator = true;
+
     protected ?string $method = null;
 
     protected ?object $notifiable = null;
@@ -141,6 +143,18 @@ class ToastNotification extends Toast implements Arrayable
         return $this;
     }
 
+    public function menuIndicator(bool $menuIndicator = true): static
+    {
+        $this->menuIndicator = $menuIndicator;
+
+        return $this;
+    }
+
+    public function hideFromMenu(): static
+    {
+        return $this->menuIndicator(false);
+    }
+
     public function method(string $method): static
     {
         $this->method = $method;
@@ -222,6 +236,7 @@ class ToastNotification extends Toast implements Arrayable
                 'progressbar' => $this->progressbar,
                 'params' => $this->params,
                 'markAsRead' => $this->markAsRead,
+                'menu_indicator' => $this->menuIndicator,
                 'method' => $this->method,
                 'emit' => $this->emit,
                 'to' => $this->to,

--- a/tests/Livewire/Features/NotificationsTest.php
+++ b/tests/Livewire/Features/NotificationsTest.php
@@ -1,9 +1,25 @@
 <?php
 
 use FluxErp\Livewire\Features\Notifications;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(Notifications::class)
         ->assertOk();
+});
+
+test('recomputes the unread count when notifications change', function (): void {
+    $component = Livewire::actingAs($this->user)
+        ->test(Notifications::class)
+        ->assertSet('unread', 0);
+
+    $this->user->notifications()->create([
+        'id' => (string) Str::uuid(),
+        'type' => 'test',
+        'data' => [],
+    ]);
+
+    $component->dispatch('notifications-changed')
+        ->assertSet('unread', 1);
 });

--- a/tests/Livewire/NavigationTest.php
+++ b/tests/Livewire/NavigationTest.php
@@ -3,15 +3,33 @@
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Facades\Menu;
 use FluxErp\Livewire\Navigation;
+use FluxErp\Models\Notification;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\Permission;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
+function createNavigationNotification(?string $route): Notification
+{
+    return test()->user->notifications()->create([
+        'id' => (string) Str::uuid(),
+        'type' => 'test',
+        'data' => is_null($route) ? [] : ['accept' => ['route' => $route]],
+    ]);
+}
+
 test('renders successfully', function (): void {
     Livewire::test(Navigation::class)
         ->assertOk();
+});
+
+test('passes unread notification counts per menu area to the view', function (): void {
+    createNavigationNotification('tickets');
+
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertViewHas('notificationCounts', fn (array $counts): bool => ($counts['tickets'] ?? 0) === 1);
 });
 
 test('shows order types', function (): void {

--- a/tests/Unit/Models/NotificationMenuAreaTest.php
+++ b/tests/Unit/Models/NotificationMenuAreaTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use FluxErp\Models\Notification;
+
+function notificationWith(array $data): Notification
+{
+    return tap(new Notification(), fn (Notification $notification) => $notification->data = $data);
+}
+
+test('derives the menu area from the stored route name', function (): void {
+    expect(notificationWith(['accept' => ['route' => 'tickets']])->menuArea())->toBe('tickets');
+});
+
+test('derives a detail route to its top level menu area', function (): void {
+    expect(notificationWith(['accept' => ['route' => 'orders.id']])->menuArea())->toBe('orders');
+});
+
+test('has no menu area without a route', function (): void {
+    expect(notificationWith(['accept' => ['url' => 'https://example.com']])->menuArea())->toBeNull();
+});
+
+test('has no menu area when opting out of the menu indicator', function (): void {
+    expect(notificationWith(['menu_indicator' => false, 'accept' => ['route' => 'tickets']])->menuArea())->toBeNull();
+});


### PR DESCRIPTION
Adds a per-menu-area badge showing the count of unread notifications, kept in sync in real time over the existing broadcast socket.

## How it works
- `NotificationAction::route($name, $params)` now stores the route name in `data.accept.route` (in addition to the url).
- `Notification::menuArea()` maps that route name to the top level menu key (the segment before the first dot, e.g. `tickets.id` → `tickets`).
- `Navigation` groups the user's unread notifications by area for the badges, and on `mount()` marks the visited area's notifications as read so the badge clears (and the bell count drops with it).
- `Features\\Notifications` dispatches a shared `notifications-changed` event on every change (new notification via the existing Echo `.notification()` listener, accept, mark read), which re-renders the menu badges and recomputes the bell's unread count. No second socket.
- A notification can opt out of the menu indicator with `ToastNotification::hideFromMenu()` (or `menuIndicator(false)`); notifications without a routed target never produce a badge.

No new storage, no schema change, no url reverse-matching.

## Summary by Sourcery

Add per-menu unread notification indicators and keep notification-related UI in sync via a shared Livewire event.

New Features:
- Expose per-menu unread notification counts to the navigation view for rendering area-level badges.
- Allow toast notifications to opt out of contributing to menu unread indicators via a configurable flag.

Enhancements:
- Derive a notification’s menu area from its stored route name to group notifications by top-level menu section.
- Automatically mark notifications for the current menu area as read when the navigation component mounts, updating unread state across the UI.
- Broadcast a shared `notifications-changed` Livewire event from notification actions so other components can refresh their unread counts.

Tests:
- Add coverage for per-menu unread notification counts in the navigation component.
- Add tests ensuring notification components recompute unread counts when notifications change.
- Add unit tests for the `Notification` model’s `menuArea` derivation and opt-out behavior.