### PR TITLE
Add token-authed user notifications endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -304,6 +304,7 @@ use FluxErp\Http\Controllers\BaseController;
 use FluxErp\Http\Controllers\CommentController;
 use FluxErp\Http\Controllers\EventSubscriptionController;
 use FluxErp\Http\Controllers\MobileController;
+use FluxErp\Http\Controllers\NotificationController;
 use FluxErp\Http\Controllers\PermissionController;
 use FluxErp\Http\Controllers\PrintController;
 use FluxErp\Http\Controllers\RoleController;
@@ -1174,6 +1175,8 @@ Route::prefix('api')
 
                     return ResponseHelper::createResponseFromBase(statusCode: 200, data: $user);
                 });
+                Route::get('/user/notifications', [NotificationController::class, 'userIndex']);
+                Route::post('/user/notifications/read', [NotificationController::class, 'markRead']);
                 Route::post('/user/login-url', [AuthController::class, 'loginUrl'])
                     ->middleware('ability:user');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1175,10 +1175,10 @@ Route::prefix('api')
 
                     return ResponseHelper::createResponseFromBase(statusCode: 200, data: $user);
                 });
-                Route::get('/user/notifications', [NotificationController::class, 'userIndex']);
-                Route::post('/user/notifications/read', [NotificationController::class, 'markRead']);
                 Route::post('/user/login-url', [AuthController::class, 'loginUrl'])
                     ->middleware('ability:user');
+                Route::get('/user/notifications', [NotificationController::class, 'userIndex']);
+                Route::post('/user/notifications/read', [NotificationController::class, 'markRead']);
 
                 Route::get('/users/{id}', [BaseController::class, 'show'])->defaults('model', User::class);
                 Route::get('/users', [BaseController::class, 'index'])->defaults('model', User::class);

--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use FluxErp\Helpers\ResponseHelper;
+use FluxErp\Http\Requests\MarkNotificationsReadRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function userIndex(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $notifications = $user->notifications()
+            ->latest()
+            ->limit(30)
+            ->get()
+            ->map(fn ($notification): array => [
+                'id' => $notification->getKey(),
+                'title' => data_get($notification->data, 'title'),
+                'description' => data_get($notification->data, 'description'),
+                'type' => data_get($notification->data, 'toastType'),
+                'url' => data_get($notification->data, 'accept.url'),
+                'read_at' => $notification->read_at,
+                'created_at' => $notification->created_at,
+            ]);
+
+        return ResponseHelper::createResponseFromBase(
+            statusCode: 200,
+            data: $notifications,
+            additions: ['unread_count' => $user->unreadNotifications()->count()],
+        )->setEncodingOptions(JSON_UNESCAPED_SLASHES);
+    }
+
+    public function markRead(MarkNotificationsReadRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+        $user = $request->user();
+
+        if (data_get($validated, 'all')) {
+            $user->unreadNotifications->markAsRead();
+        } elseif (! blank(data_get($validated, 'id'))) {
+            $user->notifications()->whereKey(data_get($validated, 'id'))->first()?->markAsRead();
+        }
+
+        return ResponseHelper::createResponseFromBase(
+            statusCode: 200,
+            data: ['unread_count' => $user->unreadNotifications()->count()],
+        );
+    }
+}

--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -13,11 +13,12 @@ class NotificationController extends Controller
     {
         $user = $request->user();
 
+        $page = max((int) $request->page, 1);
+        $perPage = $request->per_page > 500 || $request->per_page < 1 ? 25 : $request->per_page;
+
         $notifications = $user->notifications()
-            ->latest()
-            ->limit(30)
-            ->get()
-            ->map(fn ($notification): array => [
+            ->paginate(perPage: $perPage, page: $page)
+            ->through(fn ($notification): array => [
                 'id' => $notification->getKey(),
                 'title' => data_get($notification->data, 'title'),
                 'description' => data_get($notification->data, 'description'),
@@ -25,13 +26,15 @@ class NotificationController extends Controller
                 'url' => data_get($notification->data, 'accept.url'),
                 'read_at' => $notification->read_at,
                 'created_at' => $notification->created_at,
-            ]);
+            ])
+            ->appends($request->query());
 
         return ResponseHelper::createResponseFromBase(
             statusCode: 200,
             data: $notifications,
             additions: ['unread_count' => $user->unreadNotifications()->count()],
-        )->setEncodingOptions(JSON_UNESCAPED_SLASHES);
+        )
+            ->setEncodingOptions(JSON_UNESCAPED_SLASHES);
     }
 
     public function markRead(MarkNotificationsReadRequest $request): JsonResponse
@@ -40,9 +43,12 @@ class NotificationController extends Controller
         $user = $request->user();
 
         if (data_get($validated, 'all')) {
-            $user->unreadNotifications->markAsRead();
+            $user->unreadNotifications()->update(['read_at' => now()]);
         } elseif (! blank(data_get($validated, 'id'))) {
-            $user->notifications()->whereKey(data_get($validated, 'id'))->first()?->markAsRead();
+            $user->notifications()
+                ->whereKey(data_get($validated, 'id'))
+                ->first()
+                ?->markAsRead();
         }
 
         return ResponseHelper::createResponseFromBase(

--- a/src/Http/Requests/MarkNotificationsReadRequest.php
+++ b/src/Http/Requests/MarkNotificationsReadRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FluxErp\Http\Requests;
+
+class MarkNotificationsReadRequest extends BaseFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'nullable',
+                'string',
+            ],
+            'all' => [
+                'nullable',
+                'boolean',
+            ],
+        ];
+    }
+}

--- a/src/Http/Requests/MarkNotificationsReadRequest.php
+++ b/src/Http/Requests/MarkNotificationsReadRequest.php
@@ -2,17 +2,24 @@
 
 namespace FluxErp\Http\Requests;
 
+use FluxErp\Models\Notification;
+use FluxErp\Rules\ModelExists;
+
 class MarkNotificationsReadRequest extends BaseFormRequest
 {
     public function rules(): array
     {
         return [
             'id' => [
-                'nullable',
+                'required_without:all',
+                'prohibits:all',
                 'string',
+                app(ModelExists::class, ['model' => Notification::class])
+                    ->where('notifiable_type', $this->user()->getMorphClass())
+                    ->where('notifiable_id', $this->user()->getKey()),
             ],
             'all' => [
-                'nullable',
+                'required_without:id',
                 'boolean',
             ],
         ];

--- a/tests/Feature/Api/UserNotificationTest.php
+++ b/tests/Feature/Api/UserNotificationTest.php
@@ -31,10 +31,10 @@ test('the notifications endpoint returns the user notifications with an unread c
 
     $response = $this->getJson('/api/user/notifications')->assertOk();
 
-    expect($response->json('data'))->toHaveCount(1);
-    expect($response->json('data.0'))->toHaveKeys(['id', 'title', 'description', 'type', 'url', 'read_at', 'created_at']);
-    expect($response->json('data.0.title'))->toBe('A title');
-    expect($response->json('data.0.url'))->toBe('https://example.test/tickets/1');
+    expect($response->json('data.data'))->toHaveCount(1);
+    expect($response->json('data.data.0'))->toHaveKeys(['id', 'title', 'description', 'type', 'url', 'read_at', 'created_at']);
+    expect($response->json('data.data.0.title'))->toBe('A title');
+    expect($response->json('data.data.0.url'))->toBe('https://example.test/tickets/1');
     expect($response->json('unread_count'))->toBe(1);
 });
 
@@ -59,4 +59,23 @@ test('marking all notifications read clears the unread count', function (): void
 
     expect($response->json('data.unread_count'))->toBe(0);
     expect($this->user->unreadNotifications()->count())->toBe(0);
+});
+
+test('marking read rejects an id that does not belong to the user', function (): void {
+    $other = FluxErp\Models\User::factory()->create(['language_id' => $this->user->language_id]);
+    $foreign = makeNotification($other);
+    $this->user->givePermissionTo($this->readPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->postJson('/api/user/notifications/read', ['id' => $foreign->getKey()])
+        ->assertStatus(422)
+        ->assertJsonValidationErrorFor('id');
+});
+
+test('marking read requires either an id or all', function (): void {
+    $this->user->givePermissionTo($this->readPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->postJson('/api/user/notifications/read', [])
+        ->assertStatus(422);
 });

--- a/tests/Feature/Api/UserNotificationTest.php
+++ b/tests/Feature/Api/UserNotificationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use FluxErp\Models\Permission;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+function makeNotification($user, array $data = [], $readAt = null)
+{
+    return $user->notifications()->create([
+        'id' => (string) Str::uuid(),
+        'type' => 'App\\Notifications\\TestNotification',
+        'data' => array_merge([
+            'title' => 'A title',
+            'description' => 'A description',
+            'toastType' => 'info',
+            'accept' => ['url' => 'https://example.test/tickets/1'],
+        ], $data),
+        'read_at' => $readAt,
+    ]);
+}
+
+beforeEach(function (): void {
+    $this->indexPermission = Permission::findOrCreate('api.user.notifications.get', 'sanctum');
+    $this->readPermission = Permission::findOrCreate('api.user.notifications.read.post', 'sanctum');
+});
+
+test('the notifications endpoint returns the user notifications with an unread count', function (): void {
+    makeNotification($this->user);
+    $this->user->givePermissionTo($this->indexPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->getJson('/api/user/notifications')->assertOk();
+
+    expect($response->json('data'))->toHaveCount(1);
+    expect($response->json('data.0'))->toHaveKeys(['id', 'title', 'description', 'type', 'url', 'read_at', 'created_at']);
+    expect($response->json('data.0.title'))->toBe('A title');
+    expect($response->json('data.0.url'))->toBe('https://example.test/tickets/1');
+    expect($response->json('unread_count'))->toBe(1);
+});
+
+test('marking a single notification read drops the unread count', function (): void {
+    $n = makeNotification($this->user);
+    $this->user->givePermissionTo($this->readPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->postJson('/api/user/notifications/read', ['id' => $n->getKey()])->assertOk();
+
+    expect($response->json('data.unread_count'))->toBe(0);
+    expect($n->fresh()->read_at)->not->toBeNull();
+});
+
+test('marking all notifications read clears the unread count', function (): void {
+    makeNotification($this->user);
+    makeNotification($this->user);
+    $this->user->givePermissionTo($this->readPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->postJson('/api/user/notifications/read', ['all' => true])->assertOk();
+
+    expect($response->json('data.unread_count'))->toBe(0);
+    expect($this->user->unreadNotifications()->count())->toBe(0);
+});


### PR DESCRIPTION
- `GET /api/user/notifications` — recent notifications (newest 30) + `unread_count`
- `POST /api/user/notifications/read` — mark one (`{id}`) or all (`{all:true}`) read, user-scoped
- For the Nuxbe Companion extension; 3 feature tests

## Summary by Sourcery

Add token-authenticated user notifications API endpoints for listing recent notifications and marking them as read.

New Features:
- Expose GET /api/user/notifications to return the current user’s latest notifications along with an unread count.
- Expose POST /api/user/notifications/read to allow the current user to mark one or all notifications as read and receive the updated unread count.

Tests:
- Add feature tests covering listing notifications with unread count and marking single or all notifications as read.