### PR TITLE
Gate order position save button on the product round-trip

### DIFF
--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -566,6 +566,7 @@
                                     $tsui.close.modal('edit-order-position');
                             })
                         "
+                        loading="changedProductId"
                         x-cloak
                         x-show="!$wire.order.is_locked"
                         :text="__('Save')"

--- a/tests/Livewire/Order/OrderPositionsTest.php
+++ b/tests/Livewire/Order/OrderPositionsTest.php
@@ -972,3 +972,13 @@ test('sort group names match between top level and free text children', function
     expect($groups)->not->toBeEmpty();
     expect(array_unique($groups))->toHaveCount(1, 'Sort group names must match between top level and free text children');
 });
+
+test('save button is gated on the product round-trip so it cannot submit before product_id is set', function (): void {
+    // Selecting a product fills product_id/name/unit_price/vat_rate_id via the changedProductId
+    // round-trip. The save button must be disabled while that request is in flight, otherwise
+    // addOrderPosition validates against a still-empty product_id and fails with required errors.
+    Livewire::test(OrderPositions::class, ['order' => $this->orderForm])
+        ->assertOk()
+        ->assertSeeHtml('wire:target="changedProductId"')
+        ->assertSeeHtml('wire:loading.attr="disabled"');
+});


### PR DESCRIPTION
## Problem

In the order position modal, selecting a product populates `product_id`, `name`, `unit_price` and `vat_rate_id` server-side via the `changedProductId` round-trip. `product_id` is bound with a deferred `wire:model`. If the user clicks **Save** before that round-trip resolves (an easy race when the request is slow, e.g. weight-based pricing or extra lookups), `addOrderPosition` validates an order position whose `product_id` is still empty. That produces three misleading validation errors even though a product, name, price and VAT rate are visibly selected:

- `unit_price` required (required_without_all product_id/price_list_id/price_id)
- `name` required (required_without product_id)
- `vat_rate_id` required (only enforced when no product is set)

## Change

Disable the Save button via `wire:loading.attr="disabled" wire:target="changedProductId"` so it cannot be triggered while the product round-trip is still in flight. Once `changedProductId` has applied the product data, the button re-enables and the save validates against the populated fields.

## Test

Added a regression test asserting the save button renders the loading guard targeting `changedProductId`.

## Summary by Sourcery

Tests:
- Add a regression test asserting the save button is disabled via wire:loading targeting changedProductId during the product round-trip.