### PR TITLE
fix: return the public reverb connection from the broadcasting endpoint

### DIFF
--- a/src/Http/Controllers/MobileController.php
+++ b/src/Http/Controllers/MobileController.php
@@ -76,14 +76,12 @@ class MobileController extends Controller
 
     public function broadcastingConnection(): JsonResponse
     {
-        $connection = config('broadcasting.connections.' . config('broadcasting.default'));
-
         return response()
             ->json([
-                'key' => data_get($connection, 'key'),
-                'host' => data_get($connection, 'options.host'),
-                'port' => data_get($connection, 'options.port'),
-                'scheme' => data_get($connection, 'options.scheme'),
+                'key' => config('flux.vite.reverb_app_key'),
+                'host' => config('flux.vite.reverb_host'),
+                'port' => (int) config('flux.vite.reverb_port'),
+                'scheme' => config('flux.vite.reverb_protocol'),
             ]);
     }
 

--- a/tests/Feature/Api/BroadcastingAuthTest.php
+++ b/tests/Feature/Api/BroadcastingAuthTest.php
@@ -36,14 +36,12 @@ test('the user model has no generic existence channel', function (): void {
         ->and($channels)->not->toContain('user.');
 });
 
-test('the broadcasting connection endpoint exposes only public values', function (): void {
+test('the broadcasting connection endpoint exposes the public reverb values', function (): void {
     config([
-        'broadcasting.default' => 'reverb',
-        'broadcasting.connections.reverb' => [
-            'key' => 'app-key',
-            'secret' => 'app-secret',
-            'options' => ['host' => 'ws.example.test', 'port' => 443, 'scheme' => 'https'],
-        ],
+        'flux.vite.reverb_app_key' => 'app-key',
+        'flux.vite.reverb_host' => 'ws.example.test',
+        'flux.vite.reverb_port' => 443,
+        'flux.vite.reverb_protocol' => 'https',
     ]);
 
     $this->getJson('/api/broadcasting/connection')


### PR DESCRIPTION
`GET /api/broadcasting/connection` returned the **internal** reverb connection (e.g. `localhost:8081`), which remote clients (desktop app, third parties) can't reach when Reverb runs behind a proxy.

It now returns the **public** client values from `config('flux.vite.*')` (the same values the browser uses): host, port, scheme and the app key. The secret never leaves the server.

## Tests
The connection endpoint exposes the public reverb values (host, port, scheme, key) and no secret.

## Summary by Sourcery

Return public Reverb broadcasting connection details from the mobile broadcasting connection endpoint for use by remote clients.

Bug Fixes:
- Ensure the broadcasting connection endpoint exposes the public Reverb host, port, scheme, and key instead of internal connection settings.

Tests:
- Update the broadcasting connection endpoint test to assert values sourced from the public Reverb (flux.vite) configuration.