### PR TITLE
Add token-authed user tasks + tickets endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -308,6 +308,8 @@ use FluxErp\Http\Controllers\PermissionController;
 use FluxErp\Http\Controllers\PrintController;
 use FluxErp\Http\Controllers\RoleController;
 use FluxErp\Http\Controllers\SettingController;
+use FluxErp\Http\Controllers\TaskController;
+use FluxErp\Http\Controllers\TicketController;
 use FluxErp\Http\Middleware\SetAcceptHeaders;
 use FluxErp\Livewire\Widgets\Employee\CurrentWorkTimeModel;
 use FluxErp\Models\AbsencePolicy;
@@ -1109,6 +1111,7 @@ Route::prefix('api')
                 Route::put('/tasks', UpdateTask::class);
                 Route::delete('/tasks/{id}', DeleteTask::class);
                 Route::post('/tasks/{id}/replicate', ReplicateTask::class);
+                Route::get('/user/tasks', [TaskController::class, 'userIndex']);
 
                 // Tenants
                 Route::get('/tenants/{id}', [BaseController::class, 'show'])->defaults('model', Tenant::class);
@@ -1124,6 +1127,7 @@ Route::prefix('api')
                 Route::post('/tickets', CreateTicket::class);
                 Route::put('/tickets', UpdateTicket::class);
                 Route::delete('/tickets/{id}', DeleteTicket::class);
+                Route::get('/user/tickets', [TicketController::class, 'userIndex']);
 
                 // TicketTypes
                 Route::get('/ticket-types/{id}', [BaseController::class, 'show'])->defaults('model', TicketType::class);

--- a/src/Http/Controllers/TaskController.php
+++ b/src/Http/Controllers/TaskController.php
@@ -15,17 +15,12 @@ class TaskController extends Controller
     {
         $userId = $request->user()->getKey();
 
-        $endStates = TaskState::all()
-            ->filter(fn (string $state): bool => $state::$isEndState)
-            ->keys()
-            ->toArray();
-
         $tasks = resolve_static(Task::class, 'query')
             ->where(function (Builder $query) use ($userId): void {
                 $query->where('responsible_user_id', $userId)
                     ->orWhereRelation('users', 'users.id', $userId);
             })
-            ->whereNotIn('state', $endStates)
+            ->whereNotIn('state', TaskState::endStateNames())
             ->orderByDesc('priority')
             ->orderByRaw('ISNULL(due_date), due_date ASC')
             ->get(['id', 'name', 'state'])

--- a/src/Http/Controllers/TaskController.php
+++ b/src/Http/Controllers/TaskController.php
@@ -20,14 +20,16 @@ class TaskController extends Controller
                 $query->where('responsible_user_id', $userId)
                     ->orWhereRelation('users', 'users.id', $userId);
             })
-            ->whereNotIn('state', TaskState::endStateNames())
+            ->whereNotIn('state', TaskState::endStateKeys())
             ->orderByDesc('priority')
             ->orderByRaw('ISNULL(due_date), due_date ASC')
-            ->get(['id', 'name', 'state'])
+            ->get(['id', 'name', 'state', 'priority', 'due_date'])
             ->map(fn (Task $task): array => [
                 'id' => $task->getKey(),
                 'name' => $task->name,
                 'state' => $task->state::$name,
+                'priority' => $task->priority,
+                'due_date' => $task->due_date?->format('Y-m-d'),
                 'url' => $task->getUrl(),
             ]);
 

--- a/src/Http/Controllers/TaskController.php
+++ b/src/Http/Controllers/TaskController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use FluxErp\Helpers\ResponseHelper;
+use FluxErp\Models\Task;
+use FluxErp\States\Task\TaskState;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TaskController extends Controller
+{
+    public function userIndex(Request $request): JsonResponse
+    {
+        $userId = $request->user()->getKey();
+
+        $endStates = TaskState::all()
+            ->filter(fn (string $state): bool => $state::$isEndState)
+            ->keys()
+            ->toArray();
+
+        $tasks = resolve_static(Task::class, 'query')
+            ->where(function (Builder $query) use ($userId): void {
+                $query->where('responsible_user_id', $userId)
+                    ->orWhereRelation('users', 'users.id', $userId);
+            })
+            ->whereNotIn('state', $endStates)
+            ->orderByDesc('priority')
+            ->orderByRaw('ISNULL(due_date), due_date ASC')
+            ->get(['id', 'name', 'state'])
+            ->map(fn (Task $task): array => [
+                'id' => $task->getKey(),
+                'name' => $task->name,
+                'state' => $task->state::$name,
+                'url' => $task->getUrl(),
+            ]);
+
+        return ResponseHelper::createResponseFromBase(statusCode: 200, data: $tasks)
+            ->setEncodingOptions(JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Http/Controllers/TicketController.php
+++ b/src/Http/Controllers/TicketController.php
@@ -15,7 +15,7 @@ class TicketController extends Controller
     {
         $tickets = $request->user()
             ->tickets()
-            ->whereNotIn('state', TicketState::endStateNames())
+            ->whereNotIn('state', TicketState::endStateKeys())
             ->orderByRaw('state = ? DESC', [Escalated::$name])
             ->orderBy('created_at')
             ->get(['id', 'ticket_number', 'title', 'state'])

--- a/src/Http/Controllers/TicketController.php
+++ b/src/Http/Controllers/TicketController.php
@@ -4,6 +4,7 @@ namespace FluxErp\Http\Controllers;
 
 use FluxErp\Helpers\ResponseHelper;
 use FluxErp\Models\Ticket;
+use FluxErp\States\Ticket\Escalated;
 use FluxErp\States\Ticket\TicketState;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,15 +13,10 @@ class TicketController extends Controller
 {
     public function userIndex(Request $request): JsonResponse
     {
-        $endStates = TicketState::all()
-            ->filter(fn (string $state): bool => $state::$isEndState)
-            ->keys()
-            ->toArray();
-
         $tickets = $request->user()
             ->tickets()
-            ->whereNotIn('state', $endStates)
-            ->orderByRaw("state = 'escalated' DESC")
+            ->whereNotIn('state', TicketState::endStateNames())
+            ->orderByRaw('state = ? DESC', [Escalated::$name])
             ->orderBy('created_at')
             ->get(['id', 'ticket_number', 'title', 'state'])
             ->map(fn (Ticket $ticket): array => [

--- a/src/Http/Controllers/TicketController.php
+++ b/src/Http/Controllers/TicketController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FluxErp\Http\Controllers;
+
+use FluxErp\Helpers\ResponseHelper;
+use FluxErp\Models\Ticket;
+use FluxErp\States\Ticket\TicketState;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TicketController extends Controller
+{
+    public function userIndex(Request $request): JsonResponse
+    {
+        $endStates = TicketState::all()
+            ->filter(fn (string $state): bool => $state::$isEndState)
+            ->keys()
+            ->toArray();
+
+        $tickets = $request->user()
+            ->tickets()
+            ->whereNotIn('state', $endStates)
+            ->orderByRaw("state = 'escalated' DESC")
+            ->orderBy('created_at')
+            ->get(['id', 'ticket_number', 'title', 'state'])
+            ->map(fn (Ticket $ticket): array => [
+                'id' => $ticket->getKey(),
+                'ticket_number' => $ticket->ticket_number,
+                'title' => $ticket->title,
+                'state' => $ticket->state::$name,
+                'url' => $ticket->getUrl(),
+            ]);
+
+        return ResponseHelper::createResponseFromBase(statusCode: 200, data: $tickets)
+            ->setEncodingOptions(JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Jobs/SendTaskRemindersJob.php
+++ b/src/Jobs/SendTaskRemindersJob.php
@@ -51,10 +51,7 @@ class SendTaskRemindersJob implements Repeatable, ShouldQueue
 
     public function handle(): void
     {
-        $endStates = TaskState::all()
-            ->filter(fn ($state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TaskState::endStateKeys();
 
         $this->sendStartReminders($endStates);
         $this->sendDueReminders($endStates);

--- a/src/Livewire/Widgets/MyOverdueTasks.php
+++ b/src/Livewire/Widgets/MyOverdueTasks.php
@@ -65,7 +65,7 @@ class MyOverdueTasks extends Component
             ->user()
             ->tasks()
             ->with(['project:id,name', 'model'])
-            ->whereNotIn('state', $this->getEndStates())
+            ->whereNotIn('state', TaskState::endStateKeys())
             ->where('due_date', '<', now())
             ->orderBy('due_date', 'ASC')
             ->limit($this->limit + 1)
@@ -81,13 +81,5 @@ class MyOverdueTasks extends Component
                 'model_type',
                 'model_id',
             ]);
-    }
-
-    protected function getEndStates(): array
-    {
-        return TaskState::all()
-            ->filter(fn (string $state): bool => $state::$isEndState)
-            ->keys()
-            ->toArray();
     }
 }

--- a/src/Livewire/Widgets/MyResponsibleTasks.php
+++ b/src/Livewire/Widgets/MyResponsibleTasks.php
@@ -82,7 +82,7 @@ class MyResponsibleTasks extends Component implements HasWidgetOptions
     public function showInTaskList(): void
     {
         $userId = auth()->id();
-        $endStates = $this->getEndStates();
+        $endStates = TaskState::endStateKeys();
 
         SessionFilter::make(
             Livewire::new(resolve_static(TaskList::class, 'class'))->getCacheKey(),
@@ -107,7 +107,7 @@ class MyResponsibleTasks extends Component implements HasWidgetOptions
             ->user()
             ->tasksResponsible()
             ->with(['model', 'users:id,name'])
-            ->whereNotIn('state', $this->getEndStates())
+            ->whereNotIn('state', TaskState::endStateKeys())
             ->orderByDesc('priority')
             ->orderByRaw('ISNULL(due_date), due_date ASC')
             ->limit($this->limit + 1)
@@ -121,13 +121,5 @@ class MyResponsibleTasks extends Component implements HasWidgetOptions
                 'model_type',
                 'model_id',
             ]);
-    }
-
-    protected function getEndStates(): array
-    {
-        return TaskState::all()
-            ->filter(fn (string $state): bool => $state::$isEndState)
-            ->keys()
-            ->toArray();
     }
 }

--- a/src/Livewire/Widgets/MyTasks.php
+++ b/src/Livewire/Widgets/MyTasks.php
@@ -75,7 +75,7 @@ class MyTasks extends Component implements HasWidgetOptions
     public function showInTaskList(): void
     {
         $userId = auth()->id();
-        $endStates = $this->getEndStates();
+        $endStates = TaskState::endStateKeys();
 
         SessionFilter::make(
             Livewire::new(resolve_static(TaskList::class, 'class'))->getCacheKey(),
@@ -100,7 +100,7 @@ class MyTasks extends Component implements HasWidgetOptions
             ->user()
             ->tasks()
             ->with(['project:id,name', 'model'])
-            ->whereNotIn('state', $this->getEndStates())
+            ->whereNotIn('state', TaskState::endStateKeys())
             ->orderByDesc('priority')
             ->orderByRaw('ISNULL(due_date), due_date ASC')
             ->limit($this->limit + 1)
@@ -116,13 +116,5 @@ class MyTasks extends Component implements HasWidgetOptions
                 'model_type',
                 'model_id',
             ]);
-    }
-
-    protected function getEndStates(): array
-    {
-        return TaskState::all()
-            ->filter(fn (string $state): bool => $state::$isEndState)
-            ->keys()
-            ->toArray();
     }
 }

--- a/src/Livewire/Widgets/MyTickets.php
+++ b/src/Livewire/Widgets/MyTickets.php
@@ -74,13 +74,7 @@ class MyTickets extends Component
             ->user()
             ->tickets()
             ->with('authenticatable:id,name')
-            ->whereNotIn(
-                'state',
-                TicketState::all()
-                    ->filter(fn (string $state): bool => $state::$isEndState)
-                    ->keys()
-                    ->toArray()
-            )
+            ->whereNotIn('state', TicketState::endStateKeys())
             ->orderByRaw("state = 'escalated' DESC")
             ->orderBy('created_at')
             ->limit($this->limit + 1)

--- a/src/Livewire/Widgets/TicketsByState.php
+++ b/src/Livewire/Widgets/TicketsByState.php
@@ -42,10 +42,7 @@ class TicketsByState extends CircleChart implements HasWidgetOptions
     {
         $allStates = TicketState::all();
 
-        $endStates = $allStates
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TicketState::endStateKeys();
 
         $data = resolve_static(Ticket::class, 'query')
             ->whereNotIn('state', $endStates)

--- a/src/Livewire/Widgets/TicketsByTopCustomersByState.php
+++ b/src/Livewire/Widgets/TicketsByTopCustomersByState.php
@@ -51,7 +51,7 @@ class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
     public function calculateChart(): void
     {
         $allStates = TicketState::all();
-        $endStates = $this->getEndStates($allStates);
+        $endStates = TicketState::endStateKeys();
 
         $topCustomers = resolve_static(Address::class, 'query')
             ->join('tickets', function (JoinClause $join): void {
@@ -183,19 +183,11 @@ class TicketsByTopCustomersByState extends Chart implements HasWidgetOptions
             fn (Builder $query) => $query
                 ->where('authenticatable_type', $authenticatableType)
                 ->whereIntegerInRaw('authenticatable_id', $authenticatableIds)
-                ->whereNotIn('state', $this->getEndStates()),
+                ->whereNotIn('state', TicketState::endStateKeys()),
             __('Tickets by :customer', ['customer' => $name]),
         )
             ->store();
 
         $this->redirectRoute('tickets', navigate: true);
-    }
-
-    protected function getEndStates(?Collection $allStates = null): array
-    {
-        return ($allStates ?? TicketState::all())
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
     }
 }

--- a/src/Livewire/Widgets/TicketsByType.php
+++ b/src/Livewire/Widgets/TicketsByType.php
@@ -38,10 +38,7 @@ class TicketsByType extends CircleChart implements HasWidgetOptions
 
     public function calculateChart(): void
     {
-        $endStates = TicketState::all()
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TicketState::endStateKeys();
 
         $data = resolve_static(Ticket::class, 'query')
             ->whereNotIn('state', $endStates)
@@ -81,10 +78,7 @@ class TicketsByType extends CircleChart implements HasWidgetOptions
     {
         $ticketTypeId = data_get($params, 'ticket_type_id');
 
-        $endStates = TicketState::all()
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TicketState::endStateKeys();
 
         SessionFilter::make(
             Livewire::new(resolve_static(TicketList::class, 'class'))->getCacheKey(),

--- a/src/Livewire/Widgets/TicketsPerUser.php
+++ b/src/Livewire/Widgets/TicketsPerUser.php
@@ -60,10 +60,7 @@ class TicketsPerUser extends BarChart implements HasWidgetOptions
     {
         $allStates = TicketState::all();
 
-        $endStates = $allStates
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TicketState::endStateKeys();
 
         $openStates = $allStates
             ->reject(fn (string $state) => $state::$isEndState);
@@ -149,10 +146,7 @@ class TicketsPerUser extends BarChart implements HasWidgetOptions
     #[Renderless]
     public function show(array $params): void
     {
-        $endStates = TicketState::all()
-            ->filter(fn (string $state) => $state::$isEndState)
-            ->keys()
-            ->toArray();
+        $endStates = TicketState::endStateKeys();
 
         $id = data_get($params, 'id');
         $name = data_get($params, 'name');

--- a/src/Livewire/Widgets/UnassignedTickets.php
+++ b/src/Livewire/Widgets/UnassignedTickets.php
@@ -35,13 +35,7 @@ class UnassignedTickets extends MyTickets
         return resolve_static(Ticket::class, 'query')
             ->whereDoesntHave('users')
             ->with('authenticatable:id,name')
-            ->whereNotIn(
-                'state',
-                TicketState::all()
-                    ->filter(fn (string $state): bool => $state::$isEndState)
-                    ->keys()
-                    ->toArray()
-            )
+            ->whereNotIn('state', TicketState::endStateKeys())
             ->orderByRaw("state = 'escalated' DESC")
             ->orderBy('created_at')
             ->limit($this->limit + 1)

--- a/src/States/EndableState.php
+++ b/src/States/EndableState.php
@@ -5,4 +5,17 @@ namespace FluxErp\States;
 abstract class EndableState extends State
 {
     public static bool $isEndState = false;
+
+    /**
+     * The names of the states that end the lifecycle.
+     *
+     * @return array<int, string>
+     */
+    public static function endStateNames(): array
+    {
+        return static::all()
+            ->filter(fn (string $state): bool => $state::$isEndState)
+            ->keys()
+            ->toArray();
+    }
 }

--- a/src/States/EndableState.php
+++ b/src/States/EndableState.php
@@ -7,11 +7,11 @@ abstract class EndableState extends State
     public static bool $isEndState = false;
 
     /**
-     * The names of the states that end the lifecycle.
+     * The keys of the states that end the lifecycle.
      *
      * @return array<int, string>
      */
-    public static function endStateNames(): array
+    public static function endStateKeys(): array
     {
         return static::all()
             ->filter(fn (string $state): bool => $state::$isEndState)

--- a/tests/Feature/Api/UserTasksTest.php
+++ b/tests/Feature/Api/UserTasksTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use FluxErp\Models\Permission;
+use FluxErp\Models\Task;
+use FluxErp\States\Task\Done as TaskDone;
+use FluxErp\States\Task\Open as TaskOpen;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function (): void {
+    $this->tasksPermission = Permission::findOrCreate('api.user.tasks.get', 'sanctum');
+});
+
+test('the user tasks endpoint returns open tasks the user is responsible for or assigned to', function (): void {
+    $mineResponsible = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskOpen::class]);
+    $mineAssigned = Task::factory()->create(['state' => TaskOpen::class]);
+    $mineAssigned->users()->attach($this->user->id);
+    $doneMine = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskDone::class]);
+    $someoneElse = Task::factory()->create(['state' => TaskOpen::class]);
+
+    $this->user->givePermissionTo($this->tasksPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->getJson('/api/user/tasks')->assertOk();
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($mineResponsible->id, $mineAssigned->id);
+    expect($ids)->not->toContain($doneMine->id);
+    expect($ids)->not->toContain($someoneElse->id);
+    expect($response->json('data.0'))->toHaveKeys(['id', 'name', 'state', 'priority', 'due_date', 'url']);
+});

--- a/tests/Feature/Api/UserTasksTicketsTest.php
+++ b/tests/Feature/Api/UserTasksTicketsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use FluxErp\Models\Permission;
+use FluxErp\Models\Task;
+use FluxErp\Models\Ticket;
+use FluxErp\States\Task\Done as TaskDone;
+use FluxErp\States\Task\Open as TaskOpen;
+use FluxErp\States\Ticket\Closed as TicketClosed;
+use FluxErp\States\Ticket\InProgress as TicketInProgress;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function (): void {
+    $this->tasksPermission = Permission::findOrCreate('api.user.tasks.get', 'sanctum');
+    $this->ticketsPermission = Permission::findOrCreate('api.user.tickets.get', 'sanctum');
+});
+
+test('the user tasks endpoint returns open tasks the user is responsible for or assigned to', function (): void {
+    $mineResponsible = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskOpen::class]);
+    $mineAssigned = Task::factory()->create(['state' => TaskOpen::class]);
+    $mineAssigned->users()->attach($this->user->id);
+    $doneMine = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskDone::class]);
+    $someoneElse = Task::factory()->create(['state' => TaskOpen::class]);
+
+    $this->user->givePermissionTo($this->tasksPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->getJson('/api/user/tasks')->assertOk();
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($mineResponsible->id, $mineAssigned->id);
+    expect($ids)->not->toContain($doneMine->id);
+    expect($ids)->not->toContain($someoneElse->id);
+    expect($response->json('data.0'))->toHaveKeys(['id', 'name', 'state', 'url']);
+});
+
+test('the user tickets endpoint returns open tickets assigned to the user', function (): void {
+    $authenticatable = [
+        'authenticatable_type' => $this->user->getMorphClass(),
+        'authenticatable_id' => $this->user->getKey(),
+    ];
+    $mine = Ticket::factory()->create(['state' => TicketInProgress::class, ...$authenticatable]);
+    $mine->users()->attach($this->user->id);
+    $closedMine = Ticket::factory()->create(['state' => TicketClosed::class, ...$authenticatable]);
+    $closedMine->users()->attach($this->user->id);
+    $someoneElse = Ticket::factory()->create(['state' => TicketInProgress::class, ...$authenticatable]);
+
+    $this->user->givePermissionTo($this->ticketsPermission);
+    Sanctum::actingAs($this->user, ['user']);
+
+    $response = $this->getJson('/api/user/tickets')->assertOk();
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($mine->id);
+    expect($ids)->not->toContain($closedMine->id, $someoneElse->id);
+    expect($response->json('data.0'))->toHaveKeys(['id', 'ticket_number', 'title', 'state', 'url']);
+});

--- a/tests/Feature/Api/UserTicketsTest.php
+++ b/tests/Feature/Api/UserTicketsTest.php
@@ -1,36 +1,13 @@
 <?php
 
 use FluxErp\Models\Permission;
-use FluxErp\Models\Task;
 use FluxErp\Models\Ticket;
-use FluxErp\States\Task\Done as TaskDone;
-use FluxErp\States\Task\Open as TaskOpen;
 use FluxErp\States\Ticket\Closed as TicketClosed;
 use FluxErp\States\Ticket\InProgress as TicketInProgress;
 use Laravel\Sanctum\Sanctum;
 
 beforeEach(function (): void {
-    $this->tasksPermission = Permission::findOrCreate('api.user.tasks.get', 'sanctum');
     $this->ticketsPermission = Permission::findOrCreate('api.user.tickets.get', 'sanctum');
-});
-
-test('the user tasks endpoint returns open tasks the user is responsible for or assigned to', function (): void {
-    $mineResponsible = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskOpen::class]);
-    $mineAssigned = Task::factory()->create(['state' => TaskOpen::class]);
-    $mineAssigned->users()->attach($this->user->id);
-    $doneMine = Task::factory()->create(['responsible_user_id' => $this->user->id, 'state' => TaskDone::class]);
-    $someoneElse = Task::factory()->create(['state' => TaskOpen::class]);
-
-    $this->user->givePermissionTo($this->tasksPermission);
-    Sanctum::actingAs($this->user, ['user']);
-
-    $response = $this->getJson('/api/user/tasks')->assertOk();
-
-    $ids = collect($response->json('data'))->pluck('id');
-    expect($ids)->toContain($mineResponsible->id, $mineAssigned->id);
-    expect($ids)->not->toContain($doneMine->id);
-    expect($ids)->not->toContain($someoneElse->id);
-    expect($response->json('data.0'))->toHaveKeys(['id', 'name', 'state', 'url']);
 });
 
 test('the user tickets endpoint returns open tickets assigned to the user', function (): void {


### PR DESCRIPTION
Expose GET /api/user/tasks (open tasks the user is responsible for or assigned to) and GET /api/user/tickets (open tickets assigned to the user) for the Nuxbe Companion extension, normalized to id/name|title/state/url. End states are computed dynamically and the queries/orderings mirror the My-* dashboard widgets.

## Summary by Sourcery

Add authenticated user-focused task and ticket listing endpoints for use by external clients.

New Features:
- Expose GET /api/user/tasks to return non-final tasks where the authenticated user is responsible or assigned, normalized for external consumption.
- Expose GET /api/user/tickets to return non-final tickets assigned to the authenticated user, normalized with key ticket attributes and URLs.

Tests:
- Add feature tests covering authorization, filtering, and response shape for the new user tasks and tickets API endpoints.