### PR TITLE
fix: price recalculation creates missing records and override toggle resets

### DIFF
--- a/resources/views/components/product/prices.blade.php
+++ b/resources/views/components/product/prices.blade.php
@@ -1,5 +1,6 @@
 <div
     x-data="{
+        calculatedPrices: {},
         init() {
             $wire.getPriceLists().then(() =>
                 $wire.priceLists.forEach((priceList) => {
@@ -9,8 +10,21 @@
                     priceList.price_gross = $nuxbe.parseNumber(
                         priceList.price_gross,
                     );
+                    this.calculatedPrices[priceList.id] = {
+                        price_net: priceList.price_net,
+                        price_gross: priceList.price_gross,
+                    };
                 }),
             );
+        },
+        resetPrice(priceList) {
+            if (priceList.is_editable) {
+                return;
+            }
+
+            const calculated = this.calculatedPrices[priceList.id];
+            priceList.price_net = calculated?.price_net;
+            priceList.price_gross = calculated?.price_gross;
         },
         recalculate(priceList, isNet) {
             const vatRate = Number($wire.product.vat_rate?.rate_percentage);
@@ -74,6 +88,7 @@
                     <div x-show="priceList.parent">
                         <x-toggle
                             x-model.boolean="priceList.is_editable"
+                            x-on:change="resetPrice(priceList)"
                             x-bind:disabled="!isEditing"
                             label="{{ __('Override calculated price') }}"
                         />

--- a/src/Actions/Product/ProductPricesUpdate.php
+++ b/src/Actions/Product/ProductPricesUpdate.php
@@ -3,6 +3,7 @@
 namespace FluxErp\Actions\Product;
 
 use FluxErp\Actions\FluxAction;
+use FluxErp\Actions\Price\CreatePrice;
 use FluxErp\Actions\Price\UpdatePrice;
 use FluxErp\Enums\RoundingMethodEnum;
 use FluxErp\Helpers\PriceHelper;
@@ -50,16 +51,17 @@ class ProductPricesUpdate extends FluxAction
                 ->addDiscount($discount)
                 ->setPriceList($basePriceList ?? $priceList)
                 ->price();
-            $priceId = $price?->getKey();
+
+            if (! $price) {
+                continue;
+            }
+
+            $priceId = $price->getKey();
 
             if ($basePriceList) {
                 $priceId = $product->prices()
                     ->where('price_list_id', $priceList->getKey())
                     ->value('id');
-            }
-
-            if (! $priceId) {
-                continue;
             }
 
             if ($this->getData('rounding_method_enum')) {
@@ -76,8 +78,20 @@ class ProductPricesUpdate extends FluxAction
                 );
             }
 
-            UpdatePrice::make([
-                'id' => $priceId,
+            if ($priceId) {
+                UpdatePrice::make([
+                    'id' => $priceId,
+                    'product_id' => $product->id,
+                    'price_list_id' => $priceList->id,
+                    'price' => $price->price,
+                ])
+                    ->validate()
+                    ->execute();
+
+                continue;
+            }
+
+            CreatePrice::make([
                 'product_id' => $product->id,
                 'price_list_id' => $priceList->id,
                 'price' => $price->price,

--- a/tests/Feature/Actions/Product/ProductPricesUpdateTest.php
+++ b/tests/Feature/Actions/Product/ProductPricesUpdateTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use FluxErp\Actions\Product\ProductPricesUpdate;
+use FluxErp\Models\Price;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Product;
+
+test('creates price in target price list when it has no own price', function (): void {
+    $product = Product::factory()->create();
+
+    $sourcePriceList = PriceList::factory()->create(['is_net' => true]);
+    $targetPriceList = PriceList::factory()->create(['is_net' => true]);
+
+    Price::factory()->create([
+        'product_id' => $product->getKey(),
+        'price_list_id' => $sourcePriceList->getKey(),
+        'price' => 10,
+    ]);
+
+    expect(
+        $product->prices()->where('price_list_id', $targetPriceList->getKey())->exists()
+    )->toBeFalse();
+
+    ProductPricesUpdate::make([
+        'products' => [$product->getKey()],
+        'price_list_id' => $targetPriceList->getKey(),
+        'base_price_list_id' => $sourcePriceList->getKey(),
+        'rounding_method_enum' => 'none',
+        'is_percent' => false,
+        'alteration' => 0,
+    ])->validate()->execute();
+
+    $createdPrice = $product->prices()
+        ->where('price_list_id', $targetPriceList->getKey())
+        ->first();
+
+    expect($createdPrice)->not->toBeNull()
+        ->and((float) $createdPrice->price)->toBe(10.0);
+});
+
+test('still updates an existing price in the target price list', function (): void {
+    $product = Product::factory()->create();
+
+    $sourcePriceList = PriceList::factory()->create(['is_net' => true]);
+    $targetPriceList = PriceList::factory()->create(['is_net' => true]);
+
+    Price::factory()->create([
+        'product_id' => $product->getKey(),
+        'price_list_id' => $sourcePriceList->getKey(),
+        'price' => 10,
+    ]);
+
+    $existing = Price::factory()->create([
+        'product_id' => $product->getKey(),
+        'price_list_id' => $targetPriceList->getKey(),
+        'price' => 5,
+    ]);
+
+    ProductPricesUpdate::make([
+        'products' => [$product->getKey()],
+        'price_list_id' => $targetPriceList->getKey(),
+        'base_price_list_id' => $sourcePriceList->getKey(),
+        'rounding_method_enum' => 'none',
+        'is_percent' => false,
+        'alteration' => 0,
+    ])->validate()->execute();
+
+    expect((float) $existing->fresh()->price)->toBe(10.0)
+        ->and(
+            $product->prices()->where('price_list_id', $targetPriceList->getKey())->count()
+        )->toBe(1);
+});


### PR DESCRIPTION
## Product price recalculation creates missing records

The bulk price recalculation (`ProductPricesUpdate`) only updated price records that already existed in the target price list. When recalculating prices from a base price list into a target list that has no own prices (i.e. it inherits them), products were silently skipped and nothing was persisted.

Now a missing price record is created in the target price list with the calculated value instead of being skipped. Existing records are still updated as before, and products without a resolvable source price are still skipped.

Covered by `tests/Feature/Actions/Product/ProductPricesUpdateTest.php`.

## Override toggle restores the calculated price

On the product detail prices tab, enabling "Override calculated price", entering a manual value and disabling the toggle again left the entered value on screen even though it would be discarded on save. The discrepancy was only visible after a page reload.

The calculated price is now stored on load and restored in the input fields when the override toggle is disabled.

## Summary by Sourcery

Ensure bulk product price recalculation populates target price lists correctly and align the UI override toggle with the underlying calculated prices.

Bug Fixes:
- Create missing product price records in target price lists during bulk price recalculation instead of silently skipping inherited prices.
- Restore and display the original calculated prices in the product detail prices tab when the override toggle is disabled so the UI matches persisted values.

Tests:
- Add feature tests verifying that bulk price recalculation creates prices in empty target price lists and still updates existing prices correctly.