### PR TITLE
fix: drop invalid X-Socket-ID request header before broadcasting

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -13,6 +13,7 @@ use FluxErp\Http\Middleware\AuthContextMiddleware;
 use FluxErp\Http\Middleware\EnsureTwoFactorSetup;
 use FluxErp\Http\Middleware\Localization;
 use FluxErp\Http\Middleware\Permissions;
+use FluxErp\Http\Middleware\SanitizeSocketId;
 use FluxErp\Http\Middleware\SetJobAuthenticatedUserMiddleware;
 use FluxErp\Livewire\Product\Product;
 use FluxErp\Mail\MailDriverManager;
@@ -285,6 +286,7 @@ class FluxServiceProvider extends ServiceProvider
 
         $kernel->appendMiddlewareToGroup('web', Localization::class);
         $kernel->appendMiddlewareToGroup('web', AuthContextMiddleware::class);
+        $kernel->appendMiddlewareToGroup('web', SanitizeSocketId::class);
 
         $this->app['router']->aliasMiddleware('2fa.setup', EnsureTwoFactorSetup::class);
         $this->app['router']->aliasMiddleware('ability', CheckForAnyAbility::class);

--- a/src/Http/Middleware/SanitizeSocketId.php
+++ b/src/Http/Middleware/SanitizeSocketId.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FluxErp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SanitizeSocketId
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $socketId = $request->headers->get('X-Socket-ID');
+
+        // Echo sends the literal string "undefined" until it has connected, which later crashes
+        // the broadcast queue in Pusher::validate_socket_id(). Same format check as Pusher itself.
+        if (! is_null($socketId) && preg_match('/\A\d+\.\d+\z/', $socketId) !== 1) {
+            $request->headers->remove('X-Socket-ID');
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Http/Middleware/SanitizeSocketIdTest.php
+++ b/tests/Feature/Http/Middleware/SanitizeSocketIdTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use FluxErp\Http\Middleware\SanitizeSocketId;
+use Illuminate\Http\Request;
+
+test('removes the literal "undefined" socket id header', function (): void {
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('X-Socket-ID', 'undefined');
+
+    app(SanitizeSocketId::class)->handle($request, function (Request $request): void {
+        expect($request->headers->has('X-Socket-ID'))->toBeFalse();
+    });
+});
+
+test('removes any malformed socket id header', function (string $value): void {
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('X-Socket-ID', $value);
+
+    app(SanitizeSocketId::class)->handle($request, function (Request $request): void {
+        expect($request->headers->has('X-Socket-ID'))->toBeFalse();
+    });
+})->with(['undefined', 'null', '', 'abc', '123', '123.']);
+
+test('keeps a valid socket id header', function (): void {
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('X-Socket-ID', '12345.67890');
+
+    app(SanitizeSocketId::class)->handle($request, function (Request $request): void {
+        expect($request->headers->get('X-Socket-ID'))->toBe('12345.67890');
+    });
+});
+
+test('passes request to next middleware', function (): void {
+    $called = false;
+    $request = Request::create('/test', 'GET');
+
+    $response = app(SanitizeSocketId::class)->handle($request, function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+    expect($response->getContent())->toBe('ok');
+});


### PR DESCRIPTION
## Problem

`Pusher\PusherException: Invalid socket ID undefined` floods the queue on production installs (3173 failed `BroadcastableModelEventOccurred` jobs on one tenant).

Livewire/Echo attaches the current socket id to every update request via the `X-Socket-ID` header. When Echo has not connected yet, its `socketId()` is `undefined` and the header arrives as the literal string `"undefined"`. Laravel captures it as the broadcast socket and serialises it onto the queued `BroadcastableModelEventOccurred` job (confirmed in the failed-job payload: `socket: "undefined"`). The queue worker then crashes in `Pusher::validate_socket_id()`, so every model broadcast fails.

## Fix

Add a `SanitizeSocketId` middleware to the `web` group that removes the `X-Socket-ID` header whenever it is not a valid socket id, mirroring Pusher's own `<digits>.<digits>` format. Invalid values (`undefined`, `null`, empty, garbage) are dropped so `Broadcast::socket()` returns `null` and the broadcast proceeds without excluding anyone — instead of poisoning the queue.

Covers all callers (web + the queued jobs they dispatch) and connect-race timing, independent of the frontend Echo configuration.

## Summary by Sourcery

Prevent invalid X-Socket-ID headers from breaking model broadcast jobs by sanitizing incoming requests.

Bug Fixes:
- Strip malformed X-Socket-ID values from web requests so queued broadcast jobs no longer fail on invalid socket IDs.

Enhancements:
- Register a SanitizeSocketId middleware in the web group to enforce valid socket ID format on all relevant requests.

Tests:
- Add feature tests covering socket ID sanitization behavior and middleware request flow.