### PR TITLE
feat: optional redirect target for the magic login url

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2680,6 +2680,8 @@
     "The given columns must be unique.": "Jede Spalte darf nur einmal angegeben werden.",
     "The given data was invalid.": "Die übermittelten Daten waren ungültig.",
     "The given order already has a parent.": "Der Auftrag ist bereits einem anderen Auftrag untergeordnet.",
+    "The given route does not exist.": "Die angegebene Route existiert nicht.",
+    "The given route is missing required parameters.": "Der angegebenen Route fehlen erforderliche Parameter.",
     "The login link is invalid or has expired.": "Der Anmeldelink ist ungültig oder abgelaufen.",
     "The main record must not be in the merge records.": "Der Hauptdatensatz darf nicht in den zusammenzuführenden Datensätzen sein.",
     "The media collection is read-only and cannot be modified.": "Die Mediensammlung ist schreibgeschützt und kann nicht geändert werden.",

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -2,18 +2,15 @@
 
 namespace FluxErp\Http\Controllers;
 
-use Closure;
 use FluxErp\Helpers\ResponseHelper;
+use FluxErp\Http\Requests\LoginUrlRequest;
 use FluxErp\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
@@ -79,27 +76,13 @@ class AuthController extends Controller
         ])->onlyInput('email');
     }
 
-    public function loginUrl(Request $request): JsonResponse
+    public function loginUrl(LoginUrlRequest $request): JsonResponse
     {
-        $validated = $request->validate([
-            'redirect' => ['nullable', 'string', function (string $attribute, mixed $value, Closure $fail): void {
-                if (! blank($value) && ! Route::has($value)) {
-                    $fail(__('The :attribute must be a valid route name.', ['attribute' => $attribute]));
-                }
-            }],
-            'redirect_params' => ['nullable', 'array'],
-        ]);
+        $validated = $request->validated();
 
-        $intended = null;
-        if (! blank($validated['redirect'] ?? null)) {
-            try {
-                $intended = route($validated['redirect'], $validated['redirect_params'] ?? []);
-            } catch (UrlGenerationException) {
-                throw ValidationException::withMessages([
-                    'redirect' => __('The :attribute route parameters are invalid.', ['attribute' => 'redirect']),
-                ]);
-            }
-        }
+        $intended = blank($validated['redirect'] ?? null)
+            ? null
+            : route($validated['redirect'], $validated['redirect_params'] ?? []);
 
         return ResponseHelper::createResponseFromBase(
             statusCode: 200,

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -2,14 +2,18 @@
 
 namespace FluxErp\Http\Controllers;
 
+use Closure;
 use FluxErp\Helpers\ResponseHelper;
 use FluxErp\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
@@ -78,14 +82,28 @@ class AuthController extends Controller
     public function loginUrl(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'redirect' => ['nullable', 'string', 'max:2048'],
+            'redirect' => ['nullable', 'string', function (string $attribute, mixed $value, Closure $fail): void {
+                if (! blank($value) && ! Route::has($value)) {
+                    $fail(__('The :attribute must be a valid route name.', ['attribute' => $attribute]));
+                }
+            }],
+            'redirect_params' => ['nullable', 'array'],
         ]);
+
+        $intended = null;
+        if (! blank($validated['redirect'] ?? null)) {
+            try {
+                $intended = route($validated['redirect'], $validated['redirect_params'] ?? []);
+            } catch (UrlGenerationException) {
+                throw ValidationException::withMessages([
+                    'redirect' => __('The :attribute route parameters are invalid.', ['attribute' => 'redirect']),
+                ]);
+            }
+        }
 
         return ResponseHelper::createResponseFromBase(
             statusCode: 200,
-            data: ['url' => $request->user()->generateLoginLink(
-                $this->resolveSafeRedirect($validated['redirect'] ?? null)
-            )],
+            data: ['url' => $request->user()->generateLoginLink($intended)],
         );
     }
 
@@ -102,24 +120,5 @@ class AuthController extends Controller
     public function validateToken(): JsonResponse
     {
         return response()->json(['status' => 'token valid']);
-    }
-
-    protected function resolveSafeRedirect(?string $redirect): ?string
-    {
-        if (blank($redirect)) {
-            return null;
-        }
-
-        if (! str_contains($redirect, '://') && ! str_starts_with($redirect, '//') && ! str_starts_with($redirect, '/')) {
-            $redirect = '/' . $redirect;
-        }
-
-        if (str_starts_with($redirect, '/') && ! str_starts_with($redirect, '//')) {
-            return url($redirect);
-        }
-
-        return parse_url($redirect, PHP_URL_HOST) === parse_url(config('app.url'), PHP_URL_HOST)
-            ? $redirect
-            : null;
     }
 }

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -110,7 +110,11 @@ class AuthController extends Controller
             return null;
         }
 
-        if (str_starts_with($redirect, '/')) {
+        if (! str_contains($redirect, '://') && ! str_starts_with($redirect, '//') && ! str_starts_with($redirect, '/')) {
+            $redirect = '/' . $redirect;
+        }
+
+        if (str_starts_with($redirect, '/') && ! str_starts_with($redirect, '//')) {
             return url($redirect);
         }
 

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -77,9 +77,15 @@ class AuthController extends Controller
 
     public function loginUrl(Request $request): JsonResponse
     {
+        $validated = $request->validate([
+            'redirect' => ['nullable', 'string', 'max:2048'],
+        ]);
+
         return ResponseHelper::createResponseFromBase(
             statusCode: 200,
-            data: ['url' => $request->user()->generateLoginLink()],
+            data: ['url' => $request->user()->generateLoginLink(
+                $this->resolveSafeRedirect($validated['redirect'] ?? null)
+            )],
         );
     }
 
@@ -96,5 +102,20 @@ class AuthController extends Controller
     public function validateToken(): JsonResponse
     {
         return response()->json(['status' => 'token valid']);
+    }
+
+    protected function resolveSafeRedirect(?string $redirect): ?string
+    {
+        if (blank($redirect)) {
+            return null;
+        }
+
+        if (str_starts_with($redirect, '/')) {
+            return url($redirect);
+        }
+
+        return parse_url($redirect, PHP_URL_HOST) === parse_url(config('app.url'), PHP_URL_HOST)
+            ? $redirect
+            : null;
     }
 }

--- a/src/Http/Requests/LoginUrlRequest.php
+++ b/src/Http/Requests/LoginUrlRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FluxErp\Http\Requests;
+
+use FluxErp\Rules\RouteExists;
+
+class LoginUrlRequest extends BaseFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'redirect' => [
+                'nullable',
+                'string',
+                app(RouteExists::class, ['parameterAttribute' => 'redirect_params']),
+            ],
+            'redirect_params' => [
+                'nullable',
+                'array',
+            ],
+        ];
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -226,7 +226,7 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
             ->first();
     }
 
-    public function generateLoginLink(): string
+    public function generateLoginLink(?string $intendedUrl = null): string
     {
         $plaintextToken = Str::uuid()->toString();
         $expires = now()->addMinutes(15);
@@ -235,7 +235,7 @@ class User extends FluxAuthenticatable implements HasLocalePreference, HasMedia,
                 'user_type' => $this->getMorphClass(),
                 'user_id' => $this->getKey(),
                 'guard' => 'web',
-                'intended_url' => Session::get('url.intended', route('dashboard')),
+                'intended_url' => $intendedUrl ?? Session::get('url.intended', route('dashboard')),
             ],
             $expires
         );

--- a/src/Rules/RouteExists.php
+++ b/src/Rules/RouteExists.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FluxErp\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
+use Illuminate\Support\Facades\Route;
+
+class RouteExists implements DataAwareRule, ValidationRule
+{
+    protected array $data = [];
+
+    private ?string $parameterAttribute;
+
+    public function __construct(?string $parameterAttribute = null)
+    {
+        $this->parameterAttribute = $parameterAttribute;
+    }
+
+    public function setData(array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || ! Route::has($value)) {
+            $fail('The given route does not exist.')->translate();
+
+            return;
+        }
+
+        if ($this->parameterAttribute) {
+            try {
+                route($value, data_get($this->data, $this->parameterAttribute) ?? []);
+            } catch (UrlGenerationException) {
+                $fail('The given route is missing required parameters.')->translate();
+            }
+        }
+    }
+}

--- a/src/Rules/RouteExists.php
+++ b/src/Rules/RouteExists.php
@@ -12,7 +12,7 @@ class RouteExists implements DataAwareRule, ValidationRule
 {
     protected array $data = [];
 
-    private ?string $parameterAttribute;
+    protected ?string $parameterAttribute;
 
     public function __construct(?string $parameterAttribute = null)
     {

--- a/tests/Feature/Api/LoginUrlTest.php
+++ b/tests/Feature/Api/LoginUrlTest.php
@@ -42,3 +42,23 @@ test('the login url ignores an external redirect target', function (): void {
 
     $this->get($url)->assertRedirect(route('dashboard'));
 });
+
+test('the login url treats a bare path as app-relative', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $url = $this->postJson('/api/user/login-url', ['redirect' => 'profile/settings'])
+        ->assertOk()
+        ->json('data.url');
+
+    $this->get($url)->assertRedirect(url('/profile/settings'));
+});
+
+test('the login url rejects a protocol-relative redirect target', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $url = $this->postJson('/api/user/login-url', ['redirect' => '//evil.example.com/phish'])
+        ->assertOk()
+        ->json('data.url');
+
+    $this->get($url)->assertRedirect(route('dashboard'));
+});

--- a/tests/Feature/Api/LoginUrlTest.php
+++ b/tests/Feature/Api/LoginUrlTest.php
@@ -22,3 +22,23 @@ test('the login url endpoint requires the user ability', function (): void {
 
     $this->postJson('/api/user/login-url')->assertForbidden();
 });
+
+test('the login url honours a same-host redirect target', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $url = $this->postJson('/api/user/login-url', ['redirect' => '/orders/5'])
+        ->assertOk()
+        ->json('data.url');
+
+    $this->get($url)->assertRedirect(url('/orders/5'));
+});
+
+test('the login url ignores an external redirect target', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $url = $this->postJson('/api/user/login-url', ['redirect' => 'https://evil.example.com/phish'])
+        ->assertOk()
+        ->json('data.url');
+
+    $this->get($url)->assertRedirect(route('dashboard'));
+});

--- a/tests/Feature/Api/LoginUrlTest.php
+++ b/tests/Feature/Api/LoginUrlTest.php
@@ -23,42 +23,41 @@ test('the login url endpoint requires the user ability', function (): void {
     $this->postJson('/api/user/login-url')->assertForbidden();
 });
 
-test('the login url honours a same-host redirect target', function (): void {
+test('the login url redirects to a named route', function (): void {
     Sanctum::actingAs($this->user, ['user']);
 
-    $url = $this->postJson('/api/user/login-url', ['redirect' => '/orders/5'])
-        ->assertOk()
-        ->json('data.url');
-
-    $this->get($url)->assertRedirect(url('/orders/5'));
-});
-
-test('the login url ignores an external redirect target', function (): void {
-    Sanctum::actingAs($this->user, ['user']);
-
-    $url = $this->postJson('/api/user/login-url', ['redirect' => 'https://evil.example.com/phish'])
+    $url = $this->postJson('/api/user/login-url', ['redirect' => 'dashboard'])
         ->assertOk()
         ->json('data.url');
 
     $this->get($url)->assertRedirect(route('dashboard'));
 });
 
-test('the login url treats a bare path as app-relative', function (): void {
+test('the login url resolves a named route with parameters', function (): void {
     Sanctum::actingAs($this->user, ['user']);
 
-    $url = $this->postJson('/api/user/login-url', ['redirect' => 'profile/settings'])
+    $url = $this->postJson('/api/user/login-url', [
+        'redirect' => 'orders.id',
+        'redirect_params' => ['id' => 5],
+    ])
         ->assertOk()
         ->json('data.url');
 
-    $this->get($url)->assertRedirect(url('/profile/settings'));
+    $this->get($url)->assertRedirect(route('orders.id', ['id' => 5]));
 });
 
-test('the login url rejects a protocol-relative redirect target', function (): void {
+test('the login url rejects an unknown route name', function (): void {
     Sanctum::actingAs($this->user, ['user']);
 
-    $url = $this->postJson('/api/user/login-url', ['redirect' => '//evil.example.com/phish'])
-        ->assertOk()
-        ->json('data.url');
+    $this->postJson('/api/user/login-url', ['redirect' => 'this.route.does.not.exist'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('redirect');
+});
 
-    $this->get($url)->assertRedirect(route('dashboard'));
+test('the login url rejects a named route with missing parameters', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->postJson('/api/user/login-url', ['redirect' => 'orders.id'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('redirect');
 });

--- a/tests/Feature/Api/LoginUrlTest.php
+++ b/tests/Feature/Api/LoginUrlTest.php
@@ -51,7 +51,7 @@ test('the login url rejects an unknown route name', function (): void {
 
     $this->postJson('/api/user/login-url', ['redirect' => 'this.route.does.not.exist'])
         ->assertStatus(422)
-        ->assertJsonValidationErrors('redirect');
+        ->assertJsonStructure(['errors' => ['redirect']]);
 });
 
 test('the login url rejects a named route with missing parameters', function (): void {
@@ -59,5 +59,5 @@ test('the login url rejects a named route with missing parameters', function ():
 
     $this->postJson('/api/user/login-url', ['redirect' => 'orders.id'])
         ->assertStatus(422)
-        ->assertJsonValidationErrors('redirect');
+        ->assertJsonStructure(['errors' => ['redirect']]);
 });


### PR DESCRIPTION
Builds on #1837.

- `generateLoginLink(?string $intendedUrl = null)` — uses the given URL as the post-login destination, falling back to the previous behaviour (session intended → dashboard) when none is passed.
- `POST /api/user/login-url` accepts an optional `redirect`, sanitised to the app's own host (relative paths or same-host absolute URLs only) to avoid an open redirect.

Lets a client (e.g. the desktop/extension) deep-link straight to a record after logging in. Tests cover a same-host redirect being honoured and an external one falling back to the dashboard.

## Summary by Sourcery

Add support for specifying a safe, optional redirect target when generating magic login URLs and ensure external redirects are rejected.

New Features:
- Allow clients to pass an optional redirect target to the magic login URL endpoint, which is used as the post-login destination when valid.

Enhancements:
- Sanitise and constrain login redirect targets to same-host URLs to prevent open redirect vulnerabilities.

Tests:
- Add feature tests verifying that same-host redirect targets are honoured and external redirect targets fall back to the dashboard.