### PR TITLE
Add customer-configurable Meilisearch semantic search

### DIFF
--- a/database/settings/2026_06_29_000001_create_search_settings.php
+++ b/database/settings/2026_06_29_000001_create_search_settings.php
@@ -8,7 +8,7 @@ return new class() extends SettingsMigration
     {
         $this->migrator->add('search.semantic_search_enabled', false);
         $this->migrator->add('search.embedder_url', '');
-        $this->migrator->addEncrypted('search.embedder_api_key', '');
+        $this->migrator->addEncrypted('search.embedder_api_key', null);
         $this->migrator->add('search.embedder_model', 'text-embedding-3-small');
         $this->migrator->add('search.embedder_dimensions', 1536);
         $this->migrator->add('search.semantic_ratio', 0.5);

--- a/database/settings/2026_06_29_000001_create_search_settings.php
+++ b/database/settings/2026_06_29_000001_create_search_settings.php
@@ -1,0 +1,26 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('search.semantic_search_enabled', false);
+        $this->migrator->add('search.embedder_url', '');
+        $this->migrator->addEncrypted('search.embedder_api_key', '');
+        $this->migrator->add('search.embedder_model', 'text-embedding-3-small');
+        $this->migrator->add('search.embedder_dimensions', 1536);
+        $this->migrator->add('search.semantic_ratio', 0.5);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('search.semantic_search_enabled');
+        $this->migrator->delete('search.embedder_url');
+        $this->migrator->delete('search.embedder_api_key');
+        $this->migrator->delete('search.embedder_model');
+        $this->migrator->delete('search.embedder_dimensions');
+        $this->migrator->delete('search.semantic_ratio');
+    }
+};

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -100,6 +100,7 @@ use FluxErp\Livewire\Settings\QueueMonitor;
 use FluxErp\Livewire\Settings\RecordOrigins;
 use FluxErp\Livewire\Settings\ReminderSettings;
 use FluxErp\Livewire\Settings\Scheduling;
+use FluxErp\Livewire\Settings\SearchSettings;
 use FluxErp\Livewire\Settings\SecuritySettings;
 use FluxErp\Livewire\Settings\SerialNumberRanges;
 use FluxErp\Livewire\Settings\Settings;
@@ -328,6 +329,7 @@ Route::middleware('web')
                         Route::get('/record-origins', RecordOrigins::class)->name('record-origins');
                         Route::get('/reminder-settings', ReminderSettings::class)->name('reminder-settings');
                         Route::get('/scheduling', Scheduling::class)->name('scheduling');
+                        Route::get('/search-settings', SearchSettings::class)->name('search-settings');
                         Route::get('/security-settings', SecuritySettings::class)->name('security-settings');
                         Route::get('/serial-number-ranges', SerialNumberRanges::class)->name('serial-number-ranges');
                         Route::get('/subscription-settings', SubscriptionSettings::class)->name('subscription-settings');

--- a/src/Livewire/Forms/Settings/SearchSettingsForm.php
+++ b/src/Livewire/Forms/Settings/SearchSettingsForm.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FluxErp\Livewire\Forms\Settings;
+
+use FluxErp\Settings\SearchSettings;
+use FluxErp\Support\Livewire\Attributes\RenderAs;
+
+class SearchSettingsForm extends SettingsForm
+{
+    #[RenderAs(RenderAs::TOGGLE)]
+    public bool $semantic_search_enabled = false;
+
+    public string $embedder_url = '';
+
+    #[RenderAs(RenderAs::PASSWORD)]
+    public string $embedder_api_key = '';
+
+    public string $embedder_model = 'text-embedding-3-small';
+
+    public int $embedder_dimensions = 1536;
+
+    public float $semantic_ratio = 0.5;
+
+    public function getSettingsClass(): string
+    {
+        return SearchSettings::class;
+    }
+}

--- a/src/Livewire/Forms/Settings/SearchSettingsForm.php
+++ b/src/Livewire/Forms/Settings/SearchSettingsForm.php
@@ -13,7 +13,7 @@ class SearchSettingsForm extends SettingsForm
     public string $embedder_url = '';
 
     #[RenderAs(RenderAs::PASSWORD)]
-    public string $embedder_api_key = '';
+    public ?string $embedder_api_key = null;
 
     public string $embedder_model = 'text-embedding-3-small';
 

--- a/src/Livewire/Settings/SearchSettings.php
+++ b/src/Livewire/Settings/SearchSettings.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FluxErp\Livewire\Settings;
+
+use FluxErp\Livewire\Forms\Settings\SearchSettingsForm;
+use FluxErp\Livewire\Support\SettingsComponent;
+use Illuminate\Support\Facades\Artisan;
+use Livewire\Attributes\Renderless;
+
+class SearchSettings extends SettingsComponent
+{
+    public SearchSettingsForm $searchSettingsForm;
+
+    #[Renderless]
+    public function save(): bool
+    {
+        $saved = parent::save();
+
+        // Push the updated embedder config to Meilisearch so it (re-)embeds documents.
+        if ($saved && config('scout.driver') === 'meilisearch') {
+            Artisan::queue('flux-scout:sync-index-settings');
+        }
+
+        return $saved;
+    }
+
+    protected function getFormPropertyName(): string
+    {
+        return 'searchSettingsForm';
+    }
+}

--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -139,6 +139,7 @@ class MenuServiceProvider extends ServiceProvider
                 Menu::register(route: 'settings.languages', path: 'settings.children.general.children.languages');
                 Menu::register(route: 'settings.mail-settings', path: 'settings.children.general.children.mail-settings');
                 Menu::register(route: 'settings.record-origins', path: 'settings.children.general.children.record-origins');
+                Menu::register(route: 'settings.search-settings', path: 'settings.children.general.children.search-settings');
                 Menu::register(route: 'settings.security-settings', path: 'settings.children.general.children.security-settings');
                 Menu::register(route: 'settings.serial-number-ranges', path: 'settings.children.general.children.serial-number-ranges');
                 Menu::register(route: 'settings.tags', path: 'settings.children.general.children.tags');

--- a/src/Settings/SearchSettings.php
+++ b/src/Settings/SearchSettings.php
@@ -11,7 +11,7 @@ class SearchSettings extends FluxSettings
     public string $embedder_url = '';
 
     #[ShouldBeEncrypted]
-    public string $embedder_api_key = '';
+    public ?string $embedder_api_key = null;
 
     public string $embedder_model = 'text-embedding-3-small';
 

--- a/src/Settings/SearchSettings.php
+++ b/src/Settings/SearchSettings.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FluxErp\Settings;
+
+use Spatie\LaravelSettings\Attributes\ShouldBeEncrypted;
+
+class SearchSettings extends FluxSettings
+{
+    public bool $semantic_search_enabled = false;
+
+    public string $embedder_url = '';
+
+    #[ShouldBeEncrypted]
+    public string $embedder_api_key = '';
+
+    public string $embedder_model = 'text-embedding-3-small';
+
+    public int $embedder_dimensions = 1536;
+
+    public float $semantic_ratio = 0.5;
+
+    public static function group(): string
+    {
+        return 'search';
+    }
+}

--- a/src/Traits/Scout/Searchable.php
+++ b/src/Traits/Scout/Searchable.php
@@ -6,7 +6,7 @@ use FluxErp\Settings\SearchSettings;
 use FluxErp\Support\Scout\ScoutCustomize;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Searchable as BaseSearchable;
-use Throwable;
+use Spatie\LaravelSettings\Exceptions\MissingSettings;
 
 trait Searchable
 {
@@ -20,12 +20,13 @@ trait Searchable
 
         // Semantic search: turn the keyword query into a hybrid (keyword + vector) query.
         if (config('scout.driver') === 'meilisearch' && $search = static::activeSearchSettings()) {
-            $builder->options([
+            // options() replaces, so merge to preserve any caller-provided options.
+            $builder->options(array_merge($builder->options ?? [], [
                 'hybrid' => [
                     'embedder' => 'default',
                     'semanticRatio' => $search->semantic_ratio,
                 ],
-            ]);
+            ]));
         }
 
         return $builder;
@@ -52,14 +53,16 @@ trait Searchable
     {
         try {
             $search = app(SearchSettings::class);
-        } catch (Throwable) {
+
+            if (! $search->semantic_search_enabled || $search->embedder_url === '') {
+                return null;
+            }
+        } catch (MissingSettings) {
             // Settings not migrated yet -> behave as if semantic search is off.
             return null;
         }
 
-        return ($search->semantic_search_enabled && $search->embedder_url !== '')
-            ? $search
-            : null;
+        return $search;
     }
 
     protected static function embedderDefinition(SearchSettings $search): array

--- a/src/Traits/Scout/Searchable.php
+++ b/src/Traits/Scout/Searchable.php
@@ -2,16 +2,82 @@
 
 namespace FluxErp\Traits\Scout;
 
+use FluxErp\Settings\SearchSettings;
 use FluxErp\Support\Scout\ScoutCustomize;
+use Laravel\Scout\Builder;
 use Laravel\Scout\Searchable as BaseSearchable;
+use Throwable;
 
 trait Searchable
 {
-    use BaseSearchable;
+    use BaseSearchable {
+        BaseSearchable::search as protected baseScoutSearch;
+    }
+
+    public static function search($query = '', $callback = null): Builder
+    {
+        $builder = static::baseScoutSearch($query, $callback);
+
+        // Semantic search: turn the keyword query into a hybrid (keyword + vector) query.
+        if (config('scout.driver') === 'meilisearch' && $search = static::activeSearchSettings()) {
+            $builder->options([
+                'hybrid' => [
+                    'embedder' => 'default',
+                    'semanticRatio' => $search->semantic_ratio,
+                ],
+            ]);
+        }
+
+        return $builder;
+    }
 
     public static function scoutIndexSettings(): ?array
     {
-        return config('scout.' . config('scout.driver') . '.index-settings.' . static::class);
+        $settings = config('scout.' . config('scout.driver') . '.index-settings.' . static::class) ?? [];
+
+        // Semantic search: inject (or reset via null) the Meilisearch embedder from SearchSettings.
+        if (config('scout.driver') === 'meilisearch') {
+            $settings['embedders'] = ($search = static::activeSearchSettings())
+                ? ['default' => static::embedderDefinition($search)]
+                : null;
+        }
+
+        return $settings ?: null;
+    }
+
+    /**
+     * The active SearchSettings when semantic search is usable, otherwise null.
+     */
+    protected static function activeSearchSettings(): ?SearchSettings
+    {
+        try {
+            $search = app(SearchSettings::class);
+        } catch (Throwable) {
+            // Settings not migrated yet -> behave as if semantic search is off.
+            return null;
+        }
+
+        return ($search->semantic_search_enabled && $search->embedder_url !== '')
+            ? $search
+            : null;
+    }
+
+    protected static function embedderDefinition(SearchSettings $search): array
+    {
+        return [
+            'source' => 'rest',
+            'url' => $search->embedder_url,
+            'apiKey' => $search->embedder_api_key,
+            // ponytail: dimensions must match the embedding model's output, customer-tunable knob
+            'dimensions' => $search->embedder_dimensions,
+            'request' => [
+                'model' => $search->embedder_model,
+                'input' => ['{{text}}', '{{..}}'],
+            ],
+            'response' => [
+                'data' => [['embedding' => '{{embedding}}']],
+            ],
+        ];
     }
 
     public function toSearchableArray(): array

--- a/tests/Livewire/Settings/SearchSettingsTest.php
+++ b/tests/Livewire/Settings/SearchSettingsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use FluxErp\Livewire\Settings\SearchSettings;
+use Livewire\Livewire;
+
+test('renders successfully', function (): void {
+    Livewire::test(SearchSettings::class)
+        ->assertOk();
+});

--- a/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
+++ b/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use FluxErp\Models\Country;
+use FluxErp\Settings\SearchSettings;
+
+test('injects meilisearch embedder when semantic search enabled', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake([
+        'semantic_search_enabled' => true,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+        'embedder_api_key' => 'sk-test',
+        'embedder_model' => 'text-embedding-3-small',
+        'embedder_dimensions' => 1536,
+        'semantic_ratio' => 0.5,
+    ]);
+
+    $embedder = data_get(Country::scoutIndexSettings(), 'embedders.default');
+
+    expect($embedder)->toMatchArray([
+        'source' => 'rest',
+        'url' => 'https://litellm.test/v1/embeddings',
+        'apiKey' => 'sk-test',
+        'dimensions' => 1536,
+    ]);
+    expect(data_get($embedder, 'request.model'))->toBe('text-embedding-3-small');
+});
+
+test('resets embedder to null when semantic search disabled', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake([
+        'semantic_search_enabled' => false,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+    ]);
+
+    expect(data_get(Country::scoutIndexSettings(), 'embedders'))->toBeNull();
+});
+
+test('adds hybrid search options when semantic search enabled', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake([
+        'semantic_search_enabled' => true,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+        'semantic_ratio' => 0.7,
+    ]);
+
+    $builder = Country::search('berlin');
+
+    expect(data_get($builder->options, 'hybrid'))->toMatchArray([
+        'embedder' => 'default',
+        'semanticRatio' => 0.7,
+    ]);
+});
+
+test('adds no hybrid options when semantic search disabled', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake(['semantic_search_enabled' => false]);
+
+    expect(data_get(Country::search('berlin')->options, 'hybrid'))->toBeNull();
+});


### PR DESCRIPTION
## Summary
Adds opt-in hybrid (keyword + vector) search to Meilisearch, configurable per tenant from the settings UI — no env or config changes required.

## Changes
- **`SearchSettings`** settings class (group `search`): toggle, LiteLLM embedder URL, encrypted API key, model, dimensions and semantic ratio, with a settings migration.
- **Settings GUI**: form + Livewire component (auto-rendered fields), route and menu entry under Settings → General.
- **`Searchable` trait**:
  - injects the Meilisearch `default` embedder into the index settings when enabled, and resets it to `null` when disabled — guarded to the meilisearch driver and safe before the settings migration has run.
  - `search()` turns queries into hybrid searches using the configured semantic ratio, covering both the search controller and datatable filtering.
- Saving the settings queues `flux-scout:sync-index-settings` so Meilisearch re-embeds documents.

## Notes
The embedder uses the `rest` source pointing at a LiteLLM (OpenAI-compatible) `/v1/embeddings` endpoint. Enabling on a tenant triggers a full re-embed of that tenant's documents, so roll out per customer to control embedding cost and load.

## Summary by Sourcery

Introduce tenant-configurable semantic search for Meilisearch and wire it into Scout and the settings UI.

New Features:
- Add SearchSettings settings group with semantic search toggle and embedder configuration, backed by a settings migration.
- Expose a Search Settings page in the settings UI with a Livewire form component for configuring Meilisearch semantic search per tenant.

Enhancements:
- Extend the Scout Searchable trait to configure Meilisearch embedders from settings and to perform hybrid keyword+vector searches when enabled.
- Trigger index settings synchronization in Meilisearch after saving search settings to re-embed documents as needed.

Tests:
- Add unit tests covering Meilisearch embedder injection, reset behavior, and hybrid search options based on semantic search settings.
- Add a Livewire component test to ensure the Search Settings page renders successfully.