### PR TITLE
Add category form stack seam

### DIFF
--- a/resources/views/livewire/settings/categories.blade.php
+++ b/resources/views/livewire/settings/categories.blade.php
@@ -77,6 +77,7 @@
                     ]"
                         />
                     </div>
+                    @stack('settings-category-form')
                 @show
             </div>
             <x-slot:footer>

--- a/resources/views/livewire/settings/categories.blade.php
+++ b/resources/views/livewire/settings/categories.blade.php
@@ -58,23 +58,23 @@
                             select="label:label|value:id"
                             unfiltered
                             :request="[
-                        'url' => route('search', \FluxErp\Models\Category::class),
-                        'method' => 'POST',
-                        'params' => [
-                            'where' => [
-                                [
-                                    'model_type',
-                                    '=',
-                                    $category->model_type,
+                                'url' => route('search', \FluxErp\Models\Category::class),
+                                'method' => 'POST',
+                                'params' => [
+                                    'where' => [
+                                        [
+                                            'model_type',
+                                            '=',
+                                            $category->model_type,
+                                        ],
+                                        [
+                                            'id',
+                                            '!=',
+                                            $category->id,
+                                        ],
+                                    ],
                                 ],
-                                [
-                                    'id',
-                                    '!=',
-                                    $category->id,
-                                ],
-                            ],
-                        ],
-                    ]"
+                            ]"
                         />
                     </div>
                     @stack('settings-category-form')

--- a/src/Livewire/Settings/Categories.php
+++ b/src/Livewire/Settings/Categories.php
@@ -84,6 +84,10 @@ class Categories extends CategoryList
         $this->category->reset();
         $this->category->fill($category);
 
+        // Let extensions (e.g. packages pushing into 'settings-category-form')
+        // load their own per-category data.
+        $this->dispatch('category-editing', categoryId: $category->getKey());
+
         $this->js(<<<'JS'
             $tsui.open.modal('edit-category-modal');
         JS);
@@ -99,6 +103,9 @@ class Categories extends CategoryList
 
             return false;
         }
+
+        // Let extensions persist their own per-category data after the core save.
+        $this->dispatch('category-saved', categoryId: $this->category->id);
 
         $this->loadData();
 

--- a/src/Livewire/Settings/Categories.php
+++ b/src/Livewire/Settings/Categories.php
@@ -84,10 +84,6 @@ class Categories extends CategoryList
         $this->category->reset();
         $this->category->fill($category);
 
-        // Let extensions (e.g. packages pushing into 'settings-category-form')
-        // load their own per-category data.
-        $this->dispatch('category-editing', categoryId: $category->getKey());
-
         $this->js(<<<'JS'
             $tsui.open.modal('edit-category-modal');
         JS);
@@ -103,9 +99,6 @@ class Categories extends CategoryList
 
             return false;
         }
-
-        // Let extensions persist their own per-category data after the core save.
-        $this->dispatch('category-saved', categoryId: $this->category->id);
 
         $this->loadData();
 


### PR DESCRIPTION
Adds a single `@stack('settings-category-form')` inside the category edit modal content section, so packages can render their own per-category fields without overriding the core component. No core logic — just the stack.