### PR TITLE
feat: broadcast work time changes on the owner's user channel

### DIFF
--- a/src/Livewire/WorkTime.php
+++ b/src/Livewire/WorkTime.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Livewire;
 
 use FluxErp\Livewire\Forms\WorkTimeForm;
+use FluxErp\Models\User;
 use FluxErp\Models\WorkTime as WorkTimeModel;
 use FluxErp\Models\WorkTimeType;
 use FluxErp\Traits\Livewire\Actions;
@@ -31,27 +32,7 @@ class WorkTime extends Component
 
     public function mount(): void
     {
-        $this->activeWorkTimes = resolve_static(WorkTimeModel::class, 'query')
-            ->with('workTimeType:id,name')
-            ->where('user_id', auth()->id())
-            ->where('is_daily_work_time', false)
-            ->where('is_locked', false)
-            ->get()
-            ->toArray();
-
-        $this->dailyWorkTime->fill(resolve_static(WorkTimeModel::class, 'query')
-            ->where('user_id', auth()->id())
-            ->where('is_daily_work_time', true)
-            ->where('is_pause', false)
-            ->where('is_locked', false)
-            ->first() ?? []);
-
-        $this->dailyWorkTimePause->fill(resolve_static(WorkTimeModel::class, 'query')
-            ->where('user_id', auth()->id())
-            ->where('is_daily_work_time', true)
-            ->where('is_pause', true)
-            ->where('is_locked', false)
-            ->first() ?? []);
+        $this->loadWorkTimes();
     }
 
     public function render(): Factory|Application|View
@@ -63,6 +44,33 @@ class WorkTime extends Component
                 ->toArray(),
             'trackableTypes' => get_models_with_trait(Trackable::class),
         ]);
+    }
+
+    public function loadWorkTimes(): void
+    {
+        $this->activeWorkTimes = resolve_static(WorkTimeModel::class, 'query')
+            ->with('workTimeType:id,name')
+            ->where('user_id', auth()->id())
+            ->where('is_daily_work_time', false)
+            ->where('is_locked', false)
+            ->get()
+            ->toArray();
+
+        $this->dailyWorkTime->reset();
+        $this->dailyWorkTime->fill(resolve_static(WorkTimeModel::class, 'query')
+            ->where('user_id', auth()->id())
+            ->where('is_daily_work_time', true)
+            ->where('is_pause', false)
+            ->where('is_locked', false)
+            ->first() ?? []);
+
+        $this->dailyWorkTimePause->reset();
+        $this->dailyWorkTimePause->fill(resolve_static(WorkTimeModel::class, 'query')
+            ->where('user_id', auth()->id())
+            ->where('is_daily_work_time', true)
+            ->where('is_pause', true)
+            ->where('is_locked', false)
+            ->first() ?? []);
     }
 
     #[Renderless]
@@ -263,9 +271,14 @@ class WorkTime extends Component
 
     protected function getListeners(): array
     {
+        $userChannel = 'echo-private:' . app(User::class)->getMorphClass() . '.' . auth()->id();
+
         return [
             'echo-private:' . resolve_static(WorkTimeType::class, 'getBroadcastChannel')
             . ',.WorkTimeTypeCreated' => '$refresh',
+            $userChannel . ',.WorkTimeCreated' => 'loadWorkTimes',
+            $userChannel . ',.WorkTimeUpdated' => 'loadWorkTimes',
+            $userChannel . ',.WorkTimeDeleted' => 'loadWorkTimes',
         ];
     }
 }

--- a/src/Livewire/WorkTime.php
+++ b/src/Livewire/WorkTime.php
@@ -271,14 +271,18 @@ class WorkTime extends Component
 
     protected function getListeners(): array
     {
-        $userChannel = 'echo-private:' . app(User::class)->getMorphClass() . '.' . auth()->id();
-
-        return [
+        $listeners = [
             'echo-private:' . resolve_static(WorkTimeType::class, 'getBroadcastChannel')
             . ',.WorkTimeTypeCreated' => '$refresh',
-            $userChannel . ',.WorkTimeCreated' => 'loadWorkTimes',
-            $userChannel . ',.WorkTimeUpdated' => 'loadWorkTimes',
-            $userChannel . ',.WorkTimeDeleted' => 'loadWorkTimes',
         ];
+
+        if ($userId = auth()->id()) {
+            $userChannel = 'echo-private:' . morph_alias(User::class) . '.' . $userId;
+            $listeners[$userChannel . ',.WorkTimeCreated'] = 'loadWorkTimes';
+            $listeners[$userChannel . ',.WorkTimeUpdated'] = 'loadWorkTimes';
+            $listeners[$userChannel . ',.WorkTimeDeleted'] = 'loadWorkTimes';
+        }
+
+        return $listeners;
     }
 }

--- a/src/Models/WorkTime.php
+++ b/src/Models/WorkTime.php
@@ -14,10 +14,12 @@ use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\SoftDeletes;
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -256,6 +258,19 @@ class WorkTime extends FluxModel implements Calendarable, Targetable
             ->using(EmployeeDayWorkTime::class)
             ->withPivot(['hours_contributed', 'break_minutes_contributed'])
             ->withTimestamps();
+    }
+
+    public function broadcastOn(string $event): array
+    {
+        $channels = Arr::wrap(parent::broadcastOn($event));
+
+        if (! is_null($this->user_id)) {
+            $channels[] = new PrivateChannel(
+                app(User::class)->getMorphClass() . '.' . $this->user_id
+            );
+        }
+
+        return $channels;
     }
 
     public function model(): MorphTo

--- a/src/Models/WorkTime.php
+++ b/src/Models/WorkTime.php
@@ -266,7 +266,7 @@ class WorkTime extends FluxModel implements Calendarable, Targetable
 
         if (! is_null($this->user_id)) {
             $channels[] = new PrivateChannel(
-                app(User::class)->getMorphClass() . '.' . $this->user_id
+                morph_alias(User::class) . '.' . $this->user_id
             );
         }
 

--- a/tests/Unit/Models/WorkTimeBroadcastTest.php
+++ b/tests/Unit/Models/WorkTimeBroadcastTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use FluxErp\Models\User;
+use FluxErp\Models\WorkTime;
+use Illuminate\Support\Arr;
+
+function workTimeBroadcastChannels(WorkTime $workTime, string $event): array
+{
+    return collect(Arr::wrap($workTime->broadcastOn($event)))
+        ->map(fn ($channel) => $channel->name)
+        ->all();
+}
+
+test('work time broadcasts on the owning user channel', function (): void {
+    $user = User::factory()->create();
+    $workTime = WorkTime::factory()->make(['user_id' => $user->getKey()]);
+
+    expect(workTimeBroadcastChannels($workTime, 'updated'))
+        ->toContain('private-user.' . $user->getKey());
+});
+
+test('work time does not broadcast on another user channel', function (): void {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $workTime = WorkTime::factory()->make(['user_id' => $owner->getKey()]);
+
+    expect(workTimeBroadcastChannels($workTime, 'updated'))
+        ->not->toContain('private-user.' . $other->getKey());
+});
+
+test('work time without a user is not broadcast on a user channel', function (): void {
+    $workTime = WorkTime::factory()->make(['user_id' => null]);
+
+    expect(workTimeBroadcastChannels($workTime, 'updated'))
+        ->each->not->toStartWith('private-user.');
+});


### PR DESCRIPTION
When a user changes a work time, the change now also broadcasts on that **user's** private channel, so their own other sessions (e.g. the Nuxbe Desktop client and an open web app) refresh live. Other users are unaffected.

## Details
- `WorkTime::broadcastOn()` adds a `PrivateChannel` for the owning user (`user.{user_id}`) alongside the existing model channels.
- The `WorkTime` Livewire component reloads its daily work time / pause on the `WorkTimeCreated`/`WorkTimeUpdated`/`WorkTimeDeleted` events on the current user's channel. Its load logic is extracted into `loadWorkTimes()` and now resets the forms before filling, so an ended day clears correctly.

## Tests
- A work time broadcasts on the owning user channel.
- It does not broadcast on another user's channel.
- A work time without a user is not broadcast on a user channel.

## Summary by Sourcery

Broadcast work time changes on the owning user’s private channel and update the Livewire WorkTime component to reload daily work times and pauses in response to these events.

New Features:
- Broadcast work time model events on the owning user’s private channel so the user’s other sessions stay in sync.

Bug Fixes:
- Reset and reload daily work time and pause forms when work times are refreshed so ended days clear correctly.

Enhancements:
- Refactor the Livewire WorkTime component to extract work time loading into a reusable loadWorkTimes() method.
- Extend WorkTime model broadcasting to include user-specific private channels when a user_id is present.

Tests:
- Add unit tests verifying work time events broadcast only on the owning user’s channel and not on other or null-user channels.