### PR TITLE
chore(deps-dev): bump npm dev dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "@tiptap/starter-kit": "^3.27.1",
                 "@wireui/alpinejs-hold-directive": "^1.0.1",
                 "alpinejs": "^3.15.12",
-                "apexcharts": "^5.14.0",
+                "apexcharts": "^5.15.2",
                 "axios": "^1.17.0",
                 "dayjs": "^1.11.21",
                 "filepond": "^4.31.3",
@@ -45,8 +45,8 @@
                 "laravel-vite-plugin": "^3.1.0",
                 "leaflet": "^1.9.4",
                 "leaflet.markercluster": "^1.5.3",
-                "playwright": "^1.60.0",
-                "prettier": "^3.8.4",
+                "playwright": "^1.61.1",
+                "prettier": "^3.9.4",
                 "prettier-plugin-blade": "^3.1.6",
                 "prettier-plugin-tailwindcss": "^0.7.4",
                 "pusher-js": "^8.4.0-rc2",
@@ -54,7 +54,7 @@
                 "signature_pad": "^5.0.1",
                 "tailwindcss": "^4.3.1",
                 "uuid": "^14.0.1",
-                "vite": "^8.0.16"
+                "vite": "^8.1.2"
             }
         },
         "node_modules/@alpinejs/collapse": {
@@ -75,21 +75,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -98,9 +98,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -261,14 +261,14 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-            "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.2"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -280,9 +280,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.133.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-            "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+            "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -311,9 +311,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-            "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+            "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
             "cpu": [
                 "arm64"
             ],
@@ -328,9 +328,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-            "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+            "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
             "cpu": [
                 "arm64"
             ],
@@ -345,9 +345,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-            "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+            "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
             "cpu": [
                 "x64"
             ],
@@ -362,9 +362,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-            "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+            "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
             "cpu": [
                 "x64"
             ],
@@ -379,9 +379,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-            "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+            "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
             "cpu": [
                 "arm"
             ],
@@ -396,9 +396,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-            "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+            "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
             "cpu": [
                 "arm64"
             ],
@@ -413,9 +413,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-            "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+            "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
             "cpu": [
                 "arm64"
             ],
@@ -430,9 +430,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-            "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+            "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
             "cpu": [
                 "ppc64"
             ],
@@ -447,9 +447,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-            "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+            "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
             "cpu": [
                 "s390x"
             ],
@@ -464,9 +464,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-            "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+            "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
             "cpu": [
                 "x64"
             ],
@@ -481,9 +481,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-            "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+            "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
             "cpu": [
                 "x64"
             ],
@@ -498,9 +498,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-            "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+            "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
             "cpu": [
                 "arm64"
             ],
@@ -515,9 +515,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-            "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+            "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
             "cpu": [
                 "wasm32"
             ],
@@ -525,18 +525,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-            "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+            "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
             "cpu": [
                 "arm64"
             ],
@@ -551,9 +551,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-            "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+            "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
             "cpu": [
                 "x64"
             ],
@@ -1368,9 +1368,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1429,9 +1429,9 @@
             }
         },
         "node_modules/apexcharts": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.15.0.tgz",
-            "integrity": "sha512-ATswoiZi8wynKcwqf0eyE0Is5mBQoDpxZN3PlSVy41OrD+9GMBp2kZQRjyGK+5/j0GFjHkuAd7GKOrt5VMoPrw==",
+            "version": "5.15.2",
+            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.15.2.tgz",
+            "integrity": "sha512-qbd+ehDiRxo++wAqaGLmJcd683ktulTqoku4WYYyQ3XOgJIn4yhOQGV27KcdK7c2yhwxblyh4mgMm8ukI0wC0Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE"
         },
@@ -2306,9 +2306,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "dev": true,
             "funding": [
                 {
@@ -2365,13 +2365,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-            "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.61.0"
+                "playwright-core": "1.61.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -2384,9 +2384,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-            "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2397,9 +2397,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
             "dev": true,
             "funding": [
                 {
@@ -2451,9 +2451,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "version": "3.9.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+            "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2762,13 +2762,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-            "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+            "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.133.0",
+                "@oxc-project/types": "=0.137.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -2778,21 +2778,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.3",
-                "@rolldown/binding-darwin-arm64": "1.0.3",
-                "@rolldown/binding-darwin-x64": "1.0.3",
-                "@rolldown/binding-freebsd-x64": "1.0.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-                "@rolldown/binding-linux-arm64-musl": "1.0.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-musl": "1.0.3",
-                "@rolldown/binding-openharmony-arm64": "1.0.3",
-                "@rolldown/binding-wasm32-wasi": "1.0.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-                "@rolldown/binding-win32-x64-msvc": "1.0.3"
+                "@rolldown/binding-android-arm64": "1.1.3",
+                "@rolldown/binding-darwin-arm64": "1.1.3",
+                "@rolldown/binding-darwin-x64": "1.1.3",
+                "@rolldown/binding-freebsd-x64": "1.1.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+                "@rolldown/binding-linux-arm64-musl": "1.1.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-musl": "1.1.3",
+                "@rolldown/binding-openharmony-arm64": "1.1.3",
+                "@rolldown/binding-wasm32-wasi": "1.1.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+                "@rolldown/binding-win32-x64-msvc": "1.1.3"
             }
         },
         "node_modules/rope-sequence": {
@@ -2977,16 +2977,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+            "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.3",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -3003,7 +3003,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
+                "@vitejs/devtools": "^0.3.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@tiptap/starter-kit": "^3.27.1",
         "@wireui/alpinejs-hold-directive": "^1.0.1",
         "alpinejs": "^3.15.12",
-        "apexcharts": "^5.14.0",
+        "apexcharts": "^5.15.2",
         "axios": "^1.17.0",
         "dayjs": "^1.11.21",
         "filepond": "^4.31.3",
@@ -44,8 +44,8 @@
         "laravel-vite-plugin": "^3.1.0",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
-        "playwright": "^1.60.0",
-        "prettier": "^3.8.4",
+        "playwright": "^1.61.1",
+        "prettier": "^3.9.4",
         "prettier-plugin-blade": "^3.1.6",
         "prettier-plugin-tailwindcss": "^0.7.4",
         "pusher-js": "^8.4.0-rc2",
@@ -53,7 +53,7 @@
         "signature_pad": "^5.0.1",
         "tailwindcss": "^4.3.1",
         "uuid": "^14.0.1",
-        "vite": "^8.0.16"
+        "vite": "^8.1.2"
     },
     "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",


### PR DESCRIPTION
Consolidates the open dependabot npm bumps into a single PR and updates each package to its latest release.

| Package | From | To |
| --- | --- | --- |
| apexcharts | 5.14.0 | 5.15.2 |
| playwright | 1.60.0 | 1.61.1 |
| prettier | 3.8.4 | 3.9.4 |
| vite | 8.0.16 | 8.1.2 |

`prettier-plugin-blade` is intentionally held at 3.1.6. Version 3.2.2 reformats blade templates with broken indentation and would churn unrelated view files; it should be handled in its own dedicated PR.

Supersedes #1854, #1855, #1856, #1857, #1858. Frontend build passes.