### PR TITLE
Fix favicon 404: catch-all route shadowed the favicon route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -63,7 +63,6 @@ Route::middleware('web')
             Route::get('/avatar.svg', [AssetController::class, 'avatar'])
                 ->name('avatar');
             Route::get('/manifest.json', [AssetController::class, 'manifest'])->name('manifest');
-            Route::get('/flux/favicon.svg', [AssetController::class, 'favicon'])->name('favicon');
             Route::get('/pwa-service-worker', [AssetController::class, 'pwaServiceWorker'])
                 ->name('pwa-service-worker');
             Route::get('/mail-pixel/{communication:uuid}', [AssetController::class, 'mailPixel'])

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Mechanisms\FrontendAssets;
 
+use FluxErp\Http\Controllers\AssetController;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\HtmlString;
@@ -307,6 +308,14 @@ class FrontendAssets
         )
             ->where('file', '.+')
             ->name('flux.assets.package');
+
+        // Registered before the /flux/{file} catch-all so the catch-all does not
+        // shadow it and return a 404 for a file that is not in the build path.
+        // No etag in the cache headers: the favicon is a BinaryFileResponse and
+        // the etag middleware would call getContent() on it and fail.
+        Route::get('/flux/favicon.svg', [AssetController::class, 'favicon'])
+            ->middleware('cache.headers:public;max_age=31536000')
+            ->name('favicon');
 
         Route::get('/flux/{file}', static fn (string $file) => app(static::class)->returnAssetFile($file))
             ->where('file', '.+')

--- a/tests/Feature/Mechanisms/FrontendAssetsTest.php
+++ b/tests/Feature/Mechanisms/FrontendAssetsTest.php
@@ -15,7 +15,8 @@ describe('FrontendAssets', function (): void {
         expect(Route::has('flux.assets.css'))->toBeTrue()
             ->and(Route::has('flux.assets.js'))->toBeTrue()
             ->and(Route::has('flux.assets.file'))->toBeTrue()
-            ->and(Route::has('flux.assets.package'))->toBeTrue();
+            ->and(Route::has('flux.assets.package'))->toBeTrue()
+            ->and(Route::has('favicon'))->toBeTrue();
     });
 
     test('manifest is loaded correctly', function (): void {
@@ -76,6 +77,13 @@ describe('FrontendAssets', function (): void {
         $response = $this->get(route('flux.assets.file', ['file' => '../../../etc/passwd']));
 
         $response->assertNotFound();
+    });
+
+    test('favicon route is served and not shadowed by the asset file catch-all', function (): void {
+        $response = $this->get(route('favicon'));
+
+        $response->assertOk()
+            ->assertHeader('Content-Type', 'image/svg+xml');
     });
 
     test('font files are served with correct mime type', function (): void {


### PR DESCRIPTION
## Problem

The browser console showed repeated 404s for `/flux/favicon.svg`, both as a resource and from the PWA manifest:

```
/flux/favicon.svg  Failed to load resource: 404
Error while trying to use the following icon from the Manifest: .../flux/favicon.svg
```

The favicon route was registered in `routes/web.php`, but `FrontendAssets::registerRoutes()` runs earlier and registers the `/flux/{file}` catch-all. The catch-all matched `/flux/favicon.svg` first and served it through `returnAssetFile()`, which only looks in the build path (`dist/`). The favicon actually lives under `public/pwa/images/icons-vector.svg`, so the catch-all `abort(404)`'d — the specific favicon route was never reached.

## Fix

- Move the favicon route into `registerRoutes()`, immediately **before** the `/flux/{file}` catch-all, so it always matches first. Same URL (`/flux/favicon.svg`), no manifest or blade change needed.
- Drop `etag` from its cache headers. `favicon()` returns a `BinaryFileResponse`, and the etag middleware calls `getContent()` on it, which throws. This was latent before because the route was never actually hit. Long-lived `max_age` caching stays.

No web-server (nginx) config change required — the fix is entirely in the route registration order.

## Tests

- `FrontendAssetsTest`: `favicon` added to the registered-routes assertion, plus a new test that `route('favicon')` returns 200 with `image/svg+xml` (i.e. is served, not shadowed by the catch-all).

## Summary by Sourcery

Ensure the favicon route is registered ahead of the frontend asset catch-all so it is correctly served instead of returning 404s.

Bug Fixes:
- Resolve 404 errors for /flux/favicon.svg by registering its route before the /flux/{file} catch-all and adjusting cache headers for BinaryFileResponse compatibility.

Tests:
- Extend frontend assets feature tests to assert the favicon route is registered and served with the correct SVG content type.