### PR TITLE
feat: per-sub-menu unread notification indicator

### DIFF
--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -121,7 +121,7 @@
                                             <span class="truncate">
                                                 {{ __($child["label"]) }}
                                             </span>
-                                            @if ($childNotificationCount = data_get($childNotificationCounts, data_get($child, "route_name")))
+                                            @if ($childNotificationCount = data_get($childNotificationCounts, data_get($child, 'route_name')))
                                                 <span
                                                     class="ml-auto flex h-4 min-w-4 flex-none items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-none font-semibold text-white"
                                                 >

--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -116,9 +116,18 @@
                                                 wire:current="rounded-md bg-indigo-600/50 dark:bg-indigo-700/5 hover:bg-indigo-600/10"
                                             @endif
                                             href="{{ $child["uri"] }}"
-                                            class="dark:hover:text-light block truncate rounded-md p-2 pl-20 text-sm transition-colors duration-200 hover:bg-gray-800/50"
+                                            class="dark:hover:text-light flex items-center gap-2 rounded-md p-2 pr-3 pl-20 text-sm transition-colors duration-200 hover:bg-gray-800/50"
                                         >
-                                            {{ __($child["label"]) }}
+                                            <span class="truncate">
+                                                {{ __($child["label"]) }}
+                                            </span>
+                                            @if ($childNotificationCount = data_get($childNotificationCounts, data_get($child, "route_name")))
+                                                <span
+                                                    class="ml-auto flex h-4 min-w-4 flex-none items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-none font-semibold text-white"
+                                                >
+                                                    {{ $childNotificationCount }}
+                                                </span>
+                                            @endif
                                         </a>
                                     @endforeach
                                 </div>

--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -24,11 +24,14 @@ class Navigation extends Component
 
     public function render(): View|Factory|Application
     {
+        $navigations = $this->getMenu();
+
         return view('flux::livewire.navigation', [
-            'navigations' => $this->getMenu(),
+            'navigations' => $navigations,
             'visits' => $this->getVisits(),
             'favorites' => $this->getFavorites(),
             'notificationCounts' => $this->getNotificationCounts(),
+            'childNotificationCounts' => $this->getChildNotificationCounts($navigations),
         ]);
     }
 
@@ -105,6 +108,58 @@ class Navigation extends Component
             ->countBy(fn (Notification $notification): ?string => $notification->menuArea())
             ->forget('')
             ->all();
+    }
+
+    protected function getChildNotificationCounts(Collection $navigations): array
+    {
+        $user = auth()->user();
+
+        if (! method_exists($user, 'unreadNotifications')) {
+            return [];
+        }
+
+        $childRouteNames = $navigations
+            ->flatMap(fn (array $navigation): array => data_get($navigation, 'children', []))
+            ->pluck('route_name')
+            ->filter()
+            ->all();
+
+        if (blank($childRouteNames)) {
+            return [];
+        }
+
+        $counts = [];
+
+        foreach ($user->unreadNotifications as $notification) {
+            $route = $notification->menuRoute();
+
+            if (blank($route)) {
+                continue;
+            }
+
+            if ($match = $this->matchClosestRoute($route, $childRouteNames)) {
+                $counts[$match] = ($counts[$match] ?? 0) + 1;
+            }
+        }
+
+        return $counts;
+    }
+
+    protected function matchClosestRoute(string $route, array $routeNames): ?string
+    {
+        $match = null;
+
+        foreach ($routeNames as $routeName) {
+            if ($route !== $routeName && ! str_starts_with($route, $routeName . '.')) {
+                continue;
+            }
+
+            if (is_null($match) || strlen($routeName) > strlen($match)) {
+                $match = $routeName;
+            }
+        }
+
+        return $match;
     }
 
     protected function getFavorites(): ?array

--- a/src/Livewire/Navigation.php
+++ b/src/Livewire/Navigation.php
@@ -119,7 +119,7 @@ class Navigation extends Component
         }
 
         $childRouteNames = $navigations
-            ->flatMap(fn (array $navigation): array => data_get($navigation, 'children', []))
+            ->flatMap(fn (array $navigation): array => data_get($navigation, 'children') ?? [])
             ->pluck('route_name')
             ->filter()
             ->all();
@@ -154,7 +154,9 @@ class Navigation extends Component
                 continue;
             }
 
-            if (is_null($match) || strlen($routeName) > strlen($match)) {
+            // Among the matching ancestors the deepest one (most route segments)
+            // is the most specific menu entry the notification belongs to.
+            if (is_null($match) || substr_count($routeName, '.') > substr_count($match, '.')) {
                 $match = $routeName;
             }
         }

--- a/src/Models/Notification.php
+++ b/src/Models/Notification.php
@@ -18,11 +18,16 @@ class Notification extends DatabaseNotification
     // Public methods
     public function menuArea(): ?string
     {
+        return Str::before($this->menuRoute() ?? '', '.') ?: null;
+    }
+
+    public function menuRoute(): ?string
+    {
         if (data_get($this->data, 'menu_indicator') === false) {
             return null;
         }
 
-        return Str::before(data_get($this->data, 'accept.route') ?? '', '.') ?: null;
+        return data_get($this->data, 'accept.route') ?: null;
     }
 
     public function prunable(): Builder

--- a/tests/Livewire/NavigationTest.php
+++ b/tests/Livewire/NavigationTest.php
@@ -32,6 +32,28 @@ test('passes unread notification counts per menu area to the view', function ():
         ->assertViewHas('notificationCounts', fn (array $counts): bool => ($counts['tickets'] ?? 0) === 1);
 });
 
+test('passes unread notification counts per sub menu route to the view', function (): void {
+    createNavigationNotification('accounting.payment-reminders');
+
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertViewHas(
+            'childNotificationCounts',
+            fn (array $counts): bool => ($counts['accounting.payment-reminders'] ?? 0) === 1
+        );
+});
+
+test('counts a sub menu detail notification on its closest sub menu route', function (): void {
+    createNavigationNotification('accounting.payment-reminders.show');
+
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertViewHas(
+            'childNotificationCounts',
+            fn (array $counts): bool => ($counts['accounting.payment-reminders'] ?? 0) === 1
+        );
+});
+
 test('shows order types', function (): void {
     $orderTypes = OrderType::factory(5)
         ->create([

--- a/tests/Unit/Models/NotificationMenuAreaTest.php
+++ b/tests/Unit/Models/NotificationMenuAreaTest.php
@@ -22,3 +22,16 @@ test('has no menu area without a route', function (): void {
 test('has no menu area when opting out of the menu indicator', function (): void {
     expect(notificationWith(['menu_indicator' => false, 'accept' => ['route' => 'tickets']])->menuArea())->toBeNull();
 });
+
+test('exposes the full route as the menu route', function (): void {
+    expect(notificationWith(['accept' => ['route' => 'accounting.payment-reminders']])->menuRoute())
+        ->toBe('accounting.payment-reminders');
+});
+
+test('has no menu route without a route', function (): void {
+    expect(notificationWith(['accept' => ['url' => 'https://example.com']])->menuRoute())->toBeNull();
+});
+
+test('has no menu route when opting out of the menu indicator', function (): void {
+    expect(notificationWith(['menu_indicator' => false, 'accept' => ['route' => 'tickets']])->menuRoute())->toBeNull();
+});


### PR DESCRIPTION
Notification badges previously only showed on the top-level menu area, so a notification coming from a sub menu item was hard to attribute. This adds a badge on the matching sub menu entry too.

- `Notification::menuRoute()` exposes the full stored route; `menuArea()` derives from it.
- `Navigation` builds per-child counts by matching each unread notification to the deepest sub menu `route_name` that prefixes its route (handles detail routes).
- The sub menu list renders the per-entry count badge.
- The top-level area badge stays as the aggregate for the whole area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add per-sub-menu unread notification counts and expose full notification menu routes for more granular badge display.

New Features:
- Show unread notification badges on individual sub menu entries based on their associated routes.

Enhancements:
- Expose the full notification route via a new menuRoute accessor and derive menuArea from it.
- Aggregate unread notifications to the closest matching sub menu route, including detail routes, and pass these counts to the navigation view.

Tests:
- Add tests covering per-sub-menu notification counts, closest-route matching for detail routes, and the new menuRoute behavior.