### PR TITLE
feat: user access token endpoint

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use FluxErp\Actions\Token\CreateUserAccessToken;
 use FluxErp\Http\Controllers\AssetController;
 use FluxErp\Http\Controllers\FilePondChunkController;
 use FluxErp\Http\Controllers\LoginLinkController;
@@ -53,6 +54,9 @@ Route::middleware('web')
         Route::middleware(['auth:web', 'throttle:300,1'])->group(function (): void {
             Route::match(['POST', 'PATCH'], '/file-pond/chunk', [FilePondChunkController::class, 'handle'])
                 ->name('file-pond.chunk');
+
+            Route::post('/user/access-token', CreateUserAccessToken::class)
+                ->name('user.access-token');
         });
 
         Route::middleware('cache.headers:public;max_age=31536000;etag')->group(function (): void {

--- a/src/Actions/Token/CreateUserAccessToken.php
+++ b/src/Actions/Token/CreateUserAccessToken.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FluxErp\Actions\Token;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Models\User;
+use FluxErp\Rulesets\Token\CreateUserAccessTokenRuleset;
+
+class CreateUserAccessToken extends FluxAction
+{
+    protected static bool $hasPermission = false;
+
+    public static function models(): array
+    {
+        return [User::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return CreateUserAccessTokenRuleset::class;
+    }
+
+    public function performAction(): array
+    {
+        $token = auth()->user()->createToken(
+            $this->getData('name'),
+            $this->getData('abilities') ?? ['user'],
+        );
+
+        return ['token' => $token->plainTextToken];
+    }
+}

--- a/src/Rulesets/Token/CreateUserAccessTokenRuleset.php
+++ b/src/Rulesets/Token/CreateUserAccessTokenRuleset.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FluxErp\Rulesets\Token;
+
+use FluxErp\Rulesets\FluxRuleset;
+use Illuminate\Validation\Rule;
+
+class CreateUserAccessTokenRuleset extends FluxRuleset
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'abilities' => 'nullable|array',
+            'abilities.*' => [
+                'required',
+                'string',
+                Rule::in([
+                    '*',
+                    'interface',
+                    'user',
+                    'address',
+                ]),
+            ],
+        ];
+    }
+}

--- a/src/Rulesets/Token/CreateUserAccessTokenRuleset.php
+++ b/src/Rulesets/Token/CreateUserAccessTokenRuleset.php
@@ -16,10 +16,8 @@ class CreateUserAccessTokenRuleset extends FluxRuleset
                 'required',
                 'string',
                 Rule::in([
-                    '*',
                     'interface',
                     'user',
-                    'address',
                 ]),
             ],
         ];


### PR DESCRIPTION
Adds `POST /user/access-token` (under `auth:web`) that issues a personal access token owned by the currently authenticated user, implemented as a FluxAction (`CreateUserAccessToken`) with its own ruleset.

## Why
Native/desktop clients authenticate through the web login (password, password managers, passkeys, 2FA) and then need an API token. The existing `POST /api/tokens` creates a token-owned token whose permissions are a separate snapshot, so it does not reflect the user's permissions. This endpoint issues a **user-owned** token, so permission checks run against the user's live permissions and stay correct when they change.

## Details
- `name` required; optional `abilities` (defaults to `['user']`), validated against the same set as `CreateToken`.
- The action sets `$hasPermission = false` (no permission gate); access is controlled by the `auth:web` session.
- Returns `{ "token": "<plain-text-token>" }`.

## Summary by Sourcery

Add a web-authenticated endpoint for issuing user-owned API access tokens.

New Features:
- Introduce POST /user/access-token route under auth:web to create personal access tokens for the authenticated user.

Enhancements:
- Add a FluxAction (CreateUserAccessToken) and validation ruleset for creating user-owned access tokens with optional abilities configuration.