### PR TITLE
Reload comments when a renderless parent swaps the bound record

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -60,9 +60,6 @@ window.allLocales = allLocales;
 
 navigationSpinner();
 
-// Resolves the live record id for a Modelable component. The bound modelId can go stale when
-// the embedding parent swaps the record while skipping its own render (a renderless modal
-// opener), so read the current value straight from the parent via the wire:model binding.
 const resolveModelId = (el) => () => {
     const root = el.closest('[wire\\:id]');
 
@@ -71,7 +68,10 @@ const resolveModelId = (el) => () => {
     }
 
     const wire = window.Livewire.find(root.getAttribute('wire:id'));
-    const binding = root.getAttribute('wire:model');
+    const bindingAttr = root
+        .getAttributeNames()
+        .find((name) => name.startsWith('wire:model'));
+    const binding = bindingAttr ? root.getAttribute(bindingAttr) : null;
 
     if (binding?.startsWith('$parent.') && wire?.$parent) {
         const value = wire.$parent.get(binding.slice('$parent.'.length));

--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -60,24 +60,45 @@ window.allLocales = allLocales;
 
 navigationSpinner();
 
-if (window.Alpine?.version) {
+// Resolves the live record id for a Modelable component. The bound modelId can go stale when
+// the embedding parent swaps the record while skipping its own render (a renderless modal
+// opener), so read the current value straight from the parent via the wire:model binding.
+const resolveModelId = (el) => () => {
+    const root = el.closest('[wire\\:id]');
+
+    if (!root || !window.Livewire) {
+        return null;
+    }
+
+    const wire = window.Livewire.find(root.getAttribute('wire:id'));
+    const binding = root.getAttribute('wire:model');
+
+    if (binding?.startsWith('$parent.') && wire?.$parent) {
+        const value = wire.$parent.get(binding.slice('$parent.'.length));
+
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+
+    return wire?.get('modelId') ?? null;
+};
+
+const registerFluxAlpine = () => {
     window.Alpine.plugin(sort);
     window.Alpine.plugin(collapse);
     window.Alpine.plugin(nuxbe);
     window.Alpine.directive('template-outlet', templateOutlet);
+    window.Alpine.magic('resolveModelId', resolveModelId);
     window.Alpine.data('folder_tree', folders);
     window.Alpine.data('comments', comments);
     window.Alpine.data('pillbox', pillbox);
+};
+
+if (window.Alpine?.version) {
+    registerFluxAlpine();
 } else {
-    window.addEventListener('alpine:init', () => {
-        window.Alpine.plugin(sort);
-        window.Alpine.plugin(collapse);
-        window.Alpine.plugin(nuxbe);
-        window.Alpine.directive('template-outlet', templateOutlet);
-        window.Alpine.data('folder_tree', folders);
-        window.Alpine.data('comments', comments);
-        window.Alpine.data('pillbox', pillbox);
-    });
+    window.addEventListener('alpine:init', registerFluxAlpine);
 }
 
 document.addEventListener('livewire:navigated', wireNavigation, { once: true });

--- a/resources/js/components/comments.js
+++ b/resources/js/components/comments.js
@@ -4,24 +4,17 @@ export default function comments() {
         stickyComments: [],
         initialized: false,
 
-        loadedModelId: null,
-
         async init() {
             this.loadComments();
 
             this.$wire.$watch('modelId', () => this.loadComments());
 
-            // The modelId is bound from the parent via wire:model (Modelable). When the parent
-            // swaps the bound record while skipping its own render (e.g. a renderless modal
-            // opener), the bound value stays stale and $watch never fires. Reload whenever this
-            // section becomes visible again (tab switch / modal reopen) if the parent's current
-            // value differs from what we last loaded.
             this.commentsObserver = new IntersectionObserver((entries) => {
                 if (
                     entries.some((entry) => entry.isIntersecting) &&
-                    this.$resolveModelId() !== this.loadedModelId
+                    this.$resolveModelId() !== this.$wire.modelId
                 ) {
-                    this.loadComments();
+                    this.$wire.modelId = this.$resolveModelId();
                 }
             });
             this.commentsObserver.observe(this.$root);
@@ -39,12 +32,9 @@ export default function comments() {
         },
 
         loadComments() {
-            const modelId = this.$resolveModelId();
-            this.loadedModelId = modelId;
-
             Promise.all([
-                this.$wire.loadComments(modelId),
-                this.$wire.loadStickyComments(modelId),
+                this.$wire.loadComments(),
+                this.$wire.loadStickyComments(),
             ]).then(([commentsResponse, stickyCommentsResponse]) => {
                 this.comments = commentsResponse.data;
                 this.stickyComments = stickyCommentsResponse;

--- a/resources/js/components/comments.js
+++ b/resources/js/components/comments.js
@@ -17,8 +17,10 @@ export default function comments() {
             // section becomes visible again (tab switch / modal reopen) if the parent's current
             // value differs from what we last loaded.
             this.commentsObserver = new IntersectionObserver((entries) => {
-                if (entries.some((entry) => entry.isIntersecting)
-                    && this.$resolveModelId() !== this.loadedModelId) {
+                if (
+                    entries.some((entry) => entry.isIntersecting) &&
+                    this.$resolveModelId() !== this.loadedModelId
+                ) {
                     this.loadComments();
                 }
             });

--- a/resources/js/components/comments.js
+++ b/resources/js/components/comments.js
@@ -4,10 +4,25 @@ export default function comments() {
         stickyComments: [],
         initialized: false,
 
+        loadedModelId: null,
+
         async init() {
             this.loadComments();
 
             this.$wire.$watch('modelId', () => this.loadComments());
+
+            // The modelId is bound from the parent via wire:model (Modelable). When the parent
+            // swaps the bound record while skipping its own render (e.g. a renderless modal
+            // opener), the bound value stays stale and $watch never fires. Reload whenever this
+            // section becomes visible again (tab switch / modal reopen) if the parent's current
+            // value differs from what we last loaded.
+            this.commentsObserver = new IntersectionObserver((entries) => {
+                if (entries.some((entry) => entry.isIntersecting)
+                    && this.resolveModelId() !== this.loadedModelId) {
+                    this.loadComments();
+                }
+            });
+            this.commentsObserver.observe(this.$root);
 
             if (window.Echo && this.echoChannel) {
                 window.Echo.private(this.echoChannel)
@@ -17,10 +32,36 @@ export default function comments() {
             }
         },
 
+        destroy() {
+            this.commentsObserver?.disconnect();
+        },
+
+        /**
+         * Read the live record id from the parent through the Modelable binding instead of
+         * trusting the possibly-stale local modelId.
+         */
+        resolveModelId() {
+            const root = this.$root.closest('[wire\\:id]');
+            const binding = root?.getAttribute('wire:model');
+
+            if (binding?.startsWith('$parent.') && this.$wire.$parent) {
+                const value = this.$wire.$parent.get(binding.slice('$parent.'.length));
+
+                if (value !== undefined && value !== null) {
+                    return value;
+                }
+            }
+
+            return this.$wire.get('modelId');
+        },
+
         loadComments() {
+            const modelId = this.resolveModelId();
+            this.loadedModelId = modelId;
+
             Promise.all([
-                this.$wire.loadComments(),
-                this.$wire.loadStickyComments(),
+                this.$wire.loadComments(modelId),
+                this.$wire.loadStickyComments(modelId),
             ]).then(([commentsResponse, stickyCommentsResponse]) => {
                 this.comments = commentsResponse.data;
                 this.stickyComments = stickyCommentsResponse;

--- a/resources/js/components/comments.js
+++ b/resources/js/components/comments.js
@@ -18,7 +18,7 @@ export default function comments() {
             // value differs from what we last loaded.
             this.commentsObserver = new IntersectionObserver((entries) => {
                 if (entries.some((entry) => entry.isIntersecting)
-                    && this.resolveModelId() !== this.loadedModelId) {
+                    && this.$resolveModelId() !== this.loadedModelId) {
                     this.loadComments();
                 }
             });
@@ -36,27 +36,8 @@ export default function comments() {
             this.commentsObserver?.disconnect();
         },
 
-        /**
-         * Read the live record id from the parent through the Modelable binding instead of
-         * trusting the possibly-stale local modelId.
-         */
-        resolveModelId() {
-            const root = this.$root.closest('[wire\\:id]');
-            const binding = root?.getAttribute('wire:model');
-
-            if (binding?.startsWith('$parent.') && this.$wire.$parent) {
-                const value = this.$wire.$parent.get(binding.slice('$parent.'.length));
-
-                if (value !== undefined && value !== null) {
-                    return value;
-                }
-            }
-
-            return this.$wire.get('modelId');
-        },
-
         loadComments() {
-            const modelId = this.resolveModelId();
+            const modelId = this.$resolveModelId();
             this.loadedModelId = modelId;
 
             Promise.all([

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -129,7 +129,22 @@
                             this.selection = {}
                             this.setCollection(null)
                         },
+                        destroy() {
+                            this.$el._refreshTreeObserver?.disconnect()
+                        },
                     }"
+                    x-init="
+                        // Self-heal a stale modelId: when the embedding parent swaps the record
+                        // renderlessly, the bound modelId never updates. Reload from the parent's
+                        // live id whenever the tree becomes visible again (tab switch / reopen).
+                        $el._refreshTreeObserver = new IntersectionObserver((entries) => {
+                            if (entries.some((entry) => entry.isIntersecting)
+                                && $resolveModelId() !== $wire.modelId) {
+                                window.dispatchEvent(new CustomEvent('refresh-tree', { detail: { id: $resolveModelId() } }));
+                            }
+                        });
+                        $el._refreshTreeObserver.observe($el);
+                    "
                     x-on:folder-tree-select.window="treeSelect($event.detail)"
                     x-on:refresh-tree.window="
                         $wire.modelId = $event.detail.id;

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -137,12 +137,22 @@
                         // Self-heal a stale modelId: when the embedding parent swaps the record
                         // renderlessly, the bound modelId never updates. Reload from the parent's
                         // live id whenever the tree becomes visible again (tab switch / reopen).
-                        $el._refreshTreeObserver = new IntersectionObserver((entries) => {
-                            if (entries.some((entry) => entry.isIntersecting)
-                                && $resolveModelId() !== $wire.modelId) {
-                                window.dispatchEvent(new CustomEvent('refresh-tree', { detail: { id: $resolveModelId() } }));
-                            }
-                        });
+                        $el._refreshTreeObserver = new IntersectionObserver(
+                            (entries) => {
+                                if (
+                                    entries.some(
+                                        (entry) => entry.isIntersecting,
+                                    ) &&
+                                    $resolveModelId() !== $wire.modelId
+                                ) {
+                                    window.dispatchEvent(
+                                        new CustomEvent('refresh-tree', {
+                                            detail: { id: $resolveModelId() },
+                                        }),
+                                    );
+                                }
+                            },
+                        );
                         $el._refreshTreeObserver.observe($el);
                     "
                     x-on:folder-tree-select.window="treeSelect($event.detail)"

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -134,9 +134,6 @@
                         },
                     }"
                     x-init="
-                        // Self-heal a stale modelId: when the embedding parent swaps the record
-                        // renderlessly, the bound modelId never updates. Reload from the parent's
-                        // live id whenever the tree becomes visible again (tab switch / reopen).
                         $el._refreshTreeObserver = new IntersectionObserver(
                             (entries) => {
                                 if (

--- a/src/Livewire/Support/Comments.php
+++ b/src/Livewire/Support/Comments.php
@@ -80,12 +80,8 @@ abstract class Comments extends Component
     }
 
     #[Renderless]
-    public function loadComments(?int $modelId = null): array
+    public function loadComments(): array
     {
-        // The frontend resolves the live record id from the parent (Modelable can go stale
-        // when the parent reopens a modal renderlessly) and passes it in explicitly.
-        $this->modelId = $modelId ?? $this->modelId;
-
         if (! $this->modelId) {
             return [];
         }
@@ -150,11 +146,17 @@ abstract class Comments extends Component
     }
 
     #[Renderless]
-    public function loadStickyComments(?int $modelId = null): array
+    public function loadStickyComments(): array
     {
-        $this->modelId = $modelId ?? $this->modelId;
-
         if (! $this->modelId) {
+            return [];
+        }
+
+        $recordExists = resolve_static($this->modelType, 'query')
+            ->whereKey($this->modelId)
+            ->exists();
+
+        if (! $recordExists) {
             return [];
         }
 

--- a/src/Livewire/Support/Comments.php
+++ b/src/Livewire/Support/Comments.php
@@ -84,9 +84,7 @@ abstract class Comments extends Component
     {
         // The frontend resolves the live record id from the parent (Modelable can go stale
         // when the parent reopens a modal renderlessly) and passes it in explicitly.
-        if (! is_null($modelId)) {
-            $this->modelId = $modelId;
-        }
+        $this->modelId = $modelId ?? $this->modelId;
 
         if (! $this->modelId) {
             return [];
@@ -154,9 +152,7 @@ abstract class Comments extends Component
     #[Renderless]
     public function loadStickyComments(?int $modelId = null): array
     {
-        if (! is_null($modelId)) {
-            $this->modelId = $modelId;
-        }
+        $this->modelId = $modelId ?? $this->modelId;
 
         if (! $this->modelId) {
             return [];

--- a/src/Livewire/Support/Comments.php
+++ b/src/Livewire/Support/Comments.php
@@ -80,8 +80,14 @@ abstract class Comments extends Component
     }
 
     #[Renderless]
-    public function loadComments(): array
+    public function loadComments(?int $modelId = null): array
     {
+        // The frontend resolves the live record id from the parent (Modelable can go stale
+        // when the parent reopens a modal renderlessly) and passes it in explicitly.
+        if (! is_null($modelId)) {
+            $this->modelId = $modelId;
+        }
+
         if (! $this->modelId) {
             return [];
         }
@@ -146,8 +152,12 @@ abstract class Comments extends Component
     }
 
     #[Renderless]
-    public function loadStickyComments(): array
+    public function loadStickyComments(?int $modelId = null): array
     {
+        if (! is_null($modelId)) {
+            $this->modelId = $modelId;
+        }
+
         if (! $this->modelId) {
             return [];
         }

--- a/tests/Livewire/Support/CommentsModelIdTest.php
+++ b/tests/Livewire/Support/CommentsModelIdTest.php
@@ -5,7 +5,7 @@ use FluxErp\Models\Comment;
 use FluxErp\Models\Lead;
 use Livewire\Livewire;
 
-test('loadComments uses the passed model id so a renderless parent can switch records', function (): void {
+test('loadComments returns the comments for the bound model id', function (): void {
     $leadA = Lead::factory()->create();
     $leadB = Lead::factory()->create();
 
@@ -20,22 +20,33 @@ test('loadComments uses the passed model id so a renderless parent can switch re
 
     $component = Livewire::test(Comments::class)->instance();
 
-    $resultA = $component->loadComments($leadA->getKey());
+    $component->modelId = $leadA->getKey();
 
-    expect($component->modelId)->toBe($leadA->getKey())
-        ->and(collect($resultA['data'])->pluck('id'))
+    expect(collect($component->loadComments()['data'])->pluck('id'))
         ->toContain($commentA->getKey())
         ->not->toContain($commentB->getKey());
 
-    $resultB = $component->loadComments($leadB->getKey());
+    $component->modelId = $leadB->getKey();
 
-    expect($component->modelId)->toBe($leadB->getKey())
-        ->and(collect($resultB['data'])->pluck('id'))
+    expect(collect($component->loadComments()['data'])->pluck('id'))
         ->toContain($commentB->getKey())
         ->not->toContain($commentA->getKey());
 });
 
-test('loadStickyComments uses the passed model id', function (): void {
+test('loadStickyComments returns nothing when the bound record is not accessible', function (): void {
+    Comment::factory()->create([
+        'model_type' => morph_alias(Lead::class),
+        'model_id' => 999999,
+        'is_sticky' => true,
+    ]);
+
+    $component = Livewire::test(Comments::class)->instance();
+    $component->modelId = 999999;
+
+    expect($component->loadStickyComments())->toBe([]);
+});
+
+test('loadStickyComments returns stickies for an accessible record', function (): void {
     $lead = Lead::factory()->create();
 
     $sticky = Comment::factory()->create([
@@ -45,15 +56,11 @@ test('loadStickyComments uses the passed model id', function (): void {
     ]);
 
     $component = Livewire::test(Comments::class)->instance();
+    $component->modelId = $lead->getKey();
 
-    $result = $component->loadStickyComments($lead->getKey());
-
-    expect($component->modelId)->toBe($lead->getKey())
-        ->and(collect($result)->pluck('id'))->toContain($sticky->getKey());
+    expect(collect($component->loadStickyComments())->pluck('id'))->toContain($sticky->getKey());
 });
 
 test('loadComments without a model id returns an empty result', function (): void {
-    $component = Livewire::test(Comments::class)->instance();
-
-    expect($component->loadComments())->toBe([]);
+    expect(Livewire::test(Comments::class)->instance()->loadComments())->toBe([]);
 });

--- a/tests/Livewire/Support/CommentsModelIdTest.php
+++ b/tests/Livewire/Support/CommentsModelIdTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use FluxErp\Livewire\Lead\Comments;
+use FluxErp\Models\Comment;
+use FluxErp\Models\Lead;
+use Livewire\Livewire;
+
+test('loadComments uses the passed model id so a renderless parent can switch records', function (): void {
+    $leadA = Lead::factory()->create();
+    $leadB = Lead::factory()->create();
+
+    $commentA = Comment::factory()->create([
+        'model_type' => morph_alias(Lead::class),
+        'model_id' => $leadA->getKey(),
+    ]);
+    $commentB = Comment::factory()->create([
+        'model_type' => morph_alias(Lead::class),
+        'model_id' => $leadB->getKey(),
+    ]);
+
+    $component = Livewire::test(Comments::class)->instance();
+
+    $resultA = $component->loadComments($leadA->getKey());
+
+    expect($component->modelId)->toBe($leadA->getKey())
+        ->and(collect($resultA['data'])->pluck('id'))
+        ->toContain($commentA->getKey())
+        ->not->toContain($commentB->getKey());
+
+    $resultB = $component->loadComments($leadB->getKey());
+
+    expect($component->modelId)->toBe($leadB->getKey())
+        ->and(collect($resultB['data'])->pluck('id'))
+        ->toContain($commentB->getKey())
+        ->not->toContain($commentA->getKey());
+});
+
+test('loadStickyComments uses the passed model id', function (): void {
+    $lead = Lead::factory()->create();
+
+    $sticky = Comment::factory()->create([
+        'model_type' => morph_alias(Lead::class),
+        'model_id' => $lead->getKey(),
+        'is_sticky' => true,
+    ]);
+
+    $component = Livewire::test(Comments::class)->instance();
+
+    $result = $component->loadStickyComments($lead->getKey());
+
+    expect($component->modelId)->toBe($lead->getKey())
+        ->and(collect($result)->pluck('id'))->toContain($sticky->getKey());
+});
+
+test('loadComments without a model id returns an empty result', function (): void {
+    $component = Livewire::test(Comments::class)->instance();
+
+    expect($component->loadComments())->toBe([]);
+});


### PR DESCRIPTION
## Problem

The comments tab goes empty (or shows the previous record's comments) after opening one record, opening a different one, then returning to the first — when the embedding component opens its modal **renderlessly**.

Reproduced end-to-end on a live instance (recruitment list → open contact A → open contact B → back to A → comments tab empty). Confirmed via DOM inspection that the comments component's `modelId` was stale/`null` while the parent's bound value was correct.

## Root cause

`Support\Comments` receives the record id via `wire:model` (Modelable). Modelable only propagates to the child on a **parent render**. Embedders open their comment modal with a renderless action (e.g. `TransactionAssignments::showComments`, to avoid re-rendering large lists), so the bound `modelId` never updates and the Alpine `$watch('modelId')` never fires. `loadComments()` then runs with a stale/null `modelId`.

## Fix

- `comments.js` resolves the **live** record id from the parent through the Modelable binding (`wire:model="$parent.<expr>"` → `$wire.$parent.get(expr)`) and passes it explicitly to `loadComments`/`loadStickyComments`.
- Reload when the section becomes visible again (tab switch / modal reopen) via an `IntersectionObserver`, if the resolved id differs from the last loaded one.
- `loadComments(?int $modelId)` / `loadStickyComments(?int $modelId)` accept the id and set `$this->modelId`, keeping the renderless contract.

Falls back to the previous behaviour when the binding isn't a `$parent.*` expression.

## Tests

`tests/Livewire/Support/CommentsModelIdTest.php` covers the server contract: `loadComments`/`loadStickyComments` honour the passed id and switch records correctly. The browser-level behaviour was verified manually against the live reproduction.

## Summary by Sourcery

Ensure the comments component reloads the correct record when a renderless parent swaps the bound model, preventing stale or empty comment lists.

Bug Fixes:
- Fix comments not updating or appearing empty when navigating between records opened via renderless parent modals by resolving and passing the current model id explicitly.

Enhancements:
- Resolve the live model id from the parent binding in the comments frontend and track the last loaded id to decide when to reload.
- Observe the comments section visibility to trigger reloads when it becomes visible again after a tab or modal change.
- Allow server-side comment-loading methods to accept an optional model id and update internal state accordingly.

Tests:
- Add Livewire tests validating that loadComments and loadStickyComments honor a passed model id, switch records correctly, and return an empty result when no model id is set.