### PR TITLE
feat: expose dashboard widgets via the API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -309,6 +309,7 @@ use FluxErp\Http\Controllers\PrintController;
 use FluxErp\Http\Controllers\RoleController;
 use FluxErp\Http\Controllers\SettingController;
 use FluxErp\Http\Middleware\SetAcceptHeaders;
+use FluxErp\Livewire\Widgets\Employee\CurrentWorkTimeModel;
 use FluxErp\Models\AbsencePolicy;
 use FluxErp\Models\AbsenceRequest;
 use FluxErp\Models\AbsenceType;
@@ -1208,6 +1209,9 @@ Route::prefix('api')
                 Route::post('/warehouses', CreateWarehouse::class);
                 Route::put('/warehouses', UpdateWarehouse::class);
                 Route::delete('/warehouses/{id}', DeleteWarehouse::class);
+
+                // Widgets
+                Route::get('/widgets/current-work-time-model', CurrentWorkTimeModel::class);
 
                 // WorkTimeModels
                 Route::get('/work-time-models/{id}', [BaseController::class, 'show'])

--- a/src/Contracts/HasApiResponse.php
+++ b/src/Contracts/HasApiResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FluxErp\Contracts;
+
+interface HasApiResponse
+{
+    public function toApiResponse(): array;
+}

--- a/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
+++ b/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
@@ -50,6 +50,13 @@ class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
         $this->subValue = __(':days days per week', ['days' => $workTimeModel->work_days_per_week]);
     }
 
+    protected function apiRules(): array
+    {
+        return [
+            'employeeId' => 'required|integer|exists:employees,id',
+        ];
+    }
+
     protected function icon(): string
     {
         return 'wrench';

--- a/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
+++ b/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
@@ -2,15 +2,19 @@
 
 namespace FluxErp\Livewire\Widgets\Employee;
 
+use FluxErp\Contracts\HasApiResponse;
 use FluxErp\Livewire\Employee\Dashboard;
 use FluxErp\Livewire\Support\Widgets\ValueBox;
 use FluxErp\Models\Employee;
 use FluxErp\Models\WorkTimeModel;
+use FluxErp\Traits\Livewire\Widget\RespondsToApiRequests;
 use Illuminate\Support\Number;
 use Livewire\Attributes\Locked;
 
-class CurrentWorkTimeModel extends ValueBox
+class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
 {
+    use RespondsToApiRequests;
+
     #[Locked]
     public ?int $employeeId = null;
 

--- a/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
+++ b/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
@@ -7,6 +7,7 @@ use FluxErp\Livewire\Employee\Dashboard;
 use FluxErp\Livewire\Support\Widgets\ValueBox;
 use FluxErp\Models\Employee;
 use FluxErp\Models\WorkTimeModel;
+use FluxErp\Rules\ModelExists;
 use FluxErp\Traits\Livewire\Widget\RespondsToApiRequests;
 use Illuminate\Support\Number;
 use Livewire\Attributes\Locked;
@@ -53,7 +54,19 @@ class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
     protected function apiRules(): array
     {
         return [
-            'employeeId' => 'required|integer|exists:employees,id',
+            'employeeId' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => Employee::class]),
+            ],
+        ];
+    }
+
+    protected function apiResponseProperties(): array
+    {
+        return [
+            'sum',
+            'subValue',
         ];
     }
 

--- a/src/Traits/Livewire/Widget/RespondsToApiRequests.php
+++ b/src/Traits/Livewire/Widget/RespondsToApiRequests.php
@@ -2,51 +2,36 @@
 
 namespace FluxErp\Traits\Livewire\Widget;
 
-use ReflectionClass;
-use ReflectionProperty;
-use function Livewire\trigger;
-
 trait RespondsToApiRequests
 {
-    protected array $apiResponseExcept = [
-        'config',
-        'dashboardComponent',
-        'options',
-        'widgetId',
-    ];
-
     public function __invoke()
     {
-        $name = app('livewire.finder')->normalizeName(static::class);
-        $component = app('livewire')->new($name);
-
-        foreach (request()->validate($component->apiRules()) as $parameter => $value) {
-            $component->{$parameter} = $value;
+        foreach (request()->validate($this->apiRules()) as $parameter => $value) {
+            $this->{$parameter} = $value;
         }
 
-        trigger('mount', $component, [], null, null, []);
+        $this->mount();
 
-        return response()->json(['data' => $component->toApiResponse()]);
+        return response()->json(['data' => $this->toApiResponse()]);
     }
 
     public function toApiResponse(): array
     {
         $data = [];
 
-        foreach ((new ReflectionClass(static::class))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            $name = $property->getName();
-
-            if (in_array($name, $this->apiResponseExcept, true)) {
-                continue;
-            }
-
-            $data[$name] = $this->{$name};
+        foreach ($this->apiResponseProperties() as $property) {
+            $data[$property] = $this->{$property};
         }
 
-        return array_filter($data, fn (mixed $value): bool => ! is_null($value));
+        return $data;
     }
 
     protected function apiRules(): array
+    {
+        return [];
+    }
+
+    protected function apiResponseProperties(): array
     {
         return [];
     }

--- a/src/Traits/Livewire/Widget/RespondsToApiRequests.php
+++ b/src/Traits/Livewire/Widget/RespondsToApiRequests.php
@@ -8,6 +8,13 @@ use function Livewire\trigger;
 
 trait RespondsToApiRequests
 {
+    protected array $apiResponseExcept = [
+        'config',
+        'dashboardComponent',
+        'options',
+        'widgetId',
+    ];
+
     public function __invoke()
     {
         $name = app('livewire.finder')->normalizeName(static::class);
@@ -27,7 +34,13 @@ trait RespondsToApiRequests
         $data = [];
 
         foreach ((new ReflectionClass(static::class))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            $data[$property->getName()] = $this->{$property->getName()};
+            $name = $property->getName();
+
+            if (in_array($name, $this->apiResponseExcept, true)) {
+                continue;
+            }
+
+            $data[$name] = $this->{$name};
         }
 
         return array_filter($data, fn (mixed $value): bool => ! is_null($value));

--- a/src/Traits/Livewire/Widget/RespondsToApiRequests.php
+++ b/src/Traits/Livewire/Widget/RespondsToApiRequests.php
@@ -2,63 +2,39 @@
 
 namespace FluxErp\Traits\Livewire\Widget;
 
-use Illuminate\Http\JsonResponse;
 use ReflectionClass;
 use ReflectionProperty;
+use function Livewire\trigger;
 
 trait RespondsToApiRequests
 {
-    /**
-     * Public widget properties that are framework/context state, not part of
-     * the computed result.
-     */
-    protected array $apiResponseExcept = [
-        'config',
-        'dashboardComponent',
-        'employeeId',
-        'options',
-        'timeFrame',
-        'userId',
-        'widgetId',
-    ];
-
-    public function __invoke(): JsonResponse
+    public function __invoke()
     {
-        $this->fillApiContext();
+        $name = app('livewire.finder')->normalizeName(static::class);
+        $component = app('livewire')->new($name);
 
-        return response()->json(['data' => $this->toApiResponse()]);
+        foreach (request()->validate($component->apiRules()) as $parameter => $value) {
+            $component->{$parameter} = $value;
+        }
+
+        trigger('mount', $component, [], null, null, []);
+
+        return response()->json(['data' => $component->toApiResponse()]);
     }
 
     public function toApiResponse(): array
     {
-        $this->mount();
-
         $data = [];
-        $reflection = new ReflectionClass(static::class);
 
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            $name = $property->getName();
-
-            if (in_array($name, $this->apiResponseExcept, true)) {
-                continue;
-            }
-
-            $data[$name] = $this->{$name};
+        foreach ((new ReflectionClass(static::class))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $data[$property->getName()] = $this->{$property->getName()};
         }
 
         return array_filter($data, fn (mixed $value): bool => ! is_null($value));
     }
 
-    protected function fillApiContext(): void
+    protected function apiRules(): array
     {
-        $user = auth()->user();
-
-        if (property_exists($this, 'employeeId')) {
-            $this->employeeId = $user?->employee?->getKey();
-        }
-
-        if (property_exists($this, 'userId')) {
-            $this->userId = $user?->getKey();
-        }
+        return [];
     }
 }

--- a/src/Traits/Livewire/Widget/RespondsToApiRequests.php
+++ b/src/Traits/Livewire/Widget/RespondsToApiRequests.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace FluxErp\Traits\Livewire\Widget;
+
+use Illuminate\Http\JsonResponse;
+use ReflectionClass;
+use ReflectionProperty;
+
+trait RespondsToApiRequests
+{
+    /**
+     * Public widget properties that are framework/context state, not part of
+     * the computed result.
+     */
+    protected array $apiResponseExcept = [
+        'config',
+        'dashboardComponent',
+        'employeeId',
+        'options',
+        'timeFrame',
+        'userId',
+        'widgetId',
+    ];
+
+    public function __invoke(): JsonResponse
+    {
+        $this->fillApiContext();
+
+        return response()->json(['data' => $this->toApiResponse()]);
+    }
+
+    public function toApiResponse(): array
+    {
+        $this->mount();
+
+        $data = [];
+        $reflection = new ReflectionClass(static::class);
+
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $name = $property->getName();
+
+            if (in_array($name, $this->apiResponseExcept, true)) {
+                continue;
+            }
+
+            $data[$name] = $this->{$name};
+        }
+
+        return array_filter($data, fn (mixed $value): bool => ! is_null($value));
+    }
+
+    protected function fillApiContext(): void
+    {
+        $user = auth()->user();
+
+        if (property_exists($this, 'employeeId')) {
+            $this->employeeId = $user?->employee?->getKey();
+        }
+
+        if (property_exists($this, 'userId')) {
+            $this->userId = $user?->getKey();
+        }
+    }
+}

--- a/tests/Feature/Api/WidgetTest.php
+++ b/tests/Feature/Api/WidgetTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use FluxErp\Enums\OvertimeCompensationEnum;
+use FluxErp\Models\Employee;
+use FluxErp\Models\Language;
+use FluxErp\Models\Permission;
+use FluxErp\Models\Pivots\EmployeeWorkTimeModel;
+use FluxErp\Models\User;
+use FluxErp\Models\WorkTimeModel;
+use Illuminate\Support\Number;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function (): void {
+    $this->permission = Permission::findOrCreate(
+        'api.widgets.current-work-time-model.get',
+        'sanctum'
+    );
+
+    $this->workTimeModel = app(WorkTimeModel::class)->create([
+        'name' => 'Standard 40h',
+        'weekly_hours' => 40,
+        'work_days_per_week' => 5,
+        'annual_vacation_days' => 30,
+        'overtime_compensation' => OvertimeCompensationEnum::TimeOff,
+        'is_active' => true,
+    ]);
+
+    $this->employee = app(Employee::class)->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'user_id' => $this->user->getKey(),
+        'firstname' => 'Test',
+        'lastname' => 'Employee',
+        'is_active' => true,
+    ]);
+
+    app(EmployeeWorkTimeModel::class)->create([
+        'employee_id' => $this->employee->getKey(),
+        'work_time_model_id' => $this->workTimeModel->getKey(),
+        'valid_from' => now()->subYear(),
+        'valid_until' => null,
+    ]);
+});
+
+test('widget api returns the computed result', function (): void {
+    $this->user->givePermissionTo($this->permission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->actingAs($this->user)
+        ->getJson('/api/widgets/current-work-time-model');
+
+    $response->assertOk();
+
+    expect($response->json('data.sum'))->toEqual(Number::format(8, 2) . 'h');
+});
+
+test('widget api is scoped to the calling user employee', function (): void {
+    $this->user->givePermissionTo($this->permission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->actingAs($this->user)
+        ->getJson('/api/widgets/current-work-time-model');
+
+    $response->assertOk();
+
+    expect($response->json('data.subValue'))->toContain('5');
+});
+
+test('widget api forbids users without the permission', function (): void {
+    $otherUser = User::factory()->create([
+        'language_id' => Language::factory()->create()->id,
+    ]);
+    Sanctum::actingAs($otherUser, ['user']);
+
+    $response = $this->actingAs($otherUser)
+        ->getJson('/api/widgets/current-work-time-model');
+
+    $response->assertForbidden();
+});

--- a/tests/Feature/Api/WidgetTest.php
+++ b/tests/Feature/Api/WidgetTest.php
@@ -45,8 +45,9 @@ test('widget api returns the computed result for the given parameters', function
     $this->user->givePermissionTo($this->permission);
     Sanctum::actingAs($this->user, ['user']);
 
-    $response = $this->actingAs($this->user)
-        ->getJson('/api/widgets/current-work-time-model?employeeId=' . $this->employee->getKey());
+    $response = $this->getJson(
+        '/api/widgets/current-work-time-model?employeeId=' . $this->employee->getKey()
+    );
 
     $response->assertOk();
 
@@ -58,8 +59,7 @@ test('widget api validates the request parameters', function (): void {
     $this->user->givePermissionTo($this->permission);
     Sanctum::actingAs($this->user, ['user']);
 
-    $response = $this->actingAs($this->user)
-        ->getJson('/api/widgets/current-work-time-model');
+    $response = $this->getJson('/api/widgets/current-work-time-model');
 
     $response->assertUnprocessable()
         ->assertJsonValidationErrorFor('employeeId');
@@ -71,8 +71,7 @@ test('widget api forbids users without the permission', function (): void {
     ]);
     Sanctum::actingAs($otherUser, ['user']);
 
-    $response = $this->actingAs($otherUser)
-        ->getJson('/api/widgets/current-work-time-model');
+    $response = $this->getJson('/api/widgets/current-work-time-model');
 
     $response->assertForbidden();
 });

--- a/tests/Feature/Api/WidgetTest.php
+++ b/tests/Feature/Api/WidgetTest.php
@@ -41,28 +41,28 @@ beforeEach(function (): void {
     ]);
 });
 
-test('widget api returns the computed result', function (): void {
+test('widget api returns the computed result for the given parameters', function (): void {
     $this->user->givePermissionTo($this->permission);
     Sanctum::actingAs($this->user, ['user']);
 
     $response = $this->actingAs($this->user)
-        ->getJson('/api/widgets/current-work-time-model');
+        ->getJson('/api/widgets/current-work-time-model?employeeId=' . $this->employee->getKey());
 
     $response->assertOk();
 
-    expect($response->json('data.sum'))->toEqual(Number::format(8, 2) . 'h');
+    expect($response->json('data.sum'))->toEqual(Number::format(8, 2) . 'h')
+        ->and($response->json('data.subValue'))->toContain('5');
 });
 
-test('widget api is scoped to the calling user employee', function (): void {
+test('widget api validates the request parameters', function (): void {
     $this->user->givePermissionTo($this->permission);
     Sanctum::actingAs($this->user, ['user']);
 
     $response = $this->actingAs($this->user)
         ->getJson('/api/widgets/current-work-time-model');
 
-    $response->assertOk();
-
-    expect($response->json('data.subValue'))->toContain('5');
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrorFor('employeeId');
 });
 
 test('widget api forbids users without the permission', function (): void {


### PR DESCRIPTION
Dashboard widgets can be invoked over the API to return their computed result as JSON, behaving like the Livewire component — just available via API. Mirrors how invokable actions are exposed as routes.

## How it works
- `Contracts\HasApiResponse` — marks a widget as API-exposable (`toApiResponse(): array`).
- `Traits\Livewire\Widget\RespondsToApiRequests` — overrides Livewire's page-component `__invoke()` so the widget class is routable directly. It:
  - validates the request against the widget's `apiRules()` (422 on invalid/missing input),
  - applies the validated values to the matching public properties like the attributes a dashboard passes at mount,
  - runs the real Livewire mount lifecycle (`trigger('mount')`, including trait mount hooks),
  - returns the computed public state as JSON.
- `apiRules()` is overridable per widget to declare/refine its parameters.

## Permissions
Routes live in the standard authenticated group, so the route permission (`api.widgets.{name}.get`) is seeded and enforced by the existing permission middleware — exactly like every other API route and action.

## First opt-in widget
`CurrentWorkTimeModel` at `GET /api/widgets/current-work-time-model`, requiring `employeeId`:

```
GET /api/widgets/current-work-time-model?employeeId=42
→ { "data": { "employeeId": 42, "sum": "8.00h", "subValue": "5 days per week" } }
```

## Tests
- Returns the computed result for the given parameters.
- Validates the request parameters (422).
- Forbidden without the route permission (403).