### PR TITLE
feat: user login-url endpoint and weekly target on the work time widget

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1174,6 +1174,8 @@ Route::prefix('api')
 
                     return ResponseHelper::createResponseFromBase(statusCode: 200, data: $user);
                 });
+                Route::post('/user/login-url', [AuthController::class, 'loginUrl'])
+                    ->middleware('ability:user');
 
                 Route::get('/users/{id}', [BaseController::class, 'show'])->defaults('model', User::class);
                 Route::get('/users', [BaseController::class, 'index'])->defaults('model', User::class);

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -75,6 +75,14 @@ class AuthController extends Controller
         ])->onlyInput('email');
     }
 
+    public function loginUrl(Request $request): JsonResponse
+    {
+        return ResponseHelper::createResponseFromBase(
+            statusCode: 200,
+            data: ['url' => $request->user()->generateLoginLink()],
+        );
+    }
+
     public function logout(Request $request): JsonResponse
     {
         $request->user()->tokens()->delete();
@@ -88,13 +96,5 @@ class AuthController extends Controller
     public function validateToken(): JsonResponse
     {
         return response()->json(['status' => 'token valid']);
-    }
-
-    public function loginUrl(Request $request): JsonResponse
-    {
-        return ResponseHelper::createResponseFromBase(
-            statusCode: 200,
-            data: ['url' => $request->user()->generateLoginLink()],
-        );
     }
 }

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -89,4 +89,12 @@ class AuthController extends Controller
     {
         return response()->json(['status' => 'token valid']);
     }
+
+    public function loginUrl(Request $request): JsonResponse
+    {
+        return ResponseHelper::createResponseFromBase(
+            statusCode: 200,
+            data: ['url' => $request->user()->generateLoginLink()],
+        );
+    }
 }

--- a/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
+++ b/src/Livewire/Widgets/Employee/CurrentWorkTimeModel.php
@@ -19,6 +19,8 @@ class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
     #[Locked]
     public ?int $employeeId = null;
 
+    public ?float $weeklyTarget = null;
+
     public static function getCategory(): ?string
     {
         return 'Employees';
@@ -49,6 +51,7 @@ class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
 
         $this->sum = Number::format($workTimeModel->getDailyWorkHours(), 2) . 'h';
         $this->subValue = __(':days days per week', ['days' => $workTimeModel->work_days_per_week]);
+        $this->weeklyTarget = (float) $workTimeModel->weekly_hours;
     }
 
     protected function apiRules(): array
@@ -67,6 +70,7 @@ class CurrentWorkTimeModel extends ValueBox implements HasApiResponse
         return [
             'sum',
             'subValue',
+            'weeklyTarget',
         ];
     }
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -278,16 +278,7 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
         Mail::to($this->email)->queue(MagicLoginLink::make($this->generateLoginLink()));
     }
 
-    // Attributes
-    protected function password(): Attribute
-    {
-        return Attribute::set(
-            fn ($value) => Hash::info($value)['algoName'] !== 'bcrypt' ? Hash::make($value) : $value,
-        );
-    }
-
-    // Protected methods
-    protected function generateLoginLink(): string
+    public function generateLoginLink(): string
     {
         $plaintextToken = Str::uuid()->toString();
         $expires = now()->addMinutes(15);
@@ -307,6 +298,14 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
             [
                 'token' => $plaintextToken,
             ]
+        );
+    }
+
+    // Attributes
+    protected function password(): Attribute
+    {
+        return Attribute::set(
+            fn ($value) => Hash::info($value)['algoName'] !== 'bcrypt' ? Hash::make($value) : $value,
         );
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -226,6 +226,29 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
             ->first();
     }
 
+    public function generateLoginLink(): string
+    {
+        $plaintextToken = Str::uuid()->toString();
+        $expires = now()->addMinutes(15);
+        Cache::put('login_token_' . $plaintextToken,
+            [
+                'user_type' => $this->getMorphClass(),
+                'user_id' => $this->getKey(),
+                'guard' => 'web',
+                'intended_url' => Session::get('url.intended', route('dashboard')),
+            ],
+            $expires
+        );
+
+        return URL::temporarySignedRoute(
+            'login-link',
+            $expires,
+            [
+                'token' => $plaintextToken,
+            ]
+        );
+    }
+
     /**
      * @throws Exception
      */
@@ -276,29 +299,6 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
     public function sendLoginLink(): void
     {
         Mail::to($this->email)->queue(MagicLoginLink::make($this->generateLoginLink()));
-    }
-
-    public function generateLoginLink(): string
-    {
-        $plaintextToken = Str::uuid()->toString();
-        $expires = now()->addMinutes(15);
-        Cache::put('login_token_' . $plaintextToken,
-            [
-                'user_type' => $this->getMorphClass(),
-                'user_id' => $this->getKey(),
-                'guard' => 'web',
-                'intended_url' => Session::get('url.intended', route('dashboard')),
-            ],
-            $expires
-        );
-
-        return URL::temporarySignedRoute(
-            'login-link',
-            $expires,
-            [
-                'token' => $plaintextToken,
-            ]
-        );
     }
 
     // Attributes

--- a/tests/Feature/Api/LoginUrlTest.php
+++ b/tests/Feature/Api/LoginUrlTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use FluxErp\Models\Language;
+use FluxErp\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('the login url endpoint returns a signed magic login url', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->postJson('/api/user/login-url');
+
+    $response->assertOk();
+
+    expect($response->json('data.url'))
+        ->toContain('login-link')
+        ->toContain('signature=');
+});
+
+test('the login url endpoint requires the user ability', function (): void {
+    $user = User::factory()->create(['language_id' => Language::factory()->create()->id]);
+    Sanctum::actingAs($user, ['interface']);
+
+    $this->postJson('/api/user/login-url')->assertForbidden();
+});

--- a/tests/Feature/Api/WidgetTest.php
+++ b/tests/Feature/Api/WidgetTest.php
@@ -52,7 +52,8 @@ test('widget api returns the computed result for the given parameters', function
     $response->assertOk();
 
     expect($response->json('data.sum'))->toEqual(Number::format(8, 2) . 'h')
-        ->and($response->json('data.subValue'))->toContain('5');
+        ->and($response->json('data.subValue'))->toContain('5')
+        ->and($response->json('data.weeklyTarget'))->toEqual(40.0);
 });
 
 test('widget api validates the request parameters', function (): void {


### PR DESCRIPTION
Two additions for the Nuxbe Desktop client.

## Magic login URL
`POST /api/user/login-url` (gated to the `user` ability) returns a short-lived, single-use, signed magic login URL for the authenticated user. A client can open the web UI at that URL to land already authenticated, instead of being prompted to log in again. `User::generateLoginLink()` is made public so the endpoint reuses the existing mechanism (signed temporary route + cached single-use token, 15 min).

The URL is a login credential — it is short-lived, single-use (`Cache::pull`), HTTPS-only, and the desktop client excludes it from logging.

## Weekly target
`CurrentWorkTimeModel` now also exposes `weeklyTarget` (the work time model's weekly hours), so the desktop can show a weekly worked/target card.

## Tests
- The login-url endpoint returns a signed magic login URL.
- It requires the `user` ability (403 otherwise).
- The widget returns `weeklyTarget`.

## Summary by Sourcery

Add an authenticated magic login URL endpoint and expose weekly work-time targets in the employee work time widget.

New Features:
- Expose a POST /api/user/login-url endpoint that returns a short-lived, signed magic login URL for the authenticated user, gated by the user ability.
- Expose weeklyTarget on the CurrentWorkTimeModel widget API to surface weekly work-time targets to clients.

Tests:
- Add feature tests covering the login-url endpoint behavior and authorization requirements.
- Extend widget API tests to assert the presence and value of the weeklyTarget field.