### PR TITLE
make flux table sortable

### DIFF
--- a/resources/views/components/table/index.blade.php
+++ b/resources/views/components/table/index.blade.php
@@ -1,6 +1,6 @@
 {{ $title ?? '' }}
 <div
-    {{ $attributes->merge(['class' => 'mt-3 flex flex-col'])->except('wire:sortable') }}
+    {{ $attributes->merge(['class' => 'mt-3 flex flex-col'])->except(['wire:sort', 'x-sort']) }}
 >
     <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
@@ -17,7 +17,8 @@
                     </thead>
                     <tbody
                         class="relative"
-                        {{ $attributes->thatStartWith('wire:sortable') }}
+                        {{ $attributes->thatStartWith('wire:sort') }}
+                        {{ $attributes->thatStartWith('x-sort') }}
                     >
                         {{ $slot ?? '' }}
                     </tbody>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Relax table container attribute filtering to allow both Livewire wire:sort and Alpine x-sort attributes to pass through to the tbody for sortable tables.