### PR TITLE
fix: prevent empty Meilisearch settings payload in flux-scout:sync-index-settings

### DIFF
--- a/src/Console/Commands/Scout/SyncIndexSettingsCommand.php
+++ b/src/Console/Commands/Scout/SyncIndexSettingsCommand.php
@@ -5,6 +5,7 @@ namespace FluxErp\Console\Commands\Scout;
 use FluxErp\Traits\Scout\Searchable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Scout\Console\SyncIndexSettingsCommand as BaseSyncIndexSettingsCommand;
 use Laravel\Scout\EngineManager;
@@ -45,13 +46,8 @@ class SyncIndexSettingsCommand extends BaseSyncIndexSettingsCommand
             ->toArray();
 
         foreach ($searchableModels as $model) {
-            if (! method_exists($model, 'scoutIndexSettings')) {
-                $this->error('The model [' . $model . '] does not have a "scoutIndexSettings" method.');
+            $settings = $model::scoutIndexSettings() ?? [];
 
-                continue;
-            }
-
-            $settings = $model::scoutIndexSettings();
             if (
                 config('scout.soft_delete', false)
                 && in_array(SoftDeletes::class, class_uses_recursive($model))
@@ -60,13 +56,26 @@ class SyncIndexSettingsCommand extends BaseSyncIndexSettingsCommand
                 $settings['filterableAttributes'][] = '__soft_deleted';
             }
 
-            if (is_array($settings) && count($settings)) {
-                $engine->updateIndexSettings($indexName = $this->indexName($model), $settings);
-
-                $this->info('Settings for the [' . $indexName . '] index synced successfully.');
-            } else {
-                $this->info('No settings found for the [' . $model . '] model.');
+            if ($embedders = $model::scoutEmbedders()) {
+                $settings['embedders'] = $embedders;
             }
+
+            if (! $settings) {
+                $this->info('No settings found for the [' . $model . '] model.');
+
+                continue;
+            }
+
+            $indexName = $this->indexName($model);
+
+            if (Arr::except($settings, 'embedders')) {
+                $engine->updateIndexSettings($indexName, $settings);
+            } else {
+                // Meilisearch rejects an empty settings payload, sync the embedders directly.
+                $engine->index($indexName)->updateEmbedders($settings['embedders']);
+            }
+
+            $this->info('Settings for the [' . $indexName . '] index synced successfully.');
         }
     }
 }

--- a/src/Console/Commands/Scout/SyncIndexSettingsCommand.php
+++ b/src/Console/Commands/Scout/SyncIndexSettingsCommand.php
@@ -70,9 +70,9 @@ class SyncIndexSettingsCommand extends BaseSyncIndexSettingsCommand
 
             if (Arr::except($settings, 'embedders')) {
                 $engine->updateIndexSettings($indexName, $settings);
-            } else {
+            } elseif (! empty($embedders)) {
                 // Meilisearch rejects an empty settings payload, sync the embedders directly.
-                $engine->index($indexName)->updateEmbedders($settings['embedders']);
+                $engine->index($indexName)->updateEmbedders($embedders);
             }
 
             $this->info('Settings for the [' . $indexName . '] index synced successfully.');

--- a/src/Traits/Scout/Searchable.php
+++ b/src/Traits/Scout/Searchable.php
@@ -34,16 +34,21 @@ trait Searchable
 
     public static function scoutIndexSettings(): ?array
     {
-        $settings = config('scout.' . config('scout.driver') . '.index-settings.' . static::class) ?? [];
+        return config('scout.' . config('scout.driver') . '.index-settings.' . static::class) ?: null;
+    }
 
-        // Semantic search: inject (or reset via null) the Meilisearch embedder from SearchSettings.
-        if (config('scout.driver') === 'meilisearch') {
-            $settings['embedders'] = ($search = static::activeSearchSettings())
-                ? ['default' => static::embedderDefinition($search)]
-                : null;
+    /**
+     * The Meilisearch embedders derived from SearchSettings, or null when semantic search is off.
+     */
+    public static function scoutEmbedders(): ?array
+    {
+        if (config('scout.driver') !== 'meilisearch') {
+            return null;
         }
 
-        return $settings ?: null;
+        return ($search = static::activeSearchSettings())
+            ? ['default' => static::embedderDefinition($search)]
+            : null;
     }
 
     /**

--- a/src/Traits/Scout/Searchable.php
+++ b/src/Traits/Scout/Searchable.php
@@ -14,6 +14,25 @@ trait Searchable
         BaseSearchable::search as protected baseScoutSearch;
     }
 
+    /**
+     * The Meilisearch embedders derived from SearchSettings, or null when semantic search is off.
+     */
+    public static function scoutEmbedders(): ?array
+    {
+        if (config('scout.driver') !== 'meilisearch') {
+            return null;
+        }
+
+        return ($search = static::activeSearchSettings())
+            ? ['default' => static::embedderDefinition($search)]
+            : null;
+    }
+
+    public static function scoutIndexSettings(): ?array
+    {
+        return config('scout.' . config('scout.driver') . '.index-settings.' . static::class) ?: null;
+    }
+
     public static function search($query = '', $callback = null): Builder
     {
         $builder = static::baseScoutSearch($query, $callback);
@@ -30,25 +49,6 @@ trait Searchable
         }
 
         return $builder;
-    }
-
-    public static function scoutIndexSettings(): ?array
-    {
-        return config('scout.' . config('scout.driver') . '.index-settings.' . static::class) ?: null;
-    }
-
-    /**
-     * The Meilisearch embedders derived from SearchSettings, or null when semantic search is off.
-     */
-    public static function scoutEmbedders(): ?array
-    {
-        if (config('scout.driver') !== 'meilisearch') {
-            return null;
-        }
-
-        return ($search = static::activeSearchSettings())
-            ? ['default' => static::embedderDefinition($search)]
-            : null;
     }
 
     /**

--- a/tests/Feature/Console/SyncIndexSettingsCommandTest.php
+++ b/tests/Feature/Console/SyncIndexSettingsCommandTest.php
@@ -66,6 +66,9 @@ test('syncs keyword settings and embedders together through the engine', functio
     SearchSettings::fake([
         'semantic_search_enabled' => true,
         'embedder_url' => 'https://litellm.test/v1/embeddings',
+        'embedder_api_key' => 'sk-test',
+        'embedder_model' => 'text-embedding-3-small',
+        'embedder_dimensions' => 1536,
     ]);
 
     $engine = mockScoutEngine();

--- a/tests/Feature/Console/SyncIndexSettingsCommandTest.php
+++ b/tests/Feature/Console/SyncIndexSettingsCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use FluxErp\Models\Country;
+use FluxErp\Settings\SearchSettings;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\MeilisearchEngine;
+
+function mockScoutEngine(): MeilisearchEngine|Mockery\MockInterface
+{
+    $engine = Mockery::mock(MeilisearchEngine::class);
+
+    test()->mock(EngineManager::class)
+        ->shouldReceive('engine')
+        ->andReturn($engine);
+
+    return $engine;
+}
+
+beforeEach(function (): void {
+    config(['scout.driver' => 'meilisearch']);
+});
+
+test('skips models without index settings when semantic search is disabled', function (): void {
+    SearchSettings::fake(['semantic_search_enabled' => false]);
+
+    $engine = mockScoutEngine();
+    $engine->shouldNotReceive('updateIndexSettings');
+    $engine->shouldNotReceive('index');
+
+    $this->artisan('flux-scout:sync-index-settings', ['model' => Country::class])
+        ->assertExitCode(0);
+});
+
+test('syncs embedders without sending an empty settings payload', function (): void {
+    SearchSettings::fake([
+        'semantic_search_enabled' => true,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+        'embedder_api_key' => 'sk-test',
+        'embedder_model' => 'text-embedding-3-small',
+        'embedder_dimensions' => 1536,
+    ]);
+
+    $engine = mockScoutEngine();
+    $engine->shouldNotReceive('updateIndexSettings');
+    $engine->shouldReceive('index')
+        ->once()
+        ->with(app(Country::class)->indexableAs())
+        ->andReturn($index = Mockery::mock());
+    $index->shouldReceive('updateEmbedders')
+        ->once()
+        ->withArgs(fn (array $embedders) => data_get($embedders, 'default.url')
+            === 'https://litellm.test/v1/embeddings'
+        );
+
+    $this->artisan('flux-scout:sync-index-settings', ['model' => Country::class])
+        ->assertExitCode(0);
+});
+
+test('syncs keyword settings and embedders together through the engine', function (): void {
+    config([
+        'scout.meilisearch.index-settings.' . Country::class => [
+            'filterableAttributes' => ['iso_alpha2'],
+        ],
+    ]);
+
+    SearchSettings::fake([
+        'semantic_search_enabled' => true,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+    ]);
+
+    $engine = mockScoutEngine();
+    $engine->shouldReceive('updateIndexSettings')
+        ->once()
+        ->withArgs(fn (string $index, array $settings) => data_get($settings, 'filterableAttributes') === ['iso_alpha2']
+            && data_get($settings, 'embedders.default.source') === 'rest'
+        );
+
+    $this->artisan('flux-scout:sync-index-settings', ['model' => Country::class])
+        ->assertExitCode(0);
+});

--- a/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
+++ b/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
@@ -3,7 +3,7 @@
 use FluxErp\Models\Country;
 use FluxErp\Settings\SearchSettings;
 
-test('injects meilisearch embedder when semantic search enabled', function (): void {
+test('provides meilisearch embedders when semantic search enabled', function (): void {
     config(['scout.driver' => 'meilisearch']);
 
     SearchSettings::fake([
@@ -15,7 +15,7 @@ test('injects meilisearch embedder when semantic search enabled', function (): v
         'semantic_ratio' => 0.5,
     ]);
 
-    $embedder = data_get(Country::scoutIndexSettings(), 'embedders.default');
+    $embedder = data_get(Country::scoutEmbedders(), 'default');
 
     expect($embedder)->toMatchArray([
         'source' => 'rest',
@@ -26,7 +26,7 @@ test('injects meilisearch embedder when semantic search enabled', function (): v
     expect(data_get($embedder, 'request.model'))->toBe('text-embedding-3-small');
 });
 
-test('resets embedder to null when semantic search disabled', function (): void {
+test('provides no embedders when semantic search disabled', function (): void {
     config(['scout.driver' => 'meilisearch']);
 
     SearchSettings::fake([
@@ -34,7 +34,15 @@ test('resets embedder to null when semantic search disabled', function (): void 
         'embedder_url' => 'https://litellm.test/v1/embeddings',
     ]);
 
-    expect(data_get(Country::scoutIndexSettings(), 'embedders'))->toBeNull();
+    expect(Country::scoutEmbedders())->toBeNull();
+});
+
+test('returns null index settings when nothing is configured', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake(['semantic_search_enabled' => false]);
+
+    expect(Country::scoutIndexSettings())->toBeNull();
 });
 
 test('adds hybrid search options when semantic search enabled', function (): void {


### PR DESCRIPTION
## Problem

After the 1.4.4 release, every deploy that runs `flux-scout:sync-index-settings` fails with:

```
Meilisearch\Exceptions\ApiException: Invalid value type: expected an object, but found an array: `[]`
```

Since #1853, `Searchable::scoutIndexSettings()` always returned an array containing an `embedders` key (`null` when semantic search is disabled). This caused two regressions:

- Models without configured index settings no longer returned `null`, so the command no longer skipped them. Scout's `MeilisearchEngine::updateIndexSettings()` strips the `embedders` key and calls `updateSettings([])`, which serializes to `[]` instead of an object and is rejected by Meilisearch with a 400 error.
- Model overrides using `baseScoutIndexSettings() ?? [fallback]` (Product, Category, SerialNumber, ...) never fell back to their default `filterableAttributes` anymore, silently dropping them on the next settings sync.

## Solution

- `scoutIndexSettings()` returns only the configured keyword settings again (`null` when nothing is configured), restoring the `?? [fallback]` behavior of the model overrides.
- The embedder definition is exposed via a new `scoutEmbedders()` method and injected centrally by the command after the model settings are resolved.
- When a model ends up with embedder-only settings, the command calls `updateEmbedders()` on the index directly instead of going through `updateIndexSettings()`, which would send the empty keyword settings payload.

Note: Scout never forwards `embedders => null` to Meilisearch, so disabling semantic search leaves previously synced embedders on the index. This matches the behavior before this fix and can be addressed separately if needed.

## Summary by Sourcery

Guard Meilisearch index settings syncs against empty payloads and separate semantic embedders configuration from base Scout index settings.

Bug Fixes:
- Avoid sending empty Meilisearch settings payloads when only semantic embedders are configured.
- Restore null index-settings behavior so models without configured settings are skipped and model-level fallbacks work again.

Enhancements:
- Expose Meilisearch embedders via a dedicated scoutEmbedders() API and inject them centrally during index settings sync.

Tests:
- Add unit tests for the new scoutEmbedders() behavior and for models with no configured index settings.
- Add feature tests covering sync-index-settings behavior for disabled semantic search, embedder-only syncs, and combined keyword+embedder syncs.