### PR TITLE
fix(comments): resync modelId for non-$parent-prefixed wire:model bindings

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -73,8 +73,13 @@ const resolveModelId = (el) => () => {
         .find((name) => name.startsWith('wire:model'));
     const binding = bindingAttr ? root.getAttribute(bindingAttr) : null;
 
-    if (binding?.startsWith('$parent.') && wire?.$parent) {
-        const value = wire.$parent.get(binding.slice('$parent.'.length));
+    if (binding && wire?.$parent) {
+        // wire:model on a child component is evaluated in the parent's scope,
+        // whether or not it carries an explicit "$parent." prefix.
+        const prop = binding.startsWith('$parent.')
+            ? binding.slice('$parent.'.length)
+            : binding;
+        const value = wire.$parent.get(prop);
 
         if (value !== undefined && value !== null) {
             return value;


### PR DESCRIPTION
## Problem

Components that use the `$resolveModelId` Alpine magic (comments, folder tree) stay stale after a renderless parent swaps the bound record.

The resolver only read the bound value from the parent component when the `wire:model` expression carried an explicit `$parent.` prefix. For a regular modelable binding such as

```blade
<livewire:accounting.transactions.comments wire:model="transactionForm.id" ... />
```

it fell back to `wire.get('modelId')` — the child's own stale value. The resolved value therefore always equaled `$wire.modelId`, the IntersectionObserver in the comments component never re-assigned it, and the comments list stayed empty (or showed the previous record's comments) after switching records.

## Fix

A `wire:model` expression compiled onto a child component's root element is always evaluated in the parent's scope — that is how `#[Modelable]` binding works, with or without an explicit `$parent.` prefix. The resolver now reads the value from the parent whenever a binding exists and a parent component is present, stripping an optional `$parent.` prefix from the path, and only falls back to the child's own `modelId` otherwise.

All in-repo consumers were checked: every comments/attachments/media tab binds a parent-scoped dot path (`order.id`, `contact.id`, `transactionForm.id`, `leadForm.id`, ...), so reading from the parent is correct for each of them. The signature-public-link comments component has no `wire:model` binding and keeps using its own `modelId` via the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix stale modelId resolution for comments and similar components when using non-$parent-prefixed wire:model bindings on child components.