### PR TITLE
Keep plain-string tag names with spatie/laravel-tags 4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spatie/laravel-permission": "^8.0",
         "spatie/laravel-query-builder": "^7.0",
         "spatie/laravel-settings": "^3.4",
-        "spatie/laravel-tags": "^4.3",
+        "spatie/laravel-tags": "^4.12",
         "spatie/pdf-to-image": "^3.0",
         "tallstackui/tallstackui": "^3.5",
         "team-nifty-gmbh/tall-datatables": "^2.4.10",

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -2,11 +2,13 @@
 
 namespace FluxErp\Models;
 
+use ArrayAccess;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\ResolvesRelationsThroughContainer;
 use FluxErp\Traits\Scout\Searchable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Spatie\Tags\Tag as BaseTag;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
@@ -23,6 +25,27 @@ class Tag extends BaseTag implements InteractsWithDataTables
         static::saving(function (Tag $model): void {
             $model->slug = Str::slug($model->name);
         });
+    }
+
+    /**
+     * Flux tags are not translatable ({@see static::$translatable} is empty), so names are
+     * plain strings. spatie/laravel-tags >= 4.12 creates tags with a locale-keyed name array
+     * ('name' => [$locale => $value]), which bypasses {@see static::findOrCreateFromString()}
+     * and breaks the slug generation in {@see static::bootHasSlug()} and the plain-string
+     * lookups in {@see static::findFromString()}. Keep the plain-string behaviour.
+     */
+    public static function findOrCreate(
+        string|array|ArrayAccess $values,
+        ?string $type = null,
+        ?string $locale = null,
+    ): BaseCollection|BaseTag|static {
+        $tags = collect($values)->map(
+            fn ($value) => $value instanceof BaseTag
+                ? $value
+                : static::findOrCreateFromString((string) $value, $type, $locale)
+        );
+
+        return is_string($values) ? $tags->first() : $tags;
     }
 
     public static function findFromString(string $name, ?string $type = null, ?string $locale = null): ?static

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -40,7 +40,7 @@ class Tag extends BaseTag implements InteractsWithDataTables
         ?string $locale = null,
     ): BaseCollection|BaseTag|static {
         $tags = collect($values)->map(
-            fn ($value) => $value instanceof BaseTag
+            fn (mixed $value) => $value instanceof BaseTag
                 ? $value
                 : static::findOrCreateFromString((string) $value, $type, $locale)
         );

--- a/tests/Feature/Models/TagTest.php
+++ b/tests/Feature/Models/TagTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use FluxErp\Models\Lead;
+use FluxErp\Models\Tag;
+
+test('findOrCreate stores a plain string name and slug', function (): void {
+    $tag = Tag::findOrCreate('Wichtiger Kunde');
+
+    expect($tag)->toBeInstanceOf(Tag::class)
+        ->and($tag->getRawOriginal('name'))->toBe('Wichtiger Kunde')
+        ->and($tag->slug)->toBe('wichtiger-kunde');
+});
+
+test('findOrCreate reuses an existing tag instead of duplicating it', function (): void {
+    Tag::findOrCreate('Wichtiger Kunde');
+    Tag::findOrCreate('Wichtiger Kunde');
+
+    expect(Tag::query()->where('name', 'Wichtiger Kunde')->count())->toBe(1);
+});
+
+test('findOrCreate resolves a list of names to plain string tags', function (): void {
+    $tags = Tag::findOrCreate(['VIP', 'Lead']);
+
+    expect($tags)->toHaveCount(2)
+        ->and($tags->pluck('name')->all())->toEqualCanonicalizing(['VIP', 'Lead']);
+});
+
+test('attachTag on a model stores a plain string tag name', function (): void {
+    $lead = Lead::factory()->create();
+
+    $lead->attachTag('Wichtiger Kunde');
+
+    expect($lead->tags()->pluck('name')->all())->toBe(['Wichtiger Kunde']);
+});


### PR DESCRIPTION
## Problem

`attachTag()` (and any `Tag::findOrCreate`) throws `Array to string conversion` once spatie/laravel-tags 4.12 is installed.

## Root cause

Flux tags are not translatable (`Tag::$translatable` is empty), so names are stored as plain strings. spatie/laravel-tags 4.12 changed `Tag::findOrCreate` to create tags with a locale-keyed name array (`'name' => [$locale => $value]`), bypassing the plain-string `findOrCreateFromString` path that flux relies on. The array name then breaks:

- slug generation — `Str::slug()` receives an array in `bootHasSlug()`
- the plain-string lookups in `findFromString()` (no tag reuse, duplicate rows)

The `^4.3` constraint already allowed 4.12, so the breakage appears purely from a dependency upgrade.

## Fix

Override `findOrCreate` so values are resolved through `findOrCreateFromString`, keeping plain-string names, and bump the constraint to `^4.12`.

## Tests

`tests/Feature/Models/TagTest.php` covers plain-string storage, slug generation, tag reuse, list input, and `attachTag` on a model.

## Summary by Sourcery

Ensure Flux tag names remain plain strings when using spatie/laravel-tags 4.12 and verify behaviour with new tests.

Bug Fixes:
- Prevent array-based tag names from breaking slug generation and tag lookups after upgrading to spatie/laravel-tags 4.12.

Enhancements:
- Override Tag::findOrCreate to consistently resolve values via plain-string findOrCreateFromString for Flux tags.

Build:
- Bump spatie/laravel-tags dependency constraint from ^4.3 to ^4.12.

Tests:
- Add feature tests covering plain-string tag storage, slug generation, tag reuse, list-based creation, and attachTag behaviour on models.