### PR TITLE
Fix unreachable cancellation confirmation mail dialog on subscription orders

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2684,6 +2684,7 @@
     "The given route does not exist.": "Die angegebene Route existiert nicht.",
     "The given route is missing required parameters.": "Der angegebenen Route fehlen erforderliche Parameter.",
     "The login link is invalid or has expired.": "Der Anmeldelink ist ungültig oder abgelaufen.",
+    "The mail data is no longer available, please try again.": "Die E-Mail-Daten sind nicht mehr verfügbar, bitte versuche es erneut.",
     "The main record must not be in the merge records.": "Der Hauptdatensatz darf nicht in den zusammenzuführenden Datensätzen sein.",
     "The media collection is read-only and cannot be modified.": "Die Mediensammlung ist schreibgeschützt und kann nicht geändert werden.",
     "The number has already been taken for this type.": "Die Nummer wurde bereits für diesen Typ vergeben.",

--- a/resources/views/livewire/order/subscription.blade.php
+++ b/resources/views/livewire/order/subscription.blade.php
@@ -497,13 +497,13 @@
     <x-modal
         id="cancel-subscription"
         :title="__('Cancel Subscription')"
-        x-on:close="cancellationType = '{{ \FluxErp\Enums\SubscriptionCancellationTypeEnum::NextPeriod->value }}'; generateDocument = true; sendEmail = false"
+        x-on:close="cancellationType = '{{ \FluxErp\Enums\SubscriptionCancellationTypeEnum::NextPeriod->value }}'; generateDocument = {{ $canCreateCancellationConfirmation ? 'true' : 'false' }}; sendEmail = false"
     >
         <div
             x-data="{
                 cancellationType:
                     '{{ \FluxErp\Enums\SubscriptionCancellationTypeEnum::NextPeriod->value }}',
-                generateDocument: true,
+                generateDocument: {{ $canCreateCancellationConfirmation ? 'true' : 'false' }},
                 sendEmail: false,
                 get effectiveEndDate() {
                     const schedule = $wire.schedule
@@ -643,19 +643,19 @@
                 </p>
             </div>
 
-            <div class="flex flex-col gap-2 border-t pt-4">
-                <x-label :label="__('Options')" />
-                <x-toggle
-                    x-model="generateDocument"
-                    :label="__('Generate cancellation confirmation')"
-                />
-                <div x-cloak x-show="generateDocument" class="ml-6">
+            @if ($canCreateCancellationConfirmation)
+                <div class="flex flex-col gap-2 border-t pt-4">
+                    <x-label :label="__('Options')" />
+                    <x-toggle
+                        x-model="generateDocument"
+                        :label="__('Generate cancellation confirmation')"
+                    />
                     <x-toggle
                         x-model="sendEmail"
                         :label="__('Send confirmation by email')"
                     />
                 </div>
-            </div>
+            @endif
             <div class="flex justify-end gap-2 border-t pt-4">
                 <x-button
                     color="secondary"

--- a/src/Livewire/EditMail.php
+++ b/src/Livewire/EditMail.php
@@ -145,6 +145,14 @@ class EditMail extends Component
     {
         $data = session()->get($key);
 
+        if (blank($data)) {
+            $this->toast()
+                ->error(__('The mail data is no longer available, please try again.'))
+                ->send();
+
+            return;
+        }
+
         if (Arr::isAssoc($data) || count($data) === 1) {
             $data = count($data) === 1 && Arr::isList($data) ? $data[0] : $data;
             session()->forget($key);

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -162,6 +162,9 @@ class Order extends Component
                     ->where('is_tax_exemption', true)
                     ->get(['id', 'name'])
                     ->toArray(),
+                'canCreateCancellationConfirmation' => $this->view === 'flux::livewire.order.'
+                        . OrderTypeEnum::Subscription->value
+                    && array_key_exists('cancellation-confirmation', $this->getPrintLayouts()),
             ]
         );
     }
@@ -862,12 +865,12 @@ class Order extends Component
                 ->validate()
                 ->execute();
 
-            if ($generateDocument) {
+            if ($generateDocument || $sendEmail) {
                 $this->selectedPrintLayouts = [
                     'print' => [],
                     'email' => $sendEmail ? ['cancellation-confirmation'] : [],
                     'download' => [],
-                    'force' => ['cancellation-confirmation'],
+                    'force' => $generateDocument ? ['cancellation-confirmation'] : [],
                 ];
 
                 $this->createDocumentFromItems($order);

--- a/tests/Livewire/EditMailTest.php
+++ b/tests/Livewire/EditMailTest.php
@@ -51,3 +51,29 @@ test('batch send merge logic preserves individual communicatables and attachment
         expect($mergedData[$index]['subject'])->toBe('Edited Subject');
     }
 });
+
+test('create from session fills mail message from session data', function (): void {
+    $key = 'mail_' . str()->uuid()->toString();
+    session()->put($key, [
+        [
+            'to' => ['customer@example.com'],
+            'subject' => 'Cancellation Confirmation',
+            'html_body' => '<p>Test</p>',
+        ],
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(EditMail::class)
+        ->call('createFromSession', $key)
+        ->assertOk()
+        ->assertSet('mailMessage.subject', 'Cancellation Confirmation');
+
+    expect(session()->has($key))->toBeFalse();
+});
+
+test('create from session with already consumed key fails gracefully', function (): void {
+    Livewire::actingAs($this->user)
+        ->test(EditMail::class)
+        ->call('createFromSession', 'mail_' . str()->uuid()->toString())
+        ->assertOk();
+});

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -574,7 +574,24 @@ test('renders subscription order view', function (): void {
 
     Livewire::test(OrderView::class, ['id' => $this->order->id])
         ->assertOk()
-        ->assertViewIs('flux::livewire.order.subscription');
+        ->assertViewIs('flux::livewire.order.subscription')
+        ->assertViewHas('canCreateCancellationConfirmation', false);
+});
+
+test('subscription view offers cancellation confirmation when print layout is enabled', function (): void {
+    $subscriptionOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Subscription,
+        'is_active' => true,
+        'is_hidden' => false,
+        'print_layouts' => ['cancellation-confirmation'],
+    ]);
+
+    $this->order->update(['order_type_id' => $subscriptionOrderType->id]);
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->assertOk()
+        ->assertViewIs('flux::livewire.order.subscription')
+        ->assertViewHas('canCreateCancellationConfirmation', true);
 });
 
 test('renders successfully', function (): void {
@@ -798,6 +815,74 @@ test('cancel subscription next period sets ends_at to due date', function (): vo
     expect($schedule)
         ->is_active->toBeTrue()
         ->and($schedule->ends_at->toDateTimeString())->toBe($dueAt->toDateTimeString());
+});
+
+test('cancel subscription with send email opens the mail dialog', function (): void {
+    $subscriptionOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Subscription,
+        'is_active' => true,
+        'is_hidden' => false,
+        'print_layouts' => ['cancellation-confirmation'],
+    ]);
+
+    $targetOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+
+    $this->order->update(['order_type_id' => $subscriptionOrderType->id]);
+
+    $component = Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->set([
+            'schedule.parameters.orderTypeId' => $targetOrderType->id,
+            'schedule.parameters.orderId' => $this->order->id,
+            'schedule.cron.methods.basic' => 'monthlyOn',
+            'schedule.cron.parameters.basic' => ['1', '00:00', null],
+        ])
+        ->call('saveSchedule')
+        ->assertReturned(true);
+
+    $component
+        ->call('cancelSubscription', 'immediate', true, true)
+        ->assertReturned(true)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertDispatched('createFromSession');
+});
+
+test('cancel subscription generating document only does not open the mail dialog', function (): void {
+    $subscriptionOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Subscription,
+        'is_active' => true,
+        'is_hidden' => false,
+        'print_layouts' => ['cancellation-confirmation'],
+    ]);
+
+    $targetOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+
+    $this->order->update(['order_type_id' => $subscriptionOrderType->id]);
+
+    $component = Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->set([
+            'schedule.parameters.orderTypeId' => $targetOrderType->id,
+            'schedule.parameters.orderId' => $this->order->id,
+            'schedule.cron.methods.basic' => 'monthlyOn',
+            'schedule.cron.parameters.basic' => ['1', '00:00', null],
+        ])
+        ->call('saveSchedule')
+        ->assertReturned(true);
+
+    $component
+        ->call('cancelSubscription', 'immediate', true, false)
+        ->assertReturned(true)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertNotDispatched('createFromSession');
 });
 
 test('switch tabs', function (): void {


### PR DESCRIPTION
## Problem

Cancelling a subscription with the cancellation confirmation options produced nothing visible: the mail dialog never opened, even though the user expected EditMail to open with the confirmation attached.

Root cause: the cancel modal wired the mail dialog **exclusively to the nested "Send by email" toggle**. The outer "Generate cancellation confirmation" toggle only queued the PDF (`force` layout). `collectMailMessages()` returns early when no `email` layout is selected, so with only the outer toggle active no mail message was ever built and EditMail stayed closed. No error was logged because the early return is intentional.

Two secondary issues:
- The toggles were shown even when the order type had no `cancellation-confirmation` print layout, so `resolvePrintViews()` dropped the view and confirming did nothing.
- The "Send by email" toggle was nested/indented under "Generate", which read poorly.

## Fix

- **Make both toggles independent and flat.** Generating the document queues the PDF; sending by email opens EditMail with the confirmation attached. `cancelSubscription()` now creates the document when *either* option is set and only forces the PDF layout when the document toggle is on.
- **Gate the toggles** behind a new `canCreateCancellationConfirmation` view flag, so they only appear when the order type has the `cancellation-confirmation` print layout enabled (subscription view only).
- **Guard the handoff key** in `EditMail::createFromSession()`: a stale or already-consumed key now surfaces a retriable toast instead of a fatal `Arr::isAssoc(null)` TypeError (this was seen once in production). The handoff stays in the **session** (per-user scoped) as intended.

## Tests

- `Order`: cancelling with "send email" dispatches the mail dialog (`createFromSession`); cancelling with only the document toggle does not.
- `Order`: subscription view exposes `canCreateCancellationConfirmation` false by default, true when the print layout is enabled.
- `EditMail`: handoff from the session fills the mail message and consumes the key; an already-consumed key fails gracefully.