### PR TITLE
fix: exclude alternative positions from child order subtotal display

### DIFF
--- a/resources/views/livewire/order/create-child-order.blade.php
+++ b/resources/views/livewire/order/create-child-order.blade.php
@@ -5,6 +5,10 @@
                 return 0;
             }
 
+            if (position.is_alternative) {
+                return 0;
+            }
+
             const unitPrice = position.is_net
                 ? position.unit_net_price
                 : position.unit_gross_price;
@@ -152,6 +156,12 @@
                                                 <span>
                                                     {{ data_get($position, "name") }}
                                                 </span>
+                                                @if (data_get($position, "is_alternative"))
+                                                    <x-badge
+                                                        :text="__('Alternative')"
+                                                        color="red"
+                                                    />
+                                                @endif
                                                 <div
                                                     class="text-sm text-gray-600 dark:text-gray-400"
                                                 >

--- a/src/Livewire/Order/CreateChildOrder.php
+++ b/src/Livewire/Order/CreateChildOrder.php
@@ -241,6 +241,7 @@ class CreateChildOrder extends Component
                 'discount_percentage',
                 'is_net',
                 'is_free_text',
+                'is_alternative',
             ])
             ->whereKey(array_merge($realPositionIds, $freeTextIds))
             ->get();
@@ -259,6 +260,7 @@ class CreateChildOrder extends Component
                     'discount_percentage' => 0,
                     'is_net' => $orderPosition->is_net,
                     'is_free_text' => true,
+                    'is_alternative' => $orderPosition->is_alternative,
                     'unit_abbreviation' => null,
                 ];
 
@@ -286,6 +288,7 @@ class CreateChildOrder extends Component
                     'total_gross_price' => $orderPosition->total_gross_price,
                     'discount_percentage' => $orderPosition->discount_percentage,
                     'is_net' => $orderPosition->is_net,
+                    'is_alternative' => $orderPosition->is_alternative,
                     'unit_abbreviation' => $orderPosition->product?->unit?->abbreviation,
                 ];
             }

--- a/src/Livewire/Order/CreateChildOrder.php
+++ b/src/Livewire/Order/CreateChildOrder.php
@@ -239,9 +239,9 @@ class CreateChildOrder extends Component
                 'total_net_price',
                 'total_gross_price',
                 'discount_percentage',
-                'is_net',
-                'is_free_text',
                 'is_alternative',
+                'is_free_text',
+                'is_net',
             ])
             ->whereKey(array_merge($realPositionIds, $freeTextIds))
             ->get();
@@ -258,9 +258,9 @@ class CreateChildOrder extends Component
                     'total_net_price' => 0,
                     'total_gross_price' => 0,
                     'discount_percentage' => 0,
-                    'is_net' => $orderPosition->is_net,
-                    'is_free_text' => true,
                     'is_alternative' => $orderPosition->is_alternative,
+                    'is_free_text' => true,
+                    'is_net' => $orderPosition->is_net,
                     'unit_abbreviation' => null,
                 ];
 
@@ -287,8 +287,8 @@ class CreateChildOrder extends Component
                     'total_net_price' => $orderPosition->total_net_price,
                     'total_gross_price' => $orderPosition->total_gross_price,
                     'discount_percentage' => $orderPosition->discount_percentage,
-                    'is_net' => $orderPosition->is_net,
                     'is_alternative' => $orderPosition->is_alternative,
+                    'is_net' => $orderPosition->is_net,
                     'unit_abbreviation' => $orderPosition->product?->unit?->abbreviation,
                 ];
             }

--- a/tests/Livewire/Order/CreateChildOrderTest.php
+++ b/tests/Livewire/Order/CreateChildOrderTest.php
@@ -687,3 +687,95 @@ test('shows correct title for split order', function (): void {
 
     expect($component->instance()->getTitle())->toEqual(__('Create Split-Order'));
 });
+
+test('takeOrderPositions marks alternative positions in payload', function (): void {
+    $alternativePosition = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'vat_rate_id' => VatRate::query()->first()->getKey(),
+        'amount' => 5,
+        'signed_amount' => 5,
+        'unit_net_price' => 20,
+        'unit_gross_price' => 23.8,
+        'total_net_price' => 100,
+        'total_gross_price' => 119,
+        'is_net' => true,
+        'is_free_text' => false,
+        'is_alternative' => true,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->id,
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', [$alternativePosition->getKey()])
+        ->call('takeOrderPositions');
+
+    $positions = $component->get('replicateOrder.order_positions');
+    $payload = collect($positions)->firstWhere('id', $alternativePosition->getKey());
+
+    expect($payload)->not->toBeNull()
+        ->and(data_get($payload, 'is_alternative'))->toBeTrue();
+});
+
+test('saved retoure keeps alternative flag and excludes it from totals', function (): void {
+    $this->parentOrder->update([
+        'invoice_number' => Str::random(),
+        'shipping_costs_net_price' => 0,
+    ]);
+
+    $orderPosition = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'vat_rate_id' => VatRate::query()->first()->getKey(),
+        'amount' => 10,
+        'signed_amount' => 10,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 1000,
+        'total_gross_price' => 1190,
+        'is_net' => true,
+        'is_free_text' => false,
+        'is_alternative' => false,
+    ]);
+
+    $alternativePosition = OrderPosition::factory()->create([
+        'order_id' => $this->parentOrder->id,
+        'tenant_id' => $this->dbTenant->getKey(),
+        'vat_rate_id' => VatRate::query()->first()->getKey(),
+        'amount' => 5,
+        'signed_amount' => 5,
+        'unit_net_price' => 20,
+        'unit_gross_price' => 23.8,
+        'total_net_price' => 100,
+        'total_gross_price' => 119,
+        'is_net' => true,
+        'is_free_text' => false,
+        'is_alternative' => true,
+    ]);
+
+    $component = Livewire::test(CreateChildOrder::class, [
+        'orderId' => $this->parentOrder->id,
+        'type' => OrderTypeEnum::Retoure->value,
+    ]);
+
+    $component->set('selectedPositions', [$orderPosition->getKey(), $alternativePosition->getKey()])
+        ->call('takeOrderPositions')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $retoure = Order::query()
+        ->where('parent_id', $this->parentOrder->id)
+        ->first();
+
+    expect($retoure)->not->toBeNull();
+
+    $replicatedAlternative = $retoure->orderPositions()
+        ->where('created_from_id', $alternativePosition->getKey())
+        ->first();
+
+    expect($replicatedAlternative)->not->toBeNull()
+        ->and($replicatedAlternative->is_alternative)->toBeTrue()
+        ->and(abs((float) $retoure->total_net_price))->toEqual(1000.0);
+});

--- a/tests/Livewire/Order/CreateChildOrderTest.php
+++ b/tests/Livewire/Order/CreateChildOrderTest.php
@@ -688,21 +688,31 @@ test('shows correct title for split order', function (): void {
     expect($component->instance()->getTitle())->toEqual(__('Create Split-Order'));
 });
 
-test('takeOrderPositions marks alternative positions in payload', function (): void {
-    $alternativePosition = OrderPosition::factory()->create([
-        'order_id' => $this->parentOrder->id,
-        'tenant_id' => $this->dbTenant->getKey(),
+function createChildOrderTestPosition(int $orderId, int $tenantId, array $attributes = []): OrderPosition
+{
+    return OrderPosition::factory()->create(array_merge([
+        'order_id' => $orderId,
+        'tenant_id' => $tenantId,
         'vat_rate_id' => VatRate::query()->first()->getKey(),
+        'discount_percentage' => null,
         'amount' => 5,
         'signed_amount' => 5,
         'unit_net_price' => 20,
         'unit_gross_price' => 23.8,
         'total_net_price' => 100,
         'total_gross_price' => 119,
-        'is_net' => true,
+        'is_alternative' => false,
         'is_free_text' => false,
-        'is_alternative' => true,
-    ]);
+        'is_net' => true,
+    ], $attributes));
+}
+
+test('takeOrderPositions marks alternative positions in payload', function (): void {
+    $alternativePosition = createChildOrderTestPosition(
+        $this->parentOrder->id,
+        $this->dbTenant->getKey(),
+        ['is_alternative' => true]
+    );
 
     $component = Livewire::test(CreateChildOrder::class, [
         'orderId' => $this->parentOrder->id,
@@ -725,35 +735,24 @@ test('saved retoure keeps alternative flag and excludes it from totals', functio
         'shipping_costs_net_price' => 0,
     ]);
 
-    $orderPosition = OrderPosition::factory()->create([
-        'order_id' => $this->parentOrder->id,
-        'tenant_id' => $this->dbTenant->getKey(),
-        'vat_rate_id' => VatRate::query()->first()->getKey(),
-        'amount' => 10,
-        'signed_amount' => 10,
-        'unit_net_price' => 100,
-        'unit_gross_price' => 119,
-        'total_net_price' => 1000,
-        'total_gross_price' => 1190,
-        'is_net' => true,
-        'is_free_text' => false,
-        'is_alternative' => false,
-    ]);
+    $orderPosition = createChildOrderTestPosition(
+        $this->parentOrder->id,
+        $this->dbTenant->getKey(),
+        [
+            'amount' => 10,
+            'signed_amount' => 10,
+            'unit_net_price' => 100,
+            'unit_gross_price' => 119,
+            'total_net_price' => 1000,
+            'total_gross_price' => 1190,
+        ]
+    );
 
-    $alternativePosition = OrderPosition::factory()->create([
-        'order_id' => $this->parentOrder->id,
-        'tenant_id' => $this->dbTenant->getKey(),
-        'vat_rate_id' => VatRate::query()->first()->getKey(),
-        'amount' => 5,
-        'signed_amount' => 5,
-        'unit_net_price' => 20,
-        'unit_gross_price' => 23.8,
-        'total_net_price' => 100,
-        'total_gross_price' => 119,
-        'is_net' => true,
-        'is_free_text' => false,
-        'is_alternative' => true,
-    ]);
+    $alternativePosition = createChildOrderTestPosition(
+        $this->parentOrder->id,
+        $this->dbTenant->getKey(),
+        ['is_alternative' => true]
+    );
 
     $component = Livewire::test(CreateChildOrder::class, [
         'orderId' => $this->parentOrder->id,


### PR DESCRIPTION
## Problem

When creating a retoure or split order, the client-side subtotal and total in the create child order view included alternative positions. Order totals correctly exclude alternative positions everywhere else, so the displayed amount did not match the amount of the order that would actually be created. Alternative positions were also not recognizable as such in the selected positions list.

## Solution

- `CreateChildOrder::takeOrderPositions` now includes the `is_alternative` flag in the position payload
- The Alpine `calculatePositionTotal` helper returns 0 for alternative positions, so subtotal and total match the resulting order
- Alternative positions are marked with a badge in the selected positions list

## Summary by Sourcery

Ensure child order creation correctly handles alternative positions in both backend payloads and frontend calculations.

Bug Fixes:
- Exclude alternative positions from child order subtotal and total calculations so displayed amounts match the resulting order.
- Preserve the alternative position flag when replicating positions to created child orders.

Enhancements:
- Expose the alternative position flag in the create child order payload and visually mark such positions with a badge in the UI.

Tests:
- Add coverage to verify alternative positions are marked in the payload, retained on saved retour orders, and excluded from totals.