### PR TITLE
fix: render sub-menu notification badges for dotted route names

### DIFF
--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -121,7 +121,8 @@
                                             <span class="truncate">
                                                 {{ __($child["label"]) }}
                                             </span>
-                                            @if ($childNotificationCount = data_get($childNotificationCounts, data_get($child, 'route_name')))
+                                            {{-- plain array access: route names contain dots, data_get() would treat them as path segments --}}
+                                            @if ($childNotificationCount = $childNotificationCounts[data_get($child, 'route_name')] ?? null)
                                                 <span
                                                     class="ml-auto flex h-4 min-w-4 flex-none items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-none font-semibold text-white"
                                                 >

--- a/tests/Livewire/NavigationTest.php
+++ b/tests/Livewire/NavigationTest.php
@@ -96,3 +96,11 @@ test('navigation cache is invalidated when user permissions change', function ()
         ->test(Navigation::class)
         ->assertSee('Cache Probe Page');
 });
+
+test('renders the sub menu notification badge for dotted route names', function (): void {
+    createNavigationNotification('accounting.payment-reminders');
+
+    Livewire::actingAs($this->user)
+        ->test(Navigation::class)
+        ->assertSeeHtml('ml-auto flex h-4 min-w-4 flex-none items-center justify-center rounded-full bg-red-500');
+});


### PR DESCRIPTION
## Summary

The sub-menu notification badge lookup in the navigation view used `data_get($childNotificationCounts, $child['route_name'])`. Since every child route name contains dots (e.g. `accounting.banking`), `data_get()` treated them as nested path segments (`$counts['accounting']['banking']`) instead of a flat array key, so the lookup always returned null and sub-menu badges were never rendered — while the backend counts (covered by the existing `assertViewHas` tests) were correct all along.

Switches to plain array access with a null fallback and adds a render-level test that asserts the badge markup actually appears in the output, which the existing view-data assertions could not catch.

## Summary by Sourcery

Handle Meilisearch semantic search settings separately from Scout index settings and fix rendering of navigation submenu notification badges for dotted route names.

New Features:
- Introduce a scoutEmbedders helper to expose Meilisearch embedders independently of index settings.

Bug Fixes:
- Render submenu notification badges correctly for routes whose names contain dots.
- Avoid sending empty Meilisearch settings payloads when only embedders are configured.
- Skip syncing Scout index settings for models without any configured settings when semantic search is disabled.

Enhancements:
- Simplify scoutIndexSettings to return null when no index configuration exists.
- Extend the Scout sync index settings command to merge keyword settings and semantic embedders where both are present.

Tests:
- Add feature tests for syncing Scout index settings and Meilisearch embedders under different semantic search configurations.
- Adjust scout embedder unit tests to use the new scoutEmbedders helper and to assert null index settings when nothing is configured.
- Add a Livewire navigation test that asserts submenu notification badge markup is rendered for dotted route names.