### PR TITLE
feat(media): allow authenticated users to access private media without a signature

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -382,8 +382,9 @@ Route::middleware('web')
                 ->defaults('html', false);
         });
 
-        Route::middleware('signed')->group(function (): void {
+        Route::group([], function (): void {
             Route::get('/media-private/{media}/{filename}', PrivateMediaController::class)
+                ->middleware('media.signed')
                 ->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {
@@ -413,6 +414,7 @@ Route::middleware('web')
                     ['Content-Disposition' => $disposition],
                 );
             })
+                ->middleware('media.signed')
                 ->name('media.show');
 
             Route::get('/media-collection-download/{token}', function (string $token) {
@@ -429,6 +431,7 @@ Route::middleware('web')
                     ['Content-Type' => 'application/zip'],
                 );
             })
+                ->middleware('signed')
                 ->name('media-collection.download');
         });
     });

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -366,7 +366,7 @@ Route::middleware('web')
             })->name('media');
         });
 
-        Route::group(['middleware' => ['auth:web']], function (): void {
+        Route::middleware('auth:web')->group(function (): void {
             Route::any('/search/{model?}', SearchController::class)
                 ->where('model', '(.*)')
                 ->name('search');
@@ -382,9 +382,8 @@ Route::middleware('web')
                 ->defaults('html', false);
         });
 
-        Route::group([], function (): void {
+        Route::middleware('media.signed')->group(function (): void {
             Route::get('/media-private/{media}/{filename}', PrivateMediaController::class)
-                ->middleware('media.signed')
                 ->name('media.private');
 
             Route::get('/media/{media}', function (Media $media) {
@@ -414,9 +413,10 @@ Route::middleware('web')
                     ['Content-Disposition' => $disposition],
                 );
             })
-                ->middleware('media.signed')
                 ->name('media.show');
+        });
 
+        Route::middleware('signed')->group(function (): void {
             Route::get('/media-collection-download/{token}', function (string $token) {
                 $payload = Crypt::decrypt($token);
 
@@ -431,7 +431,6 @@ Route::middleware('web')
                     ['Content-Type' => 'application/zip'],
                 );
             })
-                ->middleware('signed')
                 ->name('media-collection.download');
         });
     });

--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -10,6 +10,7 @@ use FluxErp\Helpers\Livewire\Features\SupportFormObjects;
 use FluxErp\Helpers\MediaLibraryDownloader;
 use FluxErp\Http\Controllers\AuthenticateUsingPasskeyController;
 use FluxErp\Http\Middleware\AuthContextMiddleware;
+use FluxErp\Http\Middleware\AuthenticatedUserMediaOrSignature;
 use FluxErp\Http\Middleware\EnsureTwoFactorSetup;
 use FluxErp\Http\Middleware\Localization;
 use FluxErp\Http\Middleware\Permissions;
@@ -290,6 +291,7 @@ class FluxServiceProvider extends ServiceProvider
 
         $this->app['router']->aliasMiddleware('2fa.setup', EnsureTwoFactorSetup::class);
         $this->app['router']->aliasMiddleware('ability', CheckForAnyAbility::class);
+        $this->app['router']->aliasMiddleware('media.signed', AuthenticatedUserMediaOrSignature::class);
         $this->app['router']->aliasMiddleware('localization', Localization::class);
         $this->app['router']->aliasMiddleware('permission', Permissions::class);
         $this->app['router']->aliasMiddleware('role', RoleMiddleware::class);

--- a/src/Http/Middleware/AuthenticatedUserMediaOrSignature.php
+++ b/src/Http/Middleware/AuthenticatedUserMediaOrSignature.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Auth;
 
 class AuthenticatedUserMediaOrSignature
 {
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
         // Guests (and embeds) keep the signed-URL contract.
         if ($request->hasValidSignature()) {
@@ -19,15 +19,20 @@ class AuthenticatedUserMediaOrSignature
 
         // Internal users already have full access to private media. Portal logins
         // (Address) and any other authenticatable still require a valid signature.
-        if (Auth::user() instanceof User) {
+        if (is_a(Auth::user(), resolve_static(User::class, 'class'))) {
             $media = $request->route('media');
-            $mediaId = $media instanceof Media ? $media->getKey() : $media;
+
+            // Route model binding resolves through the container and has therefore
+            // already applied any global scopes - no extra query needed.
+            if (is_a($media, resolve_static(Media::class, 'class'))) {
+                return $next($request);
+            }
 
             // The exists query honours any global scope a customer registers on Media
             // to restrict visibility. In core default there is no such scope, so any
             // user passes - matching the current behaviour for internal users.
             abort_unless(
-                resolve_static(Media::class, 'query')->whereKey($mediaId)->exists(),
+                resolve_static(Media::class, 'query')->whereKey($media)->exists(),
                 404,
             );
 

--- a/src/Http/Middleware/AuthenticatedUserMediaOrSignature.php
+++ b/src/Http/Middleware/AuthenticatedUserMediaOrSignature.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FluxErp\Http\Middleware;
+
+use Closure;
+use FluxErp\Models\Media;
+use FluxErp\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthenticatedUserMediaOrSignature
+{
+    public function handle(Request $request, Closure $next)
+    {
+        // Guests (and embeds) keep the signed-URL contract.
+        if ($request->hasValidSignature()) {
+            return $next($request);
+        }
+
+        // Internal users already have full access to private media. Portal logins
+        // (Address) and any other authenticatable still require a valid signature.
+        if (Auth::user() instanceof User) {
+            $media = $request->route('media');
+            $mediaId = $media instanceof Media ? $media->getKey() : $media;
+
+            // The exists query honours any global scope a customer registers on Media
+            // to restrict visibility. In core default there is no such scope, so any
+            // user passes - matching the current behaviour for internal users.
+            abort_unless(
+                resolve_static(Media::class, 'query')->whereKey($mediaId)->exists(),
+                404,
+            );
+
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/tests/Feature/Web/PrivateMediaTest.php
+++ b/tests/Feature/Web/PrivateMediaTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use FluxErp\Models\Address;
 use FluxErp\Models\Media;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -46,9 +49,47 @@ test('signed route with conversion query serves the conversion file', function (
     expect($response->streamedContent())->toBe('fake-thumb-bytes');
 });
 
-test('unsigned request to the private route is rejected', function (): void {
+test('guest with a valid signature is served without authentication', function (): void {
+    $this->actingAsGuest();
+
+    $url = URL::temporarySignedRoute('media.private', now()->addMinutes(5), [
+        'media' => $this->media->getKey(),
+        'filename' => $this->filename,
+    ]);
+
+    $this->get($url)->assertOk();
+});
+
+test('guest without a valid signature is rejected', function (): void {
+    $this->actingAsGuest();
+
     $this->get('/media-private/' . $this->media->getKey() . '/' . $this->filename)
         ->assertStatus(403);
+});
+
+test('authenticated user is served without a signature', function (): void {
+    $this->get('/media-private/' . $this->media->getKey() . '/' . $this->filename)
+        ->assertOk();
+});
+
+test('authenticated non-user is rejected without a signature', function (): void {
+    $this->be(new Address(), 'web');
+
+    $this->get('/media-private/' . $this->media->getKey() . '/' . $this->filename)
+        ->assertStatus(403);
+});
+
+test('authenticated user is denied when a global scope hides the media', function (): void {
+    Media::addGlobalScope('test_hide_media', function (Builder $query): void {
+        $query->whereRaw('1 = 0');
+    });
+
+    try {
+        $this->get('/media-private/' . $this->media->getKey() . '/' . $this->filename)
+            ->assertNotFound();
+    } finally {
+        Model::clearBootedModels();
+    }
 });
 
 test('signed route with conversion query 404s when the conversion is not generated', function (): void {


### PR DESCRIPTION
Private media are served through the `media.private` (`/media-private/{media}/{filename}`) and `media.show` (`/media/{media}`) routes, which previously required a valid signed URL for every request.

## Behavior

A new `AuthenticatedUserMediaOrSignature` middleware (aliased `media.signed`) now gates both routes:

- A request with a **valid signature** is served, unchanged. This preserves the guest / embed / e-mail-link flow.
- An **authenticated `FluxErp\Models\User`** is served **without a signature**. Internal users already have full access to private media today, so requiring a signature for them added no security value.
- Any **other authenticatable** (portal `Address` logins, etc.) and **guests without a valid signature** are rejected with `403`.

## Security model

The `instanceof User` check is the authorization guard: only internal users get the signature bypass; portal `Address` sessions still need a valid signature.

For an authenticated user the route media id is resolved against a scoped exists query on `Media` (`resolve_static(Media::class, query)->whereKey($id)->exists()`). Core registers no visibility scope on `Media`, so any user passes, matching current behavior. This query is the extension point: a customer can register their own global scope on `Media` to restrict visibility, and a hidden media then returns `404`.

`media-collection.download` is unrelated (token-based, not media-bound) and keeps the plain `signed` middleware.

## Tests

`tests/Feature/Web/PrivateMediaTest.php` covers: guest with a valid signature (served), guest without a signature (403), authenticated user without a signature (served), authenticated non-user without a signature (403), and an authenticated user denied (404) when a global scope hides the media.

## Summary by Sourcery

Allow authenticated internal users to access private media without signed URLs while preserving signature-based access for guests and non-user authenticatables.

New Features:
- Introduce AuthenticatedUserMediaOrSignature middleware to gate private media routes based on either a valid signature or an authenticated internal user.
- Allow private media routes to bypass URL signatures for authenticated FluxErp\Models\User instances while still enforcing signatures for other actors.

Enhancements:
- Wire the new media.signed middleware into media.private and media.show routes and keep media-collection.download on the existing signed middleware.
- Ensure private media visibility respects customizable global scopes on the Media model, returning 404 when media is hidden.

Tests:
- Expand private media feature tests to cover guest signature access, unauthenticated rejection, internal user access without signatures, non-user rejection, and 404 behavior when a global Media scope hides the resource.