### PR TITLE
Add token-authed search endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1044,6 +1044,10 @@ Route::prefix('api')
                 Route::put('/schedules', UpdateSchedule::class);
                 Route::delete('/schedules/{id}', DeleteSchedule::class);
 
+                // Search
+                Route::get('/search/{model}', SearchController::class)
+                    ->where('model', '[A-Za-z0-9._-]+');
+
                 // SepaMandates
                 Route::get('/sepa-mandates/{id}', [BaseController::class, 'show'])
                     ->defaults('model', SepaMandate::class);
@@ -1177,9 +1181,6 @@ Route::prefix('api')
                 });
                 Route::post('/user/login-url', [AuthController::class, 'loginUrl'])
                     ->middleware('ability:user');
-
-                Route::get('/search/{model}', SearchController::class)
-                    ->where('model', '[A-Za-z0-9._-]+');
 
                 Route::get('/users/{id}', [BaseController::class, 'show'])->defaults('model', User::class);
                 Route::get('/users', [BaseController::class, 'index'])->defaults('model', User::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -307,6 +307,7 @@ use FluxErp\Http\Controllers\MobileController;
 use FluxErp\Http\Controllers\PermissionController;
 use FluxErp\Http\Controllers\PrintController;
 use FluxErp\Http\Controllers\RoleController;
+use FluxErp\Http\Controllers\SearchController;
 use FluxErp\Http\Controllers\SettingController;
 use FluxErp\Http\Middleware\SetAcceptHeaders;
 use FluxErp\Livewire\Widgets\Employee\CurrentWorkTimeModel;
@@ -1176,6 +1177,9 @@ Route::prefix('api')
                 });
                 Route::post('/user/login-url', [AuthController::class, 'loginUrl'])
                     ->middleware('ability:user');
+
+                Route::get('/search/{model}', SearchController::class)
+                    ->where('model', '(.*)');
 
                 Route::get('/users/{id}', [BaseController::class, 'show'])->defaults('model', User::class);
                 Route::get('/users', [BaseController::class, 'index'])->defaults('model', User::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1179,7 +1179,7 @@ Route::prefix('api')
                     ->middleware('ability:user');
 
                 Route::get('/search/{model}', SearchController::class)
-                    ->where('model', '(.*)');
+                    ->where('model', '[A-Za-z0-9._-]+');
 
                 Route::get('/users/{id}', [BaseController::class, 'show'])->defaults('model', User::class);
                 Route::get('/users', [BaseController::class, 'index'])->defaults('model', User::class);

--- a/tests/Feature/Api/SearchTest.php
+++ b/tests/Feature/Api/SearchTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use FluxErp\Models\Contact;
+use FluxErp\Models\Permission;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function (): void {
+    $this->searchPermission = Permission::findOrCreate('api.search.{model}.get', 'sanctum');
+});
+
+test('the search endpoint returns formatted records for a morph alias', function (): void {
+    $contacts = Contact::factory()->count(2)->create();
+    $this->user->givePermissionTo($this->searchPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->getJson('/api/search/contact?selected[]=' . $contacts[0]->getKey())
+        ->assertOk();
+
+    expect($response->json())->toBeArray();
+    expect($response->json('0.id'))->toBe($contacts[0]->getKey());
+    expect($response->json('0'))->toHaveKeys(['id', 'label', 'description', 'image']);
+});
+
+test('the search endpoint denies a user without the route permission', function (): void {
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->getJson('/api/search/contact?selected[]=1')->assertStatus(403);
+});
+
+test('the search endpoint 404s for an unknown model', function (): void {
+    $this->user->givePermissionTo($this->searchPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->getJson('/api/search/not-a-model?search=x')->assertStatus(404);
+});


### PR DESCRIPTION
Expose GET /api/search/{model} under auth:sanctum, reusing SearchController so API clients get the same formatted {id,label,description,image} results as the web search bar over a Bearer token.

## Summary by Sourcery

Introduce a token-authenticated API search endpoint that reuses the existing search controller behavior for model-based queries.

New Features:
- Add GET /api/search/{model} endpoint under Sanctum auth, delegating to SearchController for formatted search results.

Tests:
- Add feature tests covering successful formatted search responses, permission-based access denial, and 404 handling for unknown models on the new API search endpoint.