### PR TITLE
Exclude paid and overpaid orders from payment reminders

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1443,7 +1443,8 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
         return $query
             ->whereNotNull('invoice_number')
             ->where('is_locked', true)
-            ->where('balance', '!=', 0)
+            ->whereNotState('payment_state', Paid::class)
+            ->where('balance', '>', 0)
             ->whereHasMailablePaymentReminderAddress();
     }
 

--- a/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
+++ b/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
@@ -14,6 +14,7 @@ use FluxErp\Models\PaymentReminderText;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 use FluxErp\Settings\AccountingSettings;
+use FluxErp\States\Order\PaymentState\Paid;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
@@ -162,6 +163,64 @@ test('does not send payment reminders for orders with zero balance', function ()
     $job->handle();
 
     expect(PaymentReminder::query()->where('order_id', $paidOrder->id)->exists())->toBeFalse();
+});
+
+test('does not send payment reminders for paid orders', function (): void {
+    $paidOrder = Order::factory()
+        ->for(Currency::factory(), 'currency')
+        ->for(Language::factory(), 'language')
+        ->for(PriceList::factory(), 'priceList')
+        ->for(PaymentType::factory(), 'paymentType')
+        ->for($this->orderType, 'orderType')
+        ->state([
+            'tenant_id' => $this->dbTenant->getKey(),
+            'contact_id' => $this->contact->id,
+            'address_invoice_id' => $this->address->id,
+            'invoice_number' => Str::uuid(),
+            'is_locked' => true,
+            'balance' => 100.00,
+            'payment_reminder_current_level' => 0,
+            'payment_reminder_next_date' => now()->subDay()->toDateString(),
+        ])
+        ->create();
+
+    // Paid order with stale open balance must not be reminded
+    $paidOrder->update([
+        'balance' => 100.00,
+        'payment_state' => Paid::class,
+    ]);
+
+    $job = new AutoSendPaymentRemindersJob();
+    $job->handle();
+
+    expect(PaymentReminder::query()->where('order_id', $paidOrder->id)->exists())->toBeFalse();
+});
+
+test('does not send payment reminders for overpaid orders', function (): void {
+    $overpaidOrder = Order::factory()
+        ->for(Currency::factory(), 'currency')
+        ->for(Language::factory(), 'language')
+        ->for(PriceList::factory(), 'priceList')
+        ->for(PaymentType::factory(), 'paymentType')
+        ->for($this->orderType, 'orderType')
+        ->state([
+            'tenant_id' => $this->dbTenant->getKey(),
+            'contact_id' => $this->contact->id,
+            'address_invoice_id' => $this->address->id,
+            'invoice_number' => Str::uuid(),
+            'is_locked' => true,
+            'balance' => -100.00,
+            'payment_reminder_current_level' => 0,
+            'payment_reminder_next_date' => now()->subDay()->toDateString(),
+        ])
+        ->create();
+
+    $overpaidOrder->update(['balance' => -100.00]);
+
+    $job = new AutoSendPaymentRemindersJob();
+    $job->handle();
+
+    expect(PaymentReminder::query()->where('order_id', $overpaidOrder->id)->exists())->toBeFalse();
 });
 
 test('does not send payment reminders for not yet due orders', function (): void {


### PR DESCRIPTION
## Problem

`scopeWherePaymentReminderEligible` only checks `balance != 0`:

- Orders whose `payment_state` is already `paid` but whose balance was never zeroed out are reminded over and over.
- `balance != 0` also matches negative balances, so overpaid orders (credit in favor of the customer) receive payment reminders as well.

In production this caused an automatic reminder run to send reminders for 150 orders that were marked as paid, some of them overpaid by several thousand euros.

## Fix

- Add `whereNotState('payment_state', Paid::class)` to the eligible scope (same pattern as `scopeUnpaid`).
- Require `balance > 0` instead of `balance != 0`.

Covered by two new tests: paid order with stale positive balance and overpaid order with negative balance.

## Summary by Sourcery

Exclude paid and overpaid orders from automatic payment reminders by tightening the eligibility scope and adding regression coverage.

Bug Fixes:
- Prevent payment reminders from being sent for orders marked as paid but still showing a positive balance.
- Prevent payment reminders from being sent for overpaid orders with a negative balance.

Tests:
- Add regression tests ensuring paid orders with stale positive balances are not included in automatic payment reminders.
- Add regression tests ensuring overpaid orders with negative balances are not included in automatic payment reminders.