### PR TITLE
feat(product): run bulk price update as a monitored job with progress toast

### DIFF
--- a/src/Actions/Product/ProductPricesUpdate.php
+++ b/src/Actions/Product/ProductPricesUpdate.php
@@ -2,7 +2,7 @@
 
 namespace FluxErp\Actions\Product;
 
-use FluxErp\Actions\FluxAction;
+use FluxErp\Actions\DispatchableFluxAction;
 use FluxErp\Actions\Price\CreatePrice;
 use FluxErp\Actions\Price\UpdatePrice;
 use FluxErp\Enums\RoundingMethodEnum;
@@ -11,10 +11,13 @@ use FluxErp\Models\Discount;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
 use FluxErp\Rulesets\Product\ProductPricesUpdateRuleset;
+use FluxErp\Traits\IsMonitored;
 use Illuminate\Database\Eloquent\Collection;
 
-class ProductPricesUpdate extends FluxAction
+class ProductPricesUpdate extends DispatchableFluxAction
 {
+    use IsMonitored;
+
     public static function models(): array
     {
         return [Product::class];
@@ -23,6 +26,11 @@ class ProductPricesUpdate extends FluxAction
     protected function getRulesets(): string|array
     {
         return ProductPricesUpdateRuleset::class;
+    }
+
+    public function getName(): string
+    {
+        return __('Updating prices');
     }
 
     public function performAction(): Collection
@@ -46,7 +54,14 @@ class ProductPricesUpdate extends FluxAction
             ),
         ]]);
 
-        foreach ($products as $product) {
+        $total = $products->count();
+        $this->message(__(':count products', ['count' => $total]));
+
+        foreach ($products as $index => $product) {
+            if ($total > 0) {
+                $this->queueProgress(min(99, (int) (($index + 1) / $total * 100)));
+            }
+
             $price = PriceHelper::make($product)
                 ->addDiscount($discount)
                 ->setPriceList($basePriceList ?? $priceList)

--- a/src/Actions/Product/ProductPricesUpdate.php
+++ b/src/Actions/Product/ProductPricesUpdate.php
@@ -57,9 +57,10 @@ class ProductPricesUpdate extends DispatchableFluxAction
         $total = $products->count();
         $this->message(__(':count products', ['count' => $total]));
 
-        foreach ($products as $index => $product) {
+        $processed = 0;
+        foreach ($products as $product) {
             if ($total > 0) {
-                $this->queueProgress(min(99, (int) (($index + 1) / $total * 100)));
+                $this->queueProgress(min(99, (int) (++$processed / $total * 100)));
             }
 
             $price = PriceHelper::make($product)

--- a/src/Livewire/Product/ProductList.php
+++ b/src/Livewire/Product/ProductList.php
@@ -182,7 +182,7 @@ class ProductList extends BaseProductList
             ))
                 ->checkPermission()
                 ->validate()
-                ->execute();
+                ->executeAsync();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);
 
@@ -191,7 +191,6 @@ class ProductList extends BaseProductList
 
         $this->reset('selected');
         $this->productPricesUpdate->reset();
-        $this->loadData();
 
         return true;
     }

--- a/tests/Livewire/Product/ProductListTest.php
+++ b/tests/Livewire/Product/ProductListTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use FluxErp\Actions\Product\ProductPricesUpdate;
 use FluxErp\Livewire\Product\ProductList;
+use FluxErp\Models\PriceList;
 use FluxErp\Models\Product;
+use Illuminate\Support\Facades\Bus;
 use Livewire\Livewire;
 
 test('can add products to cart', function (): void {
@@ -17,4 +20,24 @@ test('can add products to cart', function (): void {
 test('renders successfully', function (): void {
     Livewire::test(ProductList::class)
         ->assertOk();
+});
+
+test('update prices dispatches a monitored job instead of running synchronously', function (): void {
+    Bus::fake([ProductPricesUpdate::class]);
+
+    $products = Product::factory()->count(2)->create();
+    $priceList = PriceList::factory()->create();
+
+    Livewire::test(ProductList::class)
+        ->set('selected', $products->pluck('id')->toArray())
+        ->set('productPricesUpdate.price_list_id', $priceList->getKey())
+        ->set('productPricesUpdate.base_price_list_id', $priceList->getKey())
+        ->set('productPricesUpdate.is_percent', false)
+        ->set('productPricesUpdate.alteration', 0)
+        ->set('productPricesUpdate.rounding_method_enum', 'none')
+        ->call('updatePrices')
+        ->assertHasNoErrors()
+        ->assertSet('selected', []);
+
+    Bus::assertDispatched(ProductPricesUpdate::class);
 });

--- a/tests/Livewire/Product/ProductListTest.php
+++ b/tests/Livewire/Product/ProductListTest.php
@@ -39,5 +39,11 @@ test('update prices dispatches a monitored job instead of running synchronously'
         ->assertHasNoErrors()
         ->assertSet('selected', []);
 
-    Bus::assertDispatched(ProductPricesUpdate::class);
+    Bus::assertDispatched(
+        ProductPricesUpdate::class,
+        fn (ProductPricesUpdate $action): bool => $action->getData('products') === $products->pluck('id')->toArray()
+            && $action->getData('price_list_id') === $priceList->getKey()
+            && $action->getData('base_price_list_id') === $priceList->getKey()
+            && $action->getData('is_percent') === false
+    );
 });


### PR DESCRIPTION
## What

The "Update prices" bulk action over selected products in the product list ran synchronously in the request, looping over every product before returning. This moves it into a monitored queued job so the user gets a progress toast instead of a blocked request.

## How

- `ProductPricesUpdate` now extends `DispatchableFluxAction` (a `ShouldBeMonitored, ShouldQueue` FluxAction) and uses `IsMonitored`. It reports an initial message and per-product `queueProgress()` inside the existing loop.
- `ProductList::updatePrices()` dispatches via `executeAsync()` instead of `execute()`. `checkPermission()` and `validate()` stay synchronous so unauthorized or invalid input still surfaces immediately in the modal; the heavy loop runs in the worker.
- The progress toast (started, percentage, finished) is emitted automatically by the existing QueueMonitor pipeline, the same pattern as `ExportDataTableJob`. No frontend changes required.

The synchronous `execute()` path is unchanged, so direct callers and existing action tests are unaffected.

## Tests

- Existing `ProductPricesUpdateTest` (sync `execute()`) stays green.
- Added a Livewire test asserting `updatePrices` dispatches `ProductPricesUpdate` and resets the selection.