### PR TITLE
Over-fetch only keys in search instead of highlighted documents

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -57,7 +57,7 @@ class SearchController extends Controller
             $query = ! is_string($request->input('search'))
                 ? resolve_static($model, 'query')->limit(20)
                 : resolve_static($model, 'search', ['query' => $request->input('search')])
-                    ->toEloquentBuilder(perPage: $perPageSearch);
+                    ->toEloquentBuilder(highlight: [], perPage: $perPageSearch);
         } elseif ($request->has('search')) {
             $query = resolve_static($model, 'query');
             $query->where(function (Builder $query) use ($request): void {


### PR DESCRIPTION
## Problem

For any searchable model carrying a global scope, the search endpoint over-fetches **1000** Scout candidates (to apply the global scopes afterwards) and requests them through `toEloquentBuilder` with the default highlight set. Meilisearch then returns up to 1000 **fully highlighted documents** including large text fields. Measured on a live instance, a single such request peaks near the worker's memory limit, causing intermittent `Allowed memory size exhausted` 500s once an Octane worker's baseline has crept up (a reload only helps for a few minutes).

## Change

The search response only maps the resolved models (`id` / `label` / `description` / `image`) and **never reads the highlights**. So pass an empty `highlight` set to `toEloquentBuilder`. Together with the matching `getScoutResults` change (Team-Nifty-GmbH/tall-datatables#253) the over-fetch then retrieves only the primary keys.

Behaviour is unchanged: the same ids in the same relevance order, the same mapped response. Data tables are untouched (they pass their enabled columns and keep highlighting).

Depends on Team-Nifty-GmbH/tall-datatables#253 for the memory saving to take effect; harmless without it (highlights were already discarded here).

## Summary by Sourcery

Enhancements:
- Update search controller to pass an empty highlight set to the Scout Eloquent builder so only primary keys are retrieved for over-fetched results.