### PR TITLE
Speed up IMAP sync: reconcile read status via UID search

### DIFF
--- a/src/Mail/ImapMailSyncDriver.php
+++ b/src/Mail/ImapMailSyncDriver.php
@@ -30,12 +30,7 @@ class ImapMailSyncDriver implements MailSyncDriver, ReportsSyncProgress
 
         $builder->fetchAndStore();
 
-        $builder
-            ->reset()
-            ->unseen()
-            ->withoutBody()
-            ->fetch()
-            ->syncReadStatus();
+        $builder->syncReadStatus();
     }
 
     public function testConnection(MailAccount $account): bool

--- a/src/Mail/ImapMessageBuilder.php
+++ b/src/Mail/ImapMessageBuilder.php
@@ -149,11 +149,11 @@ class ImapMessageBuilder
 
     public function syncReadStatus(): static
     {
-        $unreadUids = $this->messages
-            ->reject(fn (ImapMessage $message) => $message->isSeen)
-            ->map(fn (ImapMessage $message) => $message->uid)
-            ->values()
-            ->toArray();
+        $unreadUids = $this->resolveUnseenUids();
+
+        if (is_null($unreadUids)) {
+            return $this;
+        }
 
         resolve_static(Communication::class, 'query')
             ->where('mail_account_id', $this->folder->mailAccount->getKey())
@@ -208,6 +208,43 @@ class ImapMessageBuilder
         }
 
         return $client->getFolderByPath($this->folder->slug, utf7: true);
+    }
+
+    /**
+     * Return the UIDs of the currently unseen messages on the server, or null
+     * when the state could not be determined.
+     *
+     * Uses a plain IMAP SEARCH (a single round-trip returning only UIDs) instead
+     * of fetching full message objects, so the read-status reconciliation no
+     * longer scales with the number of unseen mails times a per-message fetch.
+     *
+     * Returns null (not an empty array) when the folder cannot be resolved or
+     * the search fails, so the caller can skip reconciliation instead of
+     * treating the failure as "nothing is unseen".
+     *
+     * @return array<int, int>|null
+     */
+    protected function resolveUnseenUids(): ?array
+    {
+        $imapFolder = $this->resolveImapFolder();
+
+        if (! $imapFolder) {
+            return null;
+        }
+
+        try {
+            return $imapFolder->messages()
+                ->setFetchBody(false)
+                ->leaveUnread()
+                ->unseen()
+                ->since($this->folder->mailAccount->created_at)
+                ->search()
+                ->map(fn (mixed $uid): int => (int) $uid)
+                ->values()
+                ->toArray();
+        } catch (ResponseException) {
+            return null;
+        }
     }
 
     protected function fetchNewMessages(Folder $imapFolder, ?Closure $onMessage = null): void

--- a/tests/Unit/Mail/ImapMessageBuilderTest.php
+++ b/tests/Unit/Mail/ImapMessageBuilderTest.php
@@ -88,15 +88,81 @@ test('reports progress for each stored message', function (): void {
     expect($progress)->toBe([[1, 2], [2, 2]]);
 });
 
+test('syncReadStatus reconciles db read status against the server unseen uids', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory())
+        ->create();
+    $folder = $mailAccount->mailFolders->first();
+
+    $base = [
+        'mail_account_id' => $mailAccount->getKey(),
+        'mail_folder_id' => $folder->getKey(),
+        'communication_type_enum' => 'mail',
+    ];
+
+    // seen in db, not unseen on server -> stays seen
+    $staysSeen = Communication::factory()->create($base + ['message_uid' => '41', 'is_seen' => true]);
+    // seen in db, unseen on server -> becomes unseen
+    $becomesUnseen = Communication::factory()->create($base + ['message_uid' => '42', 'is_seen' => true]);
+    // unseen in db, no longer unseen on server -> becomes seen
+    $becomesSeen = Communication::factory()->create($base + ['message_uid' => '43', 'is_seen' => false]);
+
+    makeTestableBuilder($folder)
+        ->setUnseenUids([42])
+        ->syncReadStatus();
+
+    expect($staysSeen->refresh()->is_seen)->toBeTrue()
+        ->and($becomesUnseen->refresh()->is_seen)->toBeFalse()
+        ->and($becomesSeen->refresh()->is_seen)->toBeTrue();
+});
+
+test('syncReadStatus leaves read status untouched when the unseen uids cannot be determined', function (): void {
+    $mailAccount = MailAccount::factory()
+        ->has(MailFolder::factory())
+        ->create();
+    $folder = $mailAccount->mailFolders->first();
+
+    $base = [
+        'mail_account_id' => $mailAccount->getKey(),
+        'mail_folder_id' => $folder->getKey(),
+        'communication_type_enum' => 'mail',
+    ];
+
+    $seen = Communication::factory()->create($base + ['message_uid' => '41', 'is_seen' => true]);
+    $unseen = Communication::factory()->create($base + ['message_uid' => '42', 'is_seen' => false]);
+
+    makeTestableBuilder($folder)
+        ->setUnseenUids(null)
+        ->syncReadStatus();
+
+    expect($seen->refresh()->is_seen)->toBeTrue()
+        ->and($unseen->refresh()->is_seen)->toBeFalse();
+});
+
 function makeTestableBuilder(MailFolder $folder): ImapMessageBuilder
 {
     return new class($folder) extends ImapMessageBuilder
     {
+        /** @var array<int, int>|null */
+        public ?array $unseenUids = [];
+
         public function pushMessage(ImapMessage $message): static
         {
             $this->messages->push($message);
 
             return $this;
+        }
+
+        public function setUnseenUids(?array $uids): static
+        {
+            $this->unseenUids = $uids;
+
+            return $this;
+        }
+
+        protected function resolveUnseenUids(): ?array
+        {
+            return $this->unseenUids;
         }
     };
 }


### PR DESCRIPTION
## Problem

An IMAP mail sync took ~10 minutes per run on a real account. Instrumented timing on production pinned it down: almost the entire time was the read-status pass on the INBOX (613s of a ~10 min sync; every other folder and the incremental new-mail fetch were 1-3s each).

`ImapMailSyncDriver::syncMessages()` runs two passes per folder:
1. Incremental fetch of new messages since the highest stored UID (`getByUidGreater`) — fast and correct.
2. A read-status reconciliation that called `->unseen()->withoutBody()->fetch()->syncReadStatus()`.

Pass 2 was the problem. `fetch()` built a full `ImapMessage` object for **every unseen message in the folder, since the account was created**, on **every** sync — pulling headers per message (getSubject/getFrom/getTo/getDate/getFlags). Measured overhead ~1.2s per message. All of this only to compare UIDs against the database. It was not incremental and scaled with the total number of unseen mails in the mailbox, so it got slower as the INBOX grew.

## Fix

The read-status reconciliation only needs the UIDs of the currently unseen messages. Resolve them with a plain IMAP SEARCH (`->search()`, a single round-trip returning only UIDs) and reconcile the database against that list. No message objects are built.

- `ImapMessageBuilder::syncReadStatus()` now sources the unseen UIDs from a new `resolveUnseenUids()` (IMAP SEARCH) instead of the previously fetched `$this->messages`.
- `ImapMailSyncDriver::syncMessages()` drops the separate `->unseen()->withoutBody()->fetch()` pass and just calls `syncReadStatus()`.

## Result (production account)

| | before | after |
|---|--------|-------|
| Full sync | ~10 min | ~11s |
| INBOX read-status pass | 613s | ~3s |

The resulting read state was identical (unseen/seen counts unchanged), confirming the reconciliation still works.

## Tests

- `ImapMessageBuilderTest`: new test asserting `syncReadStatus()` reconciles the database against a given unseen-UID set (marks db-seen→unseen when present, db-unseen→seen when absent, leaves matching state untouched).

## Summary by Sourcery

Reconcile IMAP read status using server-side UID search instead of per-message fetch and update tests accordingly.

Bug Fixes:
- Fix IMAP read-status synchronization by basing database reconciliation on the server’s current unseen UID set rather than locally fetched unseen messages.

Enhancements:
- Introduce a dedicated resolver for unseen IMAP UIDs that uses an efficient SEARCH-based query and handles missing folders or response errors gracefully.

Tests:
- Add a unit test and test-only hook ensuring read-status synchronization correctly reconciles database seen/unseen flags against a supplied unseen UID set.