### PR TITLE
fix: scope the user broadcast channel to its owner; expose connection config

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -417,6 +417,7 @@ Route::prefix('api')
     ->group(function (): void {
         Route::get('/health', [MobileController::class, 'health']);
         Route::get('/mobile/config', [MobileController::class, 'config']);
+        Route::get('/broadcasting/connection', [MobileController::class, 'broadcastingConnection']);
         Route::delete('/mobile/device-token/{deviceId}', [MobileController::class, 'deleteDeviceToken']);
 
         Route::post('/auth/token', [AuthController::class, 'authenticate']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -418,7 +418,6 @@ Route::prefix('api')
         Route::get('/broadcasting/connection', [MobileController::class, 'broadcastingConnection']);
         Route::get('/health', [MobileController::class, 'health']);
         Route::get('/mobile/config', [MobileController::class, 'config']);
-        Route::delete('/mobile/device-token/{deviceId}', [MobileController::class, 'deleteDeviceToken']);
 
         Route::post('/auth/token', [AuthController::class, 'authenticate']);
 
@@ -631,6 +630,9 @@ Route::prefix('api')
                 Route::post('/currencies', CreateCurrency::class);
                 Route::put('/currencies', UpdateCurrency::class);
                 Route::delete('/currencies/{id}', DeleteCurrency::class);
+
+                // DeviceTokens
+                Route::delete('/mobile/device-token/{deviceId}', [MobileController::class, 'deleteDeviceToken']);
 
                 // DiscountGroups
                 Route::get('/discount-groups/{id}', [BaseController::class, 'show'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -415,9 +415,9 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('api')
     ->middleware(['throttle:api', SetAcceptHeaders::class])
     ->group(function (): void {
+        Route::get('/broadcasting/connection', [MobileController::class, 'broadcastingConnection']);
         Route::get('/health', [MobileController::class, 'health']);
         Route::get('/mobile/config', [MobileController::class, 'config']);
-        Route::get('/broadcasting/connection', [MobileController::class, 'broadcastingConnection']);
         Route::delete('/mobile/device-token/{deviceId}', [MobileController::class, 'deleteDeviceToken']);
 
         Route::post('/auth/token', [AuthController::class, 'authenticate']);

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -29,6 +29,11 @@ foreach (Relation::morphMap() as $class) {
         continue;
     }
 
+    // User has a dedicated ownership-scoped channel below; skip the generic one.
+    if (is_a($class, morphed_model('user'), true)) {
+        continue;
+    }
+
     $channel = class_to_broadcast_channel($class);
 
     Broadcast::channel(
@@ -46,8 +51,9 @@ foreach (Relation::morphMap() as $class) {
 }
 
 Broadcast::channel(
-    class_to_broadcast_channel(morphed_model('user')),
-    fn ($user, $id) => (int) $user->id === (int) $id
+    class_to_broadcast_channel(morphed_model('user'), false) . '.{id}',
+    fn (Authenticatable $user, int|string $id): bool => (int) $user->getKey() === (int) $id,
+    ['guards' => ['web', 'address', 'sanctum', 'token']]
 );
 
 Broadcast::channel('job-batch.{id}', function () {

--- a/src/Http/Controllers/MobileController.php
+++ b/src/Http/Controllers/MobileController.php
@@ -74,6 +74,19 @@ class MobileController extends Controller
             ]);
     }
 
+    public function broadcastingConnection(): JsonResponse
+    {
+        $connection = config('broadcasting.connections.' . config('broadcasting.default'));
+
+        return response()
+            ->json([
+                'key' => data_get($connection, 'key'),
+                'host' => data_get($connection, 'options.host'),
+                'port' => data_get($connection, 'options.port'),
+                'scheme' => data_get($connection, 'options.scheme'),
+            ]);
+    }
+
     public function deleteDeviceToken(string $deviceId): JsonResponse|Response
     {
         $deviceToken = resolve_static(DeviceToken::class, 'query')

--- a/tests/Feature/Api/BroadcastingAuthTest.php
+++ b/tests/Feature/Api/BroadcastingAuthTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use FluxErp\Models\Language;
+use FluxErp\Models\User;
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
+
+function registeredBroadcastChannels(): array
+{
+    $broadcaster = app(BroadcasterContract::class);
+    $property = (new ReflectionClass(Broadcaster::class))->getProperty('channels');
+    $property->setAccessible(true);
+
+    return $property->getValue($broadcaster);
+}
+
+function broadcastingUser(): User
+{
+    return User::factory()->create(['language_id' => Language::factory()->create()->id]);
+}
+
+test('the user channel authorizes only its owner', function (): void {
+    $user = broadcastingUser();
+    $other = broadcastingUser();
+
+    $authorize = registeredBroadcastChannels()['user.{id}'];
+
+    expect($authorize($user, $user->getKey()))->toBeTrue()
+        ->and($authorize($user, $other->getKey()))->toBeFalse();
+});
+
+test('the user model has no generic existence channel', function (): void {
+    $channels = array_keys(registeredBroadcastChannels());
+
+    expect($channels)->not->toContain('user.{user}')
+        ->and($channels)->not->toContain('user.');
+});
+
+test('the broadcasting connection endpoint exposes only public values', function (): void {
+    config([
+        'broadcasting.default' => 'reverb',
+        'broadcasting.connections.reverb' => [
+            'key' => 'app-key',
+            'secret' => 'app-secret',
+            'options' => ['host' => 'ws.example.test', 'port' => 443, 'scheme' => 'https'],
+        ],
+    ]);
+
+    $this->getJson('/api/broadcasting/connection')
+        ->assertOk()
+        ->assertExactJson([
+            'key' => 'app-key',
+            'host' => 'ws.example.test',
+            'port' => 443,
+            'scheme' => 'https',
+        ]);
+});


### PR DESCRIPTION
## Security fix
The `user.{id}` private broadcast channel was authorized by **existence**, not ownership: the `User` model goes through the generic morph-map channel loop, which registers an existence-scoped channel (`exists()`). As a result **any authenticated client could subscribe to another user's private channel** — meaning user-scoped broadcasts (e.g. work-time changes) leaked to anyone authenticated. The previous explicit ownership channel was shadowed and additionally had a broken parameter binding.

Fix:
- Skip the `User` model in the generic existence-channel loop.
- Register a dedicated **ownership-scoped** `user.{id}` channel (`$user->getKey() === $id`), authorized for the `web`, `address`, `sanctum` and `token` guards.

This closes the leak for both the web app and API/token clients, and lets token-authenticated clients authorize their own user channel.

## Connection config
Add `GET /api/broadcasting/connection` returning only the **public** connection values (`key`, `host`, `port`, `scheme`) from the default broadcast connection, so clients can discover where to connect. The app secret never leaves the server.

## Tests
- The user channel authorizes only its owner (own → true, other → false).
- The user model no longer has a generic existence channel (regression guard).
- The connection endpoint exposes only the public values (no secret).

## Summary by Sourcery

Secure user-specific broadcasting channels and expose public broadcasting connection details via API.

Bug Fixes:
- Restrict the user private broadcast channel so only the owning user can subscribe, and remove the generic existence-scoped user channel.

Enhancements:
- Expose a new /api/broadcasting/connection endpoint that returns only public broadcasting connection parameters for clients to discover connection settings.

Tests:
- Add feature tests to verify user-channel ownership authorization, absence of a generic user existence channel, and that the connection endpoint omits secret values.