### PR TITLE
feat: add targeted loading feedback to action buttons

### DIFF
--- a/resources/views/components/absence-request/approval.blade.php
+++ b/resources/views/components/absence-request/approval.blade.php
@@ -16,6 +16,7 @@
                         :text="__('Approve')"
                         color="emerald"
                         wire:click="approve()"
+                        loading="approve()"
                         icon="check"
                     />
                 @endcanAction
@@ -27,6 +28,7 @@
                         :text="__('Reject')"
                         color="red"
                         wire:click="reject()"
+                        loading="reject()"
                         icon="x-mark"
                         x-bind:disabled="!$wire.absenceRequestForm.comment"
                     />
@@ -39,6 +41,7 @@
                         :text="__('Revoke')"
                         color="secondary"
                         wire:click="revoke()"
+                        loading="revoke()"
                         icon="no-symbol"
                         x-bind:disabled="!$wire.absenceRequestForm.comment"
                     />

--- a/resources/views/components/absence-request/general.blade.php
+++ b/resources/views/components/absence-request/general.blade.php
@@ -102,7 +102,12 @@
         </div>
 
         <div class="mt-6 flex justify-end">
-            <x-button wire:click="save()" color="primary" :text="__('Save')" />
+            <x-button
+                wire:click="save()"
+                loading="save()"
+                color="primary"
+                :text="__('Save')"
+            />
         </div>
     </x-card>
 </div>

--- a/resources/views/components/shop/cart-item.blade.php
+++ b/resources/views/components/shop/cart-item.blade.php
@@ -5,6 +5,7 @@
             icon="x-mark"
             color="red"
             wire:click="remove({{ $cartItem->id }})"
+            loading="remove({{ $cartItem->id }})"
         />
     </div>
     <div class="flex justify-start gap-2">

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -48,8 +48,8 @@
             @stack('transaction-assign-orders-modal-footer')
             <x-button
                 :text="__('Assign')"
-                wire:click="assignOrders"
-                loading="assignOrders"
+                wire:click="assignOrders()"
+                loading="assignOrders()"
             />
         </x-slot:footer>
     </x-modal>

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -46,7 +46,11 @@
                 "
             />
             @stack('transaction-assign-orders-modal-footer')
-            <x-button :text="__('Assign')" wire:click="assignOrders" />
+            <x-button
+                :text="__('Assign')"
+                wire:click="assignOrders"
+                loading="assignOrders"
+            />
         </x-slot:footer>
     </x-modal>
 
@@ -669,6 +673,7 @@
                             color="emerald"
                             wire:flux-confirm.type.warning="{{ __('Accept all assignments|All suggested transaction assignments will be accepted') }}"
                             wire:click="acceptAll()"
+                            loading="acceptAll()"
                             :text="__('Accept all')"
                             x-cloak
                             x-show="$wire.tab === '{{ __('Assignment suggestions') }}' && data.data?.length > 0"

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -22,6 +22,7 @@
                         <x-slot:footer>
                             <x-button
                                 wire:click="resetPassword()"
+                                loading="resetPassword()"
                                 color="indigo"
                                 class="w-full"
                                 :text="__('Reset password')"

--- a/resources/views/livewire/cart/cart.blade.php
+++ b/resources/views/livewire/cart/cart.blade.php
@@ -64,6 +64,7 @@
                                     @section('cart-sidebar.footer.buttons.buy')
                                         <x-button
                                             wire:click="addToCurrentOrder()"
+                                            loading="addToCurrentOrder()"
                                             color="indigo"
                                             class="w-full"
                                             :text="__('Add to current order')"
@@ -72,6 +73,7 @@
                                             light
                                             :text="__('Clear cart')"
                                             wire:click="clear()"
+                                            loading="clear()"
                                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Cart Items')]) }}"
                                             color="red"
                                             class="w-full"

--- a/resources/views/livewire/cart/watchlist-card.blade.php
+++ b/resources/views/livewire/cart/watchlist-card.blade.php
@@ -43,6 +43,7 @@
                         color="red"
                         icon="x-mark"
                         wire:click="removeProduct({{ $cartFormItem['product_id'] }})"
+                        loading="removeProduct({{ $cartFormItem['product_id'] }})"
                         class="absolute top-2 right-2 z-10 h-4 w-4"
                     />
                 @endif
@@ -75,6 +76,7 @@
                 color="red"
                 wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Watchlist')]) }}"
                 wire:click="delete()"
+                loading="delete()"
                 :text="__('Delete')"
             />
         @endif
@@ -82,6 +84,7 @@
         <x-button
             color="indigo"
             wire:click="addToCart()"
+            loading="addToCart()"
             :text="__('Add products to cart')"
         />
     </x-slot:footer>

--- a/resources/views/livewire/contact/addresses.blade.php
+++ b/resources/views/livewire/contact/addresses.blade.php
@@ -295,6 +295,7 @@
                                     <x-button
                                         wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Address')]) }}"
                                         wire:click="delete()"
+                                        loading="delete()"
                                         color="red"
                                         :text="__('Delete')"
                                     />

--- a/resources/views/livewire/contact/contact.blade.php
+++ b/resources/views/livewire/contact/contact.blade.php
@@ -69,6 +69,7 @@
                             :text="__('Delete') "
                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Contact')]) }}"
                             wire:click="delete()"
+                            loading="delete()"
                         />
                     @endcanAction
                     @stack('contact-detail-header-actions')

--- a/resources/views/livewire/contact/orders.blade.php
+++ b/resources/views/livewire/contact/orders.blade.php
@@ -138,10 +138,10 @@
                 x-on:click="$tsui.close.modal('create-order-modal')"
             />
             <x-button
-                loading
                 color="indigo"
                 :text="__('Save')"
                 wire:click="save()"
+                loading="save()"
             />
         </x-slot:footer>
     </x-modal>

--- a/resources/views/livewire/create-documents-modal.blade.php
+++ b/resources/views/livewire/create-documents-modal.blade.php
@@ -28,10 +28,10 @@
                 />
                 @stack('create-documents-preview-modal-footer')
                 <x-button
-                    loading
                     color="indigo"
                     :text="__('Download')"
                     wire:click="downloadPreview()"
+                    loading="downloadPreview()"
                 />
             </x-slot:footer>
         </x-modal>

--- a/resources/views/livewire/employee/employee-work-time-model-assignment.blade.php
+++ b/resources/views/livewire/employee/employee-work-time-model-assignment.blade.php
@@ -62,6 +62,7 @@
                     :text="__('Assign')"
                     color="primary"
                     wire:click="assignWorkTimeModel()"
+                    loading="assignWorkTimeModel()"
                 />
             </div>
         </div>

--- a/resources/views/livewire/features/calendar/calendar-event.blade.php
+++ b/resources/views/livewire/features/calendar/calendar-event.blade.php
@@ -634,6 +634,7 @@
                                     :text="__('Reactivate')"
                                     primary
                                     wire:click="reactivate()"
+                                    loading="reactivate()"
                                 />
                             </div>
                         @endcanAction

--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -257,6 +257,7 @@
                                             color="red"
                                             icon="trash"
                                             wire:click="deleteFavorite({{ $favorite['id'] }})"
+                                            loading="deleteFavorite({{ $favorite['id'] }})"
                                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Favorite')]) }}"
                                         />
                                     </div>

--- a/resources/views/livewire/order/additional-addresses.blade.php
+++ b/resources/views/livewire/order/additional-addresses.blade.php
@@ -67,6 +67,7 @@
                     <x-button.circle
                         icon="trash"
                         wire:click="delete({{ data_get($address, 'address_id') }})"
+                        loading="delete({{ data_get($address, 'address_id') }})"
                         color="red"
                         wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Address assignment')]) }}"
                     />

--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -139,6 +139,7 @@
                                         icon="trash"
                                         sm
                                         wire:click="removePosition({{ $index }})"
+                                        loading="removePosition({{ $index }})"
                                     />
                                 </div>
                             @else
@@ -192,6 +193,7 @@
                                             color="red"
                                             icon="trash"
                                             wire:click="removePosition({{ $index }})"
+                                            loading="removePosition({{ $index }})"
                                         />
                                     </x-slot:actions>
                                 </x-flux::list-item>
@@ -262,7 +264,7 @@
                     color="indigo"
                     :text="$this->getTitle()"
                     wire:click="save()"
-                    loading
+                    loading="save()"
                     x-bind:disabled="
                         !$wire.replicateOrder.order_type_id ||
                         !$wire.replicateOrder.order_positions.length

--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -391,6 +391,7 @@
                     color="red"
                     :text="__('Delete')"
                     wire:click="delete()"
+                    loading="delete()"
                 />
             @endif
 

--- a/resources/views/livewire/product/product.blade.php
+++ b/resources/views/livewire/product/product.blade.php
@@ -58,6 +58,7 @@
                     color="red"
                     :text="__('Delete') "
                     wire:click="delete()"
+                    loading="delete()"
                     wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Product')]) }}"
                 />
             @endcanAction

--- a/resources/views/livewire/project/project.blade.php
+++ b/resources/views/livewire/project/project.blade.php
@@ -77,6 +77,7 @@
                     color="red"
                     :text="__('Delete')"
                     wire:click="delete()"
+                    loading="delete()"
                 />
             @endcanAction
 

--- a/resources/views/livewire/settings/notifications.blade.php
+++ b/resources/views/livewire/settings/notifications.blade.php
@@ -69,7 +69,12 @@
                     $tsui.close.modal('edit-notification-settings-modal')
                 "
             />
-            <x-button color="indigo" :text="__('Save')" wire:click="save()" />
+            <x-button
+                color="indigo"
+                :text="__('Save')"
+                wire:click="save()"
+                loading="save()"
+            />
         </x-slot:footer>
     </x-modal>
     <div class="px-4 sm:px-6 lg:px-8">

--- a/resources/views/livewire/settings/price-lists.blade.php
+++ b/resources/views/livewire/settings/price-lists.blade.php
@@ -201,6 +201,7 @@
                                 color="primary"
                                 icon="plus"
                                 wire:click="addCategoryDiscount()"
+                                loading="addCategoryDiscount()"
                             />
                         </div>
                     </div>

--- a/resources/views/livewire/settings/printers.blade.php
+++ b/resources/views/livewire/settings/printers.blade.php
@@ -116,6 +116,7 @@
                 :text="__('Generate Configuration')"
                 icon="cog"
                 wire:click="generateBridgeConfig()"
+                loading="generateBridgeConfig()"
             />
         </div>
 

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -535,6 +535,7 @@
                                 :text="__('Send Test')"
                                 color="secondary"
                                 wire:click="sendTestNotification()"
+                                loading="sendTestNotification()"
                                 icon="paper-airplane"
                             />
                         </div>
@@ -621,6 +622,7 @@
                                 :text="__('Send Test')"
                                 color="secondary"
                                 wire:click="sendFcmTestNotification()"
+                                loading="sendFcmTestNotification()"
                                 icon="paper-airplane"
                             />
                         </div>
@@ -684,7 +686,12 @@
                 :text="__('Cancel')"
                 x-on:click="window.history.back()"
             />
-            <x-button color="indigo" :text="__('Save')" wire:click="save()" />
+            <x-button
+                color="indigo"
+                :text="__('Save')"
+                wire:click="save()"
+                loading="save()"
+            />
         </div>
         @stack('profile-integration-sections')
     @show

--- a/resources/views/livewire/settings/subscription-settings.blade.php
+++ b/resources/views/livewire/settings/subscription-settings.blade.php
@@ -55,6 +55,6 @@
     </div>
 
     <div class="flex justify-end">
-        <x-button wire:click="save()" :text="__('Save')" />
+        <x-button wire:click="save()" loading="save()" :text="__('Save')" />
     </div>
 </div>

--- a/resources/views/livewire/settings/two-factor-setup.blade.php
+++ b/resources/views/livewire/settings/two-factor-setup.blade.php
@@ -91,6 +91,7 @@
                                 color="red"
                                 wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Two-Factor Authentication')]) }}"
                                 wire:click="disableTwoFactor()"
+                                loading="disableTwoFactor()"
                             />
                         @else
                             <p class="text-xs text-amber-600 dark:text-amber-400">
@@ -112,6 +113,7 @@
                             :text="__('Enable')"
                             color="primary"
                             wire:click="startSetup()"
+                            loading="startSetup()"
                         />
                     </div>
                     @if ($isForced)

--- a/resources/views/livewire/settings/user-edit.blade.php
+++ b/resources/views/livewire/settings/user-edit.blade.php
@@ -105,6 +105,7 @@
                             size="sm"
                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Two-Factor Authentication')]) }}"
                             wire:click="resetTwoFactor()"
+                            loading="resetTwoFactor()"
                         />
                     @endif
                 </div>
@@ -364,6 +365,7 @@
                         color="red"
                         :text="__('Delete')"
                         wire:click="delete()"
+                        loading="delete()"
                         wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('User')]) }}"
                     />
                 @endcanAction
@@ -379,6 +381,7 @@
                         color="indigo"
                         :text="__('Save')"
                         wire:click="save()"
+                        loading="save()"
                     />
                 </div>
             </div>

--- a/resources/views/livewire/settings/work-time-model.blade.php
+++ b/resources/views/livewire/settings/work-time-model.blade.php
@@ -15,13 +15,14 @@
                     :text="__('Delete')"
                     color="red"
                     wire:click="delete()"
+                    loading="delete()"
                     wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Work Time Model')]) }}"
                 />
                 <x-button
                     :text="__('Save')"
                     color="primary"
                     wire:click="save()"
-                    wire:loading.attr="disabled"
+                    loading="save()"
                 />
             </div>
         </div>

--- a/resources/views/livewire/support/settings-component.blade.php
+++ b/resources/views/livewire/support/settings-component.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-4">
     {{ $this->{$this->getFormPropertyName()}->autoRender($__data) }}
     <div class="flex justify-end">
-        <x-button wire:click="save()" :text="__('Save')" />
+        <x-button wire:click="save()" loading="save()" :text="__('Save')" />
     </div>
 </div>

--- a/resources/views/livewire/task/task.blade.php
+++ b/resources/views/livewire/task/task.blade.php
@@ -223,6 +223,7 @@
             <x-button
                 color="primary"
                 wire:click="replicate()"
+                loading="replicate()"
                 primary
                 :text="__('Save')"
             />
@@ -271,6 +272,7 @@
                     color="red"
                     :text="__('Delete')"
                     wire:click="delete()"
+                    loading="delete()"
                 />
             @endcanAction
 

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -62,10 +62,16 @@
                     color="red"
                     :text="__('Delete') "
                     wire:click="delete()"
+                    loading="delete()"
                     wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Ticket')]) }}"
                 />
             @endcanAction
-            <x-button color="indigo" :text="__('Save')" wire:click="save()" />
+            <x-button
+                color="indigo"
+                :text="__('Save')"
+                wire:click="save()"
+                loading="save()"
+            />
             @stack('ticket-detail-header-actions')
         @show
     </div>

--- a/resources/views/livewire/ticket/tickets.blade.php
+++ b/resources/views/livewire/ticket/tickets.blade.php
@@ -57,6 +57,11 @@
             x-on:click="$tsui.close.modal('new-ticket-modal')"
         />
         @stack('ticket-new-modal-footer')
-        <x-button color="indigo" :text="__('Save')" wire:click="save()" />
+        <x-button
+            color="indigo"
+            :text="__('Save')"
+            wire:click="save()"
+            loading="save()"
+        />
     </x-slot:footer>
 </x-modal>


### PR DESCRIPTION
Adds the TallStackUI `loading` attribute to action buttons (save, delete, send, create, assign, sync, process, download) that previously gave no visual feedback during the server round-trip. On click the button now shows a spinner and disables, so the UI feels responsive instead of frozen.

Each `loading` target mirrors the button's `wire:click` call including its parameters (e.g. `loading="delete({{ $id }})"`), so only the clicked button shows the spinner rather than every button on the component. A few pre-existing untargeted `loading` / `wire:loading.attr` attributes that reacted to any component request were replaced with the targeted form.

Scope: only genuine server actions. Buttons whose `wire:click` runs pure JS, opens a modal, or navigates were left untouched, as were per-row buttons whose target depends on an Alpine runtime variable (loading can't be matched per-instance there).

## Summary by Sourcery

Improve user feedback on long-running Livewire actions by adding targeted loading states to action buttons across the app.

Enhancements:
- Add TallStackUI loading targets to save, delete, assign, send, download, and similar Livewire action buttons so they show a spinner and disable during server requests.
- Replace generic component-wide loading attributes with action-specific loading bindings to ensure only the triggered button reflects the in-progress state.