### PR TITLE
fix: apply request where constraints to preselected search results

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -43,6 +43,8 @@ class SearchController extends Controller
                 ? $query->whereIn($optionValue, Arr::wrap($selected))
                 : $query->where($optionValue, $selected);
 
+            $this->applyRequestConstraints($query, $request, $model);
+
             return $this->formatAndDispatch($query->get(), $model, $request);
         } elseif ($request->has('search') && $isSearchable && ! $request->input('searchFields')) {
             /** @var Builder $perPageSearch */
@@ -84,6 +86,21 @@ class SearchController extends Controller
             $query->orderBy($request->input('orderBy'), $request->input('orderDirection', 'asc'));
         }
 
+        $this->applyRequestConstraints($query, $request, $model);
+
+        $result = $query->latest()->get();
+
+        if ($request->has('appends')) {
+            $result->each(function ($item) use ($request): void {
+                $item->append(array_intersect($item->getAppends(), $request->input('appends')));
+            });
+        }
+
+        return $this->formatAndDispatch($result, $model, $request);
+    }
+
+    protected function applyRequestConstraints(Builder $query, Request $request, string $model): void
+    {
         if ($request->has('where')) {
             $query->where($request->input('where'));
         }
@@ -190,16 +207,6 @@ class SearchController extends Controller
                 }
             }
         }
-
-        $result = $query->latest()->get();
-
-        if ($request->has('appends')) {
-            $result->each(function ($item) use ($request): void {
-                $item->append(array_intersect($item->getAppends(), $request->input('appends')));
-            });
-        }
-
-        return $this->formatAndDispatch($result, $model, $request);
     }
 
     protected function formatAndDispatch(Collection $result, string $model, Request $request)

--- a/tests/Feature/Web/SearchControllerTest.php
+++ b/tests/Feature/Web/SearchControllerTest.php
@@ -51,6 +51,33 @@ test('search controller returns multiple selected records including soft deleted
     $response->assertJsonFragment(['id' => $softDeletedAddress->getKey()]);
 });
 
+test('search controller applies where filter to selected records', function (): void {
+    $contact = Contact::factory()->create();
+
+    $mainAddress = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+    ]);
+
+    $response = $this->post(
+        route('search', Address::class),
+        [
+            'option-value' => 'contact_id',
+            'selected' => [$contact->getKey()],
+            'where' => [['is_main_address', '=', true]],
+        ]
+    );
+
+    $response->assertOk();
+    $response->assertJsonCount(1);
+    $response->assertJsonFragment(['id' => $mainAddress->getKey()]);
+});
+
 test('search controller maps response keys to the requested mapping', function (): void {
     $contact = Contact::factory()->create();
     $address = Address::factory()->create([


### PR DESCRIPTION
## Problem

The `SearchController` "selected" fast path (triggered when a request sends `selected` and no `search`) returned records matching only the selected option value and then returned early — skipping the `where`, `whereIn`, `whereNotIn`, scopes and every other constraint that the main search path applies.

When `option-value` points at a non-unique column (e.g. `contact_id`), `whereIn(option-value, selected)` matches multiple rows. A filter like `where: [["is_main_address", "=", true]]` was silently ignored, so a preselected async select could render a non-main or soft-deleted address instead of the intended one.

## Fix

Extract the constraint-application block into `applyRequestConstraints()` and call it on both the selected fast path and the main path. Preselected results now honor the same `where`/`whereIn`/`whereNotIn`/scope constraints as a live search. The intentional soft-delete scope removal on the selected path is preserved.

## Summary by Sourcery

Apply request-level constraints consistently to both selected and regular search paths in SearchController.

Bug Fixes:
- Ensure preselected search results respect where/whereIn/whereNotIn and scope constraints like live searches.

Enhancements:
- Refactor constraint application logic into a reusable applyRequestConstraints helper on SearchController.

Tests:
- Add a feature test to verify where filters are applied correctly to selected records in the search controller.