### PR TITLE
fix: strip quoted conversation history from email-based ticket comments

### DIFF
--- a/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
+++ b/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
@@ -211,11 +211,14 @@ class CreateMailExecutedSubscriber
             $model = $matches[1];
             $id = $matches[2];
 
+            $textBody = $this->stripQuotedReply($message->text_body);
+            $htmlBody = $this->stripQuotedReply($message->html_body);
+
             try {
                 $comment = CreateComment::make([
                     'model_type' => $model,
                     'model_id' => $id,
-                    'comment' => nl2br($message->text_body ?? '') ?: $message->html_body ?? $message->subject,
+                    'comment' => nl2br($textBody ?? '') ?: $htmlBody ?? $message->subject,
                     'is_internal' => false,
                 ])
                     ->actingAs($this->address)
@@ -235,5 +238,18 @@ class CreateMailExecutedSubscriber
         return [
             'action.executed: ' . resolve_static(CreateMailMessage::class, 'class') => 'handle',
         ];
+    }
+
+    protected function stripQuotedReply(?string $body): ?string
+    {
+        if ($body === null) {
+            return null;
+        }
+
+        $position = mb_strpos($body, '[flux:quote]');
+
+        return $position === false
+            ? $body
+            : rtrim(mb_substr($body, 0, $position));
     }
 }

--- a/src/Notifications/Comment/CommentCreatedNotification.php
+++ b/src/Notifications/Comment/CommentCreatedNotification.php
@@ -42,7 +42,7 @@ class CommentCreatedNotification extends SubscribableNotification implements Sho
 
     public function toMail(object $notifiable): MailMessage
     {
-        return parent::toMail($notifiable)
+        $mail = parent::toMail($notifiable)
             ->when(
                 $ticketAccount = resolve_static(MailAccount::class, 'query')
                     ->whereHas('mailFolders', fn ($query) => $query->where('can_create_ticket', true))
@@ -55,6 +55,13 @@ class CommentCreatedNotification extends SubscribableNotification implements Sho
                 . $this->model->model->getKey()
                 . ']</span>'
             ));
+
+        array_unshift(
+            $mail->introLines,
+            new HtmlString('<span style="display: none">[flux:quote]</span>')
+        );
+
+        return $mail;
     }
 
     public function via(object $notifiable): array

--- a/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
+++ b/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
@@ -3,6 +3,7 @@
 use FluxErp\Actions\MailMessage\CreateMailMessage;
 use FluxErp\Listeners\MailMessage\CreateMailExecutedSubscriber;
 use FluxErp\Models\Address;
+use FluxErp\Models\Comment;
 use FluxErp\Models\Contact;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
@@ -59,6 +60,55 @@ test('add comment to ticket from mail message', function (): void {
     ]);
 
     expect($ticket->communications()->where('communications.id', $result->id)->exists())->toBeTrue();
+});
+
+test('strips quoted conversation from comment created from mail reply', function (): void {
+    Event::fake('action.executed: ' . CreateMailMessage::class);
+    $ticket = Ticket::factory()->create([
+        'authenticatable_type' => $this->address->getMorphClass(),
+        'authenticatable_id' => $this->address->getKey(),
+    ]);
+
+    $reply = 'habs freigegeben.' . PHP_EOL . 'Nächstes mal schreib ich den Mandanten dazu.';
+    $token = '[flux:comment:' . $ticket->getMorphClass() . ':' . $ticket->getKey() . ']';
+    $quotedHistory = 'Mit freundlichen Grüßen' . PHP_EOL . 'Alexander' . PHP_EOL
+        . '[flux:quote]' . PHP_EOL
+        . 'Hallo, es gibt eine neue Antwort auf Ihr Ticket.' . PHP_EOL
+        . 'Vorherige Kommentare: Hier der Videolink' . PHP_EOL
+        . 'Ursprüngliches Ticket: ...' . PHP_EOL
+        . $token;
+
+    $action = CreateMailMessage::make([
+        'mail_account_id' => $this->mailAccount->id,
+        'mail_folder_id' => $this->mailAccount->mailFolders->first()->id,
+        'from' => 'Tester McTestFace <' . $this->address->email_primary . '>',
+        'to' => [$this->mailAccount->email],
+        'subject' => Str::uuid()->toString(),
+        'text_body' => $reply . PHP_EOL . $quotedHistory,
+        'html_body' => '<p>' . $reply . '</p>'
+            . '<span style="display: none">[flux:quote]</span>'
+            . '<p>Vorherige Kommentare: Hier der Videolink' . $token . '</p>',
+        'communication_type_enum' => 'mail',
+        'date' => now()->format('Y-m-d H:i:s'),
+        'tags' => [],
+    ]);
+    $action->validate()->execute();
+
+    $listener = new CreateMailExecutedSubscriber();
+    $listener->handle($action);
+
+    $comment = Comment::query()
+        ->where('model_type', $ticket->getMorphClass())
+        ->where('model_id', $ticket->getKey())
+        ->latest('id')
+        ->first();
+
+    expect($comment)->not->toBeNull()
+        ->and($comment->comment)->toContain('habs freigegeben')
+        ->and($comment->comment)->not->toContain('Vorherige Kommentare')
+        ->and($comment->comment)->not->toContain('Ursprüngliches Ticket')
+        ->and($comment->comment)->not->toContain('flux:comment')
+        ->and($comment->comment)->not->toContain('[flux:quote]');
 });
 
 test('create ticket from mail message', function (): void {


### PR DESCRIPTION
## Problem

When a recipient replies by mail to a comment notification, their mail client quotes our entire message below their answer. The whole quoted block — previous comments, original ticket, notification footer and the hidden `[flux:comment:...]` tracking token — was stored verbatim as the new comment.

## Solution

Embed a hidden boundary marker (`[flux:quote]`) at the very top of the notification body. On reply, everything from that marker onwards is our quoted history and gets stripped before the reply is stored as a comment. No fragile heuristic parsing of client-generated quote headers.

## Notes

- Strips only our quoted content (history, original ticket, footer, tracking token).
- Residual that cannot be reached via the marker: the recipient's own signature and the few client-generated quote-header lines (`Von:/An:/Betreff:`), which the mail client inserts above our quoted message.
- Only applies to replies on notifications sent after this change (the marker must be present in the original mail).

## Summary by Sourcery

Strip quoted notification content from email replies before creating ticket comments, using a hidden boundary marker embedded in comment notification emails.

Bug Fixes:
- Prevent storage of full quoted notification history, footer, and tracking tokens when creating comments from email replies.

Enhancements:
- Introduce a hidden reply boundary marker in comment notification emails and use it to extract only the user’s reply text when generating comments.
- Add logic to trim reply bodies at the boundary marker for both text and HTML mail content.

Tests:
- Add a unit test verifying that comments created from mail replies only contain the user’s reply and no quoted history, footer, tracking token, or boundary marker.