### PR TITLE
fix(views): stop Alpine class bindings sticking after a Livewire morph

### DIFF
--- a/resources/views/components/address/address.blade.php
+++ b/resources/views/components/address/address.blade.php
@@ -46,7 +46,7 @@
         </div>
         <div
             class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-            x-bind:class="!$wire.edit && 'pointer-events-none'"
+            x-bind:class="{ 'pointer-events-none': !$wire.edit }"
         >
             <x-label
                 :label="__('Salutation')"
@@ -120,7 +120,7 @@
         </div>
         <div
             class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-            x-bind:class="!$wire.edit && 'pointer-events-none'"
+            x-bind:class="{ 'pointer-events-none': !$wire.edit }"
         >
             <x-label
                 :label="__('Country')"
@@ -325,7 +325,7 @@
             @show
             <div
                 class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-                x-bind:class="!$wire.edit && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !$wire.edit }"
             >
                 <x-label
                     :label="__('Language')"
@@ -343,7 +343,7 @@
             </div>
             <div
                 class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-                x-bind:class="!$wire.edit && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !$wire.edit }"
             >
                 <x-label
                     :label="__('Search Aliases')"
@@ -355,7 +355,7 @@
             </div>
             <div
                 class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-                x-bind:class="!$wire.edit && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !$wire.edit }"
             >
                 <x-label :label="__('Tags')" for="{{ md5('address.tags') }}" />
                 <div class="col-span-2">
@@ -399,7 +399,7 @@
             </div>
             <div
                 class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:pt-2"
-                x-bind:class="!$wire.edit && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !$wire.edit }"
             >
                 <x-label
                     :label="__('Advertising State')"
@@ -407,7 +407,7 @@
                 />
                 <div class="col-span-2">
                     <x-flux::state
-                        x-bind:class="!$wire.edit && 'pointer-events-none'"
+                        x-bind:class="{ 'pointer-events-none': !$wire.edit }"
                         class="w-full"
                         align="bottom-start"
                         wire:model="address.advertising_state"
@@ -496,10 +496,10 @@
                         <div>
                             <x-select.native
                                 x-bind:readonly="!$wire.edit"
-                                x-bind:class="
-                                    !$wire.edit &&
-                                    'border-none bg-transparent shadow-none'
-                                "
+                                x-bind:class="{
+                                    'border-none bg-transparent shadow-none':
+                                        !$wire.edit,
+                                }"
                                 x-model="contactOption.type"
                                 :options="resolve_static(\FluxErp\Enums\ContactOptionTypeEnum::class, 'valuesLocalized')"
                                 required
@@ -509,10 +509,10 @@
                             x-model="contactOption.label"
                             :placeholder="__('Label')"
                             x-bind:disabled="!$wire.edit"
-                            x-bind:class="
-                                !$wire.edit &&
-                                'border-none bg-transparent shadow-none'
-                            "
+                            x-bind:class="{
+                                'border-none bg-transparent shadow-none':
+                                    !$wire.edit,
+                            }"
                         />
                         <x-input
                             x-cloak
@@ -520,10 +520,10 @@
                             x-model="contactOption.value"
                             :placeholder="__('Value')"
                             x-bind:disabled="!$wire.edit"
-                            x-bind:class="
-                                !$wire.edit &&
-                                'border-none bg-transparent shadow-none'
-                            "
+                            x-bind:class="{
+                                'border-none bg-transparent shadow-none':
+                                    !$wire.edit,
+                            }"
                         />
                         <div
                             class="block text-sm font-medium text-gray-700 sm:mt-px dark:text-gray-50"

--- a/resources/views/components/dashboard/grid.blade.php
+++ b/resources/views/components/dashboard/grid.blade.php
@@ -37,7 +37,7 @@
             >
                 <div
                     class="grid-stack-item-content"
-                    x-bind:class="editGrid ? 'border-4 border-primary-500' : ''"
+                    x-bind:class="{ 'border-4 border-primary-500': editGrid }"
                 >
                     <div class="absolute top-2 right-2 z-10">
                         <x-button.circle
@@ -52,7 +52,7 @@
                     </div>
                     <div
                         class="w-full"
-                        x-bind:class="editGrid ? 'pointer-events-none' : ''"
+                        x-bind:class="{ 'pointer-events-none': editGrid }"
                     >
                         @livewire(
                             $widget['component_name'] ?? $widget['class'],

--- a/resources/views/components/employee/general.blade.php
+++ b/resources/views/components/employee/general.blade.php
@@ -111,7 +111,7 @@
                 wire:model="employee.nationality"
                 x-bind:disabled="!isEditing"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     wire:model="employee.country_id"
                     :label="__('Country')"
@@ -146,7 +146,7 @@
                 wire:model="employee.city"
                 x-bind:disabled="!isEditing"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-number
                     min="0"
                     step="0.5"
@@ -186,7 +186,7 @@
     <x-card :header="__('Employment Information')">
         <div
             class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2"
-            x-bind:class="!isEditing && 'pointer-events-none'"
+            x-bind:class="{ 'pointer-events-none': !isEditing }"
         >
             <x-date
                 :label="__('Employment Date')"
@@ -259,7 +259,7 @@
                     ]
                 ]"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Salary Type')"
                     wire:model="employee.salary_type"
@@ -278,7 +278,7 @@
 
     <x-card :header="__('Vacation Carryover Rule')">
         <div class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Vacation Carryover Rule')"
                     wire:model="employee.vacation_carryover_rule_id"

--- a/resources/views/components/map/fullscreen-container.blade.php
+++ b/resources/views/components/map/fullscreen-container.blade.php
@@ -6,11 +6,10 @@
 <div
     x-data="{ isFullscreen: false }"
     class="transition-all duration-500 ease-in-out"
-    x-bind:class="
-        isFullscreen && $wire.showMap
-            ? 'fixed inset-0 z-50 bg-white dark:bg-secondary-800 p-4 flex flex-col'
-            : ''
-    "
+    x-bind:class="{
+        'fixed inset-0 z-50 bg-white dark:bg-secondary-800 p-4 flex flex-col':
+            isFullscreen && $wire.showMap,
+    }"
 >
     <div
         x-on:load-map.window="$nextTick(() => onChange())"
@@ -34,7 +33,7 @@
     >
         <div
             class="w-full"
-            x-bind:class="isFullscreen ? 'flex-1 flex flex-col min-h-0' : ''"
+            x-bind:class="{ 'flex-1 flex flex-col min-h-0': isFullscreen }"
         >
             <div class="flex items-center justify-between gap-4 pb-4">
                 <div class="flex items-center gap-4">
@@ -76,9 +75,7 @@
             </div>
             <div
                 x-intersect.once="onChange()"
-                x-bind:class="
-                    isFullscreen ? 'flex-1 min-h-0 flex flex-col' : ''
-                "
+                x-bind:class="{ 'flex-1 min-h-0 flex flex-col': isFullscreen }"
                 class="border-secondary-200 dark:border-secondary-600 overflow-hidden rounded-lg border"
             >
                 <div

--- a/resources/views/components/pillbox.blade.php
+++ b/resources/views/components/pillbox.blade.php
@@ -68,10 +68,10 @@
                     <li
                         dusk="flux_pillbox_option"
                         class="dark:hover:bg-dark-600 flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-gray-100"
-                        x-bind:class="
-                            highlighted === index &&
-                            'dark:bg-dark-600 bg-gray-100'
-                        "
+                        x-bind:class="{
+                            'dark:bg-dark-600 bg-gray-100':
+                                highlighted === index,
+                        }"
                         x-on:mouseenter="highlighted = index"
                         x-on:click="add(item.value)"
                     >

--- a/resources/views/components/product/general.blade.php
+++ b/resources/views/components/product/general.blade.php
@@ -80,7 +80,7 @@
             />
             <div
                 class="grid grid-cols-1 gap-4 sm:grid-cols-4"
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
             >
                 <x-number
                     x-bind:readonly="!isEditing"

--- a/resources/views/components/project/edit.blade.php
+++ b/resources/views/components/project/edit.blade.php
@@ -20,7 +20,7 @@
             class="space-y-2.5 p-0.5"
         >
             <div
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
                 x-show="!$wire.project.id"
                 x-cloak
             >
@@ -41,20 +41,20 @@
                     <x-date
                         without-time
                         x-bind:readonly="!isEditing"
-                        x-bind:class="!isEditing && 'pointer-events-none'"
+                        x-bind:class="{ 'pointer-events-none': !isEditing }"
                         wire:model="project.start_date"
                         :label="__('Start Date')"
                     />
                     <x-date
                         without-time
                         x-bind:readonly="!isEditing"
-                        x-bind:class="!isEditing && 'pointer-events-none'"
+                        x-bind:class="{ 'pointer-events-none': !isEditing }"
                         wire:model="project.end_date"
                         :label="__('End Date')"
                     />
                 @show
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-flux::state
                     x-bind:readonly="!isEditing"
                     class="w-full"
@@ -71,7 +71,7 @@
                 :label="__('Description')"
             />
             @section('connections')
-                <div x-bind:class="!isEditing && 'pointer-events-none'">
+                <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                     <x-select.styled
                         x-bind:readonly="!isEditing"
                         :label="__('Responsible User')"
@@ -88,7 +88,7 @@
                     ]"
                     />
                 </div>
-                <div x-bind:class="!isEditing && 'pointer-events-none'">
+                <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                     <x-select.styled
                         x-bind:readonly="!isEditing"
                         wire:model="project.contact_id"
@@ -126,7 +126,7 @@
                         </x-slot:label>
                     </x-select.styled>
                 </div>
-                <div x-bind:class="!isEditing && 'pointer-events-none'">
+                <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                     <x-select.styled
                         x-bind:readonly="!isEditing"
                         wire:model="project.order_id"
@@ -181,7 +181,7 @@
                 </x-slot:text>
                 <x-slot:left
                     class="relative flex h-2 w-2 items-center transition-transform"
-                    x-bind:class="expanded && '-rotate-180'"
+                    x-bind:class="{ '-rotate-180': expanded }"
                 >
                     <x-icon name="chevron-down" class="h-4 w-4 shrink-0" />
                 </x-slot:left>

--- a/resources/views/components/task/general.blade.php
+++ b/resources/views/components/task/general.blade.php
@@ -30,7 +30,7 @@
                 @section('task-content.selects.project')
                     <div
                         x-show="$wire.task.id"
-                        x-bind:class="!isEditing && 'pointer-events-none'"
+                        x-bind:class="{ 'pointer-events-none': !isEditing }"
                     >
                         <x-select.styled
                             wire:model="task.project_id"
@@ -56,7 +56,7 @@
                     </div>
                 @show
                 @section('task-content.selects.responsible-users')
-                    <div x-bind:class="!isEditing && 'pointer-events-none'">
+                    <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                         <x-select.styled
                             :label="__('Responsible User')"
                             autocomplete="off"
@@ -77,7 +77,7 @@
             @show
             <div
                 class="flex justify-between gap-x-4"
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
             >
                 @section('task-content.dates')
                     @section('task-content.start')
@@ -99,9 +99,9 @@
                                 class="flex flex-col gap-2"
                                 x-cloak
                                 x-show="$wire.task.start_date"
-                                x-bind:class="
-                                    !isEditing && 'pointer-events-none'
-                                "
+                                x-bind:class="{
+                                    'pointer-events-none': !isEditing,
+                                }"
                             >
                                 <x-toggle
                                     :label="__('Start Reminder')"
@@ -142,9 +142,9 @@
                                 class="flex flex-col gap-2"
                                 x-cloak
                                 x-show="$wire.task.due_date"
-                                x-bind:class="
-                                    !isEditing && 'pointer-events-none'
-                                "
+                                x-bind:class="{
+                                    'pointer-events-none': !isEditing,
+                                }"
                             >
                                 <x-toggle
                                     :label="__('Due Reminder')"
@@ -170,7 +170,7 @@
             </div>
             @section('task-content.multi-selects')
                 <x-flux::state
-                    x-bind:class="!isEditing && 'pointer-events-none'"
+                    x-bind:class="{ 'pointer-events-none': !isEditing }"
                     class="w-full"
                     align="bottom-start"
                     :label="__('Task state')"
@@ -191,7 +191,7 @@
                 scope="task"
                 :label="__('Description')"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Categories')"
                     wire:model="task.categories"
@@ -214,7 +214,7 @@
                 ]"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Assigned')"
                     autocomplete="off"
@@ -234,7 +234,7 @@
             </div>
             <div
                 class="col-span-2"
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
             >
                 <x-select.styled
                     multiple

--- a/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
+++ b/resources/views/livewire/accounting/purchase-invoice-list/include-before.blade.php
@@ -55,10 +55,10 @@
                 @section('tenant')
                     @if (count($tenants ?? []) > 1)
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-select.styled
                                 x-bind:readonly="
@@ -77,10 +77,10 @@
                 @section('basic-info')
                     <div
                         class="flex items-end gap-2"
-                        x-bind:class="
-                            $wire.purchaseInvoiceForm.order_id &&
-                            'pointer-events-none'
-                        "
+                        x-bind:class="{
+                            'pointer-events-none':
+                                $wire.purchaseInvoiceForm.order_id,
+                        }"
                     >
                         <div class="flex-1">
                             <x-select.styled
@@ -120,10 +120,10 @@
                     </div>
                     <div class="grid grid-cols-2 gap-4">
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-select.styled
                                 x-bind:readonly="
@@ -136,10 +136,10 @@
                             />
                         </div>
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-select.styled
                                 x-bind:readonly="
@@ -167,10 +167,10 @@
                             :label="__('Invoice Number')"
                         />
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-date
                                 x-bind:readonly="
@@ -184,10 +184,10 @@
                     </div>
                     <div class="grid grid-cols-2 gap-4">
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-date
                                 x-bind:readonly="
@@ -199,10 +199,10 @@
                             />
                         </div>
                         <div
-                            x-bind:class="
-                                $wire.purchaseInvoiceForm.order_id &&
-                                'pointer-events-none'
-                            "
+                            x-bind:class="{
+                                'pointer-events-none':
+                                    $wire.purchaseInvoiceForm.order_id,
+                            }"
                         >
                             <x-date
                                 x-bind:readonly="
@@ -229,18 +229,18 @@
                             <x-icon
                                 name="chevron-down"
                                 class="h-4 w-4 transition-transform"
-                                x-bind:class="showPayment && 'rotate-180'"
+                                x-bind:class="{ 'rotate-180': showPayment }"
                             />
                         </button>
                         <div x-cloak x-show="showPayment" x-collapse>
                             <div class="grid grid-cols-2 gap-4 pt-2 pb-2">
                                 @if (count($currencies ?? []) > 1)
                                     <div
-                                        x-bind:class="
-                                            $wire.purchaseInvoiceForm
-                                                .order_id &&
-                                            'pointer-events-none'
-                                        "
+                                        x-bind:class="{
+                                            'pointer-events-none':
+                                                $wire.purchaseInvoiceForm
+                                                    .order_id,
+                                        }"
                                     >
                                         <x-select.styled
                                             x-bind:readonly="
@@ -256,10 +256,10 @@
                                 @endif
 
                                 <div
-                                    x-bind:class="
-                                        $wire.purchaseInvoiceForm.order_id &&
-                                        'pointer-events-none'
-                                    "
+                                    x-bind:class="{
+                                        'pointer-events-none':
+                                            $wire.purchaseInvoiceForm.order_id,
+                                    }"
                                 >
                                     <x-select.styled
                                         :label="__('Approval User')"
@@ -274,10 +274,10 @@
                                     />
                                 </div>
                                 <div
-                                    x-bind:class="
-                                        $wire.purchaseInvoiceForm.order_id &&
-                                        'pointer-events-none'
-                                    "
+                                    x-bind:class="{
+                                        'pointer-events-none':
+                                            $wire.purchaseInvoiceForm.order_id,
+                                    }"
                                 >
                                     <x-date
                                         x-bind:readonly="
@@ -288,10 +288,10 @@
                                     />
                                 </div>
                                 <div
-                                    x-bind:class="
-                                        $wire.purchaseInvoiceForm.order_id &&
-                                        'pointer-events-none'
-                                    "
+                                    x-bind:class="{
+                                        'pointer-events-none':
+                                            $wire.purchaseInvoiceForm.order_id,
+                                    }"
                                 >
                                     <x-date
                                         x-bind:readonly="
@@ -302,10 +302,10 @@
                                     />
                                 </div>
                                 <div
-                                    x-bind:class="
-                                        $wire.purchaseInvoiceForm.order_id &&
-                                        'pointer-events-none'
-                                    "
+                                    x-bind:class="{
+                                        'pointer-events-none':
+                                            $wire.purchaseInvoiceForm.order_id,
+                                    }"
                                 >
                                     <x-number
                                         x-bind:readonly="
@@ -334,7 +334,7 @@
                             <x-icon
                                 name="chevron-down"
                                 class="h-4 w-4 transition-transform"
-                                x-bind:class="showBank && 'rotate-180'"
+                                x-bind:class="{ 'rotate-180': showBank }"
                             />
                         </button>
                         <div x-cloak x-show="showBank" x-collapse>
@@ -531,11 +531,11 @@
                                             :label="__('Name')"
                                         />
                                         <div
-                                            x-bind:class="
-                                                $wire.purchaseInvoiceForm
-                                                    .order_id &&
-                                                'pointer-events-none'
-                                            "
+                                            x-bind:class="{
+                                                'pointer-events-none':
+                                                    $wire.purchaseInvoiceForm
+                                                        .order_id,
+                                            }"
                                         >
                                             <x-select.styled
                                                 :label="__('Product')"
@@ -616,11 +616,11 @@
                                             :label="__('Total')"
                                         />
                                         <div
-                                            x-bind:class="
-                                                $wire.purchaseInvoiceForm
-                                                    .order_id &&
-                                                'pointer-events-none'
-                                            "
+                                            x-bind:class="{
+                                                'pointer-events-none':
+                                                    $wire.purchaseInvoiceForm
+                                                        .order_id,
+                                            }"
                                         >
                                             <x-select.styled
                                                 x-bind:readonly="
@@ -643,11 +643,11 @@
                                     </div>
 
                                     <div
-                                        x-bind:class="
-                                            $wire.purchaseInvoiceForm
-                                                .order_id &&
-                                            'pointer-events-none'
-                                        "
+                                        x-bind:class="{
+                                            'pointer-events-none':
+                                                $wire.purchaseInvoiceForm
+                                                    .order_id,
+                                        }"
                                     >
                                         <x-select.styled
                                             x-bind:readonly="

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -788,11 +788,10 @@
                                             link.active || link.url === null
                                         "
                                         x-text="link.label"
-                                        x-bind:class="
-                                            link.active
-                                                ? 'bg-primary-50 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400'
-                                                : ''
-                                        "
+                                        x-bind:class="{
+                                            'bg-primary-50 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400':
+                                                link.active,
+                                        }"
                                         x-on:click="
                                             link.url !== null &&
                                                 !link.active &&

--- a/resources/views/livewire/contact/accounting/general.blade.php
+++ b/resources/views/livewire/contact/accounting/general.blade.php
@@ -1,6 +1,6 @@
 <div
     class="flex flex-col gap-4"
-    x-bind:class="!$wire.$parent.$parent.edit && 'pointer-events-none'"
+    x-bind:class="{ 'pointer-events-none': !$wire.$parent.$parent.edit }"
 >
     @section('commercial')
         <x-card>

--- a/resources/views/livewire/contact/addresses.blade.php
+++ b/resources/views/livewire/contact/addresses.blade.php
@@ -52,18 +52,18 @@
                             >
                                 <div
                                     wire:click="select(addressItem.id)"
-                                    x-bind:class="
-                                        $wire.address.id === addressItem.id &&
-                                        'rounded-lg ring-2 ring-inset ring-primary-500 bg-blue-100 dark:bg-secondary-700'
-                                    "
+                                    x-bind:class="{
+                                        'rounded-lg ring-2 ring-inset ring-primary-500 bg-blue-100 dark:bg-secondary-700':
+                                            $wire.address.id === addressItem.id,
+                                    }"
                                     class="dark:hover:bg-secondary-800 cursor-pointer space-y-2 p-1.5 hover:bg-blue-50"
                                 >
                                     <div
                                         class="flex w-full justify-between gap-1.5 dark:text-gray-50"
-                                        x-bind:class="
-                                            !addressItem.is_active &&
-                                            'text-secondary-400 dark:text-gray-200'
-                                        "
+                                        x-bind:class="{
+                                            'text-secondary-400 dark:text-gray-200':
+                                                !addressItem.is_active,
+                                        }"
                                     >
                                         <div
                                             class="text-sm text-ellipsis whitespace-nowrap"
@@ -118,9 +118,9 @@
                 <x-card>
                     <div
                         class="flex flex-col gap-1.5"
-                        x-bind:class="
-                            !$wire.$parent.edit && 'pointer-events-none'
-                        "
+                        x-bind:class="{
+                            'pointer-events-none': !$wire.$parent.edit,
+                        }"
                     >
                         <x-select.styled
                             x-bind:disabled="!$wire.$parent.edit"

--- a/resources/views/livewire/edit-mail.blade.php
+++ b/resources/views/livewire/edit-mail.blade.php
@@ -59,7 +59,7 @@
             <x-flux::pillbox
                 wire:model="mailMessage.to"
                 class="flex flex-col gap-1.5"
-                x-bind:class="$wire.multiple && 'pointer-events-none opacity-50'"
+                x-bind:class="{ 'pointer-events-none opacity-50': $wire.multiple }"
                 :label="__('To')"
                 :placeholder="__('Add a new to')"
                 lazy="2"
@@ -119,7 +119,7 @@
                                 <x-slot:text>
                                     <div
                                         x-on:click.prevent="file.id && $wire.download(file.id)"
-                                        x-bind:class="file.id ? 'cursor-pointer' : ''"
+                                        x-bind:class="{ 'cursor-pointer': file.id }"
                                     >
                                         <span x-text="file.name"></span>
                                     </div>

--- a/resources/views/livewire/employee/employee-work-time-model-assignment.blade.php
+++ b/resources/views/livewire/employee/employee-work-time-model-assignment.blade.php
@@ -105,11 +105,10 @@
                 >
                     <template x-for="assignment in $wire.assignments">
                         <tr
-                            x-bind:class="
-                                assignment.is_current
-                                    ? 'bg-green-50 dark:bg-green-900/20'
-                                    : ''
-                            "
+                            x-bind:class="{
+                                'bg-green-50 dark:bg-green-900/20':
+                                    assignment.is_current,
+                            }"
                         >
                             <td
                                 class="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-gray-100"

--- a/resources/views/livewire/features/communications/communication.blade.php
+++ b/resources/views/livewire/features/communications/communication.blade.php
@@ -329,7 +329,7 @@
             <div
                 x-cloak
                 x-show="$wire.communication.communication_type_enum === 'mail'"
-                x-bind:class="$wire.communication.id && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': $wire.communication.id }"
             >
                 <x-select.styled
                     required

--- a/resources/views/livewire/lead/general.blade.php
+++ b/resources/views/livewire/lead/general.blade.php
@@ -16,7 +16,7 @@
                 :label="__('Description')"
                 wire:model="leadForm.description"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Commission Agent')"
                     wire:model="leadForm.user_id"
@@ -31,7 +31,7 @@
                     ]"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     x-bind:readonly="!isEditing"
                     wire:model="leadForm.address_id"
@@ -62,7 +62,7 @@
                     </x-slot:label>
                 </x-select.styled>
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     x-on:select="$wire.isLost = $event.detail.select.is_lost"
                     wire:model="leadForm.lead_state_id"
@@ -82,7 +82,7 @@
                 />
             </div>
             <div
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
                 x-cloak
                 x-show="$wire.isLost"
             >
@@ -120,7 +120,7 @@
                     :label="__('Loss Reason')"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     x-bind:readonly="!isEditing"
                     wire:model="leadForm.recommended_by_address_id"
@@ -150,7 +150,7 @@
                     </x-slot:label>
                 </x-select.styled>
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Origin')"
                     wire:model="leadForm.record_origin_id"
@@ -189,7 +189,7 @@
                 :label="__('Expected Gross Profit')"
                 wire:model="leadForm.expected_gross_profit"
             />
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-rating
                     x-bind:readonly="!isEditing"
                     wire:model.number="leadForm.score"
@@ -198,7 +198,7 @@
                     position="right"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-range
                     x-bind:readonly="!isEditing"
                     wire:model.number="leadForm.probability_percentage"
@@ -220,7 +220,7 @@
                 </x-range>
             </div>
             <div
-                x-bind:class="!isEditing && 'pointer-events-none'"
+                x-bind:class="{ 'pointer-events-none': !isEditing }"
                 class="flex gap-4"
             >
                 <x-date
@@ -234,7 +234,7 @@
                     x-bind:readonly="!isEditing"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     :label="__('Categories')"
                     wire:model="leadForm.categories"
@@ -257,7 +257,7 @@
                     ]"
                 />
             </div>
-            <div x-bind:class="!isEditing && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': !isEditing }">
                 <x-select.styled
                     multiple
                     wire:model.number="leadForm.tags"

--- a/resources/views/livewire/mail/mail.blade.php
+++ b/resources/views/livewire/mail/mail.blade.php
@@ -136,7 +136,7 @@
                         light
                         icon="paper-clip"
                         x-on:click="file.id && $wire.download(file.id)"
-                        x-bind:class="! file.id && 'pointer-events-none opacity-50'"
+                        x-bind:class="{ 'pointer-events-none opacity-50': ! file.id }"
                         rounded
                     >
                         <x-slot:text>

--- a/resources/views/livewire/navigation.blade.php
+++ b/resources/views/livewire/navigation.blade.php
@@ -158,9 +158,9 @@
                                 <x-icon
                                     name="chevron-left"
                                     class="h-4 w-4 transform text-white transition-transform"
-                                    x-bind:class="
-                                        frequentlyVisitedOpen && '-rotate-90'
-                                    "
+                                    x-bind:class="{
+                                        '-rotate-90': frequentlyVisitedOpen,
+                                    }"
                                 />
                             </span>
                         </div>
@@ -214,7 +214,9 @@
                                 <x-icon
                                     name="chevron-left"
                                     class="h-4 w-4 transform text-white transition-transform"
-                                    x-bind:class="favoritesOpen && '-rotate-90'"
+                                    x-bind:class="{
+                                        '-rotate-90': favoritesOpen,
+                                    }"
                                 />
                             </span>
                         </div>
@@ -266,7 +268,7 @@
                             @endforeach
 
                             <x-button
-                                x-bind:class="!menuOpen && 'invisible'"
+                                x-bind:class="{ invisible: !menuOpen }"
                                 color="emerald"
                                 class="w-full"
                                 icon="plus"

--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -411,9 +411,9 @@
                                         <x-icon
                                             name="chevron-down"
                                             class="h-4 w-4 transition-transform"
-                                            x-bind:class="
-                                                showAdvanced && 'rotate-180'
-                                            "
+                                            x-bind:class="{
+                                                'rotate-180': showAdvanced,
+                                            }"
                                         />
                                     </button>
                                     <div

--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -36,10 +36,10 @@
             >
                 <div
                     class="divide-secondary-200 space-y-2.5 divide-y"
-                    x-bind:class="
-                        $wire.disableReplicateModalInputs &&
-                        'pointer-events-none'
-                    "
+                    x-bind:class="{
+                        'pointer-events-none':
+                            $wire.disableReplicateModalInputs,
+                    }"
                 >
                     <x-select.styled
                         :label="__('Order type')"
@@ -644,11 +644,11 @@
                                 </div>
                                 <div
                                     class="text-sm"
-                                    x-bind:class="
-                                        $wire.order.address_delivery_id ===
-                                            $wire.order.address_invoice_id &&
-                                        'hidden'
-                                    "
+                                    x-bind:class="{
+                                        hidden:
+                                            $wire.order.address_delivery_id ===
+                                            $wire.order.address_invoice_id,
+                                    }"
                                 >
                                     <p
                                         class="truncate first-line:font-semibold"

--- a/resources/views/livewire/settings/categories.blade.php
+++ b/resources/views/livewire/settings/categories.blade.php
@@ -37,9 +37,9 @@
                         ></x-toggle>
                     </div>
                     <div
-                        x-bind:class="
-                            $wire.category.id && 'pointer-events-none'
-                        "
+                        x-bind:class="{
+                            'pointer-events-none': $wire.category.id,
+                        }"
                     >
                         <x-select.styled
                             x-bind:disabled="$wire.category.id"

--- a/resources/views/livewire/settings/permissions.blade.php
+++ b/resources/views/livewire/settings/permissions.blade.php
@@ -35,7 +35,7 @@
 <x-modal id="edit-role-permissions-modal">
     <div class="flex flex-col gap-1.5">
         <x-input wire:model="roleForm.name" :label="__('Name')" />
-        <div x-bind:class="$wire.roleForm.id && 'pointer-events-none'">
+        <div x-bind:class="{ 'pointer-events-none': $wire.roleForm.id }">
             <x-select.styled
                 :label="__('Guard')"
                 :disabled="$roleForm->id ?? false"

--- a/resources/views/livewire/settings/plugins.blade.php
+++ b/resources/views/livewire/settings/plugins.blade.php
@@ -255,12 +255,12 @@
                     @if (resolve_static(\FluxErp\Actions\Plugins\ToggleActive::class, 'canPerformAction', [false]))
                         <div
                             x-cloak
-                            x-bind:class="
-                                !(
+                            x-bind:class="{
+                                invisible: !(
                                     plugin.can_uninstall &&
                                     !plugin.offer_install
-                                ) && 'invisible'
-                            "
+                                ),
+                            }"
                         >
                             <x-toggle
                                 x-model="$wire.installed[key].is_active"
@@ -270,7 +270,7 @@
                 </div>
                 <div
                     class="flex grow gap-1.5"
-                    x-bind:class="!plugin.is_active && 'opacity-60'"
+                    x-bind:class="{ 'opacity-60': !plugin.is_active }"
                 >
                     <img
                         x-bind:src="

--- a/resources/views/livewire/settings/tags.blade.php
+++ b/resources/views/livewire/settings/tags.blade.php
@@ -3,7 +3,7 @@
         <div class="flex flex-col gap-1.5">
             <x-input wire:model="tagForm.name" :label="__('Name')" />
             <x-color wire:model="tagForm.color" :label="__('Color')" />
-            <div x-bind:class="$wire.tagForm.id && 'pointer-events-none'">
+            <div x-bind:class="{ 'pointer-events-none': $wire.tagForm.id }">
                 <x-select.styled
                     x-bind:disabled="$wire.tagForm.id"
                     wire:model="tagForm.type"

--- a/resources/views/livewire/settings/tenants.blade.php
+++ b/resources/views/livewire/settings/tenants.blade.php
@@ -25,7 +25,7 @@
                         <x-button
                             light
                             wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Tenant')]) }}"
-                            x-bind:class="$wire.tenant.id > 0 || 'invisible'"
+                            x-bind:class="{ invisible: !($wire.tenant.id > 0) }"
                             x-on:click="
                                 $wire.delete().then((success) => {
                                     if (success) close();

--- a/resources/views/livewire/support/comments.blade.php
+++ b/resources/views/livewire/support/comments.blade.php
@@ -58,10 +58,10 @@
                             <template>
                                 <ul>
                                     <li
-                                        x-bind:class="
-                                            comment.is_sticky &&
-                                            'bg-emerald-50 dark:bg-emerald-900'
-                                        "
+                                        x-bind:class="{
+                                            'bg-emerald-50 dark:bg-emerald-900':
+                                                comment.is_sticky,
+                                        }"
                                         class="px-4 py-6 sm:px-6"
                                     >
                                         <x-flux::features.comments.comment

--- a/resources/views/livewire/ticket/ticket.blade.php
+++ b/resources/views/livewire/ticket/ticket.blade.php
@@ -205,14 +205,14 @@
                                             outline
                                             icon="eye"
                                             wire:navigate
-                                            x-bind:class="
-                                                ($wire.get(
-                                                    'authorTypeContact',
-                                                ) !== true ||
+                                            x-bind:class="{
+                                                'cursor-not-allowed':
+                                                    $wire.get(
+                                                        'authorTypeContact',
+                                                    ) !== true ||
                                                     !$wire.ticket
-                                                        .authenticatable_id) &&
-                                                'cursor-not-allowed'
-                                            "
+                                                        .authenticatable_id,
+                                            }"
                                             x-bind:href="($wire.get('authorTypeContact') === true && $wire.ticket.authenticatable.contact_id) && '{{ route('contacts.id?', ':id') }}'.replace(':id', $wire.ticket.authenticatable.contact_id) + '?address=' + $wire.ticket.authenticatable_id"
                                         ></x-button>
                                     </div>

--- a/resources/views/livewire/work-time.blade.php
+++ b/resources/views/livewire/work-time.blade.php
@@ -114,10 +114,10 @@
         color="indigo"
         x-on:click="open = !open"
         x-ref="button"
-        x-bind:class="
-            $wire.workTime.is_pause &&
-            'ring-amber-500 text-white bg-amber-500 hover:bg-amber-600 hover:ring-amber-600 dark:ring-offset-slate-800 dark:bg-amber-700 dark:ring-amber-700 dark:hover:bg-amber-600 dark:hover:ring-amber-600'
-        "
+        x-bind:class="{
+            'ring-amber-500 text-white bg-amber-500 hover:bg-amber-600 hover:ring-amber-600 dark:ring-offset-slate-800 dark:bg-amber-700 dark:ring-amber-700 dark:hover:bg-amber-600 dark:hover:ring-amber-600':
+                $wire.workTime.is_pause,
+        }"
         icon="clock"
     >
         <div x-text="msTimeToString(time)"></div>

--- a/tests/Browser/Features/Contact/EditLockTest.php
+++ b/tests/Browser/Features/Contact/EditLockTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use Pest\Browser\Api\AwaitableWebpage;
+use Pest\Browser\Api\PendingAwaitablePage;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+    Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+});
+
+/**
+ * Wait until the contact component's edit state matches the expectation.
+ */
+function waitForContactEditState(PendingAwaitablePage|AwaitableWebpage $page, bool $expected): void
+{
+    $expectedJson = $expected ? 'true' : 'false';
+
+    $page->script(<<<JS
+        () => new Promise((resolve, reject) => {
+            const timeout = setTimeout(
+                () => reject(new Error('Contact edit state never became {$expectedJson}')),
+                10000,
+            );
+            const check = () => {
+                const root = document
+                    .getElementById('contact')
+                    .closest('[wire\\\\:id]');
+                const wire = Livewire.find(root.getAttribute('wire:id'));
+
+                if (wire.edit === {$expectedJson}) {
+                    clearTimeout(timeout);
+                    // Let Alpine flush the effects that react to the state change.
+                    setTimeout(resolve, 250);
+                } else {
+                    setTimeout(check, 100);
+                }
+            };
+            check();
+        })
+    JS);
+}
+
+/**
+ * The accounting tab is locked via "pointer-events-none" while not editing,
+ * so hit test the field instead of trusting the class name.
+ */
+function vatFieldIsLocked(PendingAwaitablePage|AwaitableWebpage $page): bool
+{
+    return $page->script(<<<'JS'
+        () => {
+            const input = document.querySelector(
+                'input[wire\\:model="contact.vat_id"]',
+            );
+
+            if (! input) {
+                throw new Error('VAT input not found on the accounting tab');
+            }
+
+            input.scrollIntoView({ block: 'center' });
+
+            const rect = input.getBoundingClientRect();
+            const hit = document.elementFromPoint(
+                rect.left + rect.width / 2,
+                rect.top + rect.height / 2,
+            );
+
+            return hit !== input;
+        }
+    JS);
+}
+
+test('accounting fields stay interactive after edit, save and edit', function (): void {
+    $page = visit(route('contacts.id?', ['id' => $this->contact->getKey()]))
+        ->assertNoSmoke();
+
+    $page->script(<<<'JS'
+        () => new Promise((resolve, reject) => {
+            const timeout = setTimeout(
+                () => reject(new Error('Accounting tab did not render')),
+                10000,
+            );
+            const check = () => {
+                if (document.querySelector('input[wire\\:model="contact.vat_id"]')) {
+                    clearTimeout(timeout);
+                    resolve();
+                } else {
+                    document
+                        .querySelector('[data-tab-name="contact.accounting"]')
+                        ?.click();
+                    setTimeout(check, 200);
+                }
+            };
+            check();
+        })
+    JS);
+
+    expect(vatFieldIsLocked($page))->toBeTrue();
+
+    $page->click('Edit');
+    waitForContactEditState($page, true);
+    expect(vatFieldIsLocked($page))->toBeFalse();
+
+    $page->click('Save');
+    waitForContactEditState($page, false);
+    expect(vatFieldIsLocked($page))->toBeTrue();
+
+    $page->click('Edit');
+    waitForContactEditState($page, true);
+    expect(vatFieldIsLocked($page))->toBeFalse();
+});


### PR DESCRIPTION
## Problem

`x-bind:class="cond && 'class'"` (the string form) relies on Alpine's `_x_undoAddedClasses` bookkeeping, which only removes the classes Alpine recorded adding.

When a Livewire morph re-initialises the binding on an element that **already carries** the Alpine-added class, `missingClasses` resolves to an empty list, so the new undo closure records nothing. From then on the class can never be removed.

Verified in the browser:

- the server sends `class="flex flex-col gap-4"` in the morph HTML, i.e. without the toggled class
- the DOM still shows `... pointer-events-none`
- calling `el._x_undoAddedClasses()` by hand removes nothing

## Impact

On the contact detail page this locked the accounting tab. After `Edit -> Save -> Edit` the inputs were re-enabled (`x-bind:disabled` works fine) but the wrapper kept `pointer-events-none`, so no field could be clicked until a page reload.

The trigger is specific: `Contact::save()` is `#[Renderless]`, but its `#[Modelable]` child `contact.accounting.general` re-renders, and that morph is what strands the class. Components whose `save()` is renderless and whose edit flag lives in the same template (Task, Project, Employee, Product, Lead) are not affected.

## Change

Convert every **single-branch** class binding to the object form:

```blade
- x-bind:class="!$wire.$parent.$parent.edit && 'pointer-events-none'"
+ x-bind:class="{ 'pointer-events-none': !$wire.$parent.$parent.edit }"
```

`setClassesFromObject` has no undo bookkeeping and removes falsy keys unconditionally, so it is immune.

92 bindings across 28 views: `cond && 'class'`, `cond ? 'class' : ''`, and one `cond || 'class'`.

## Not covered

Two-branch ternaries (`cond ? 'a' : 'b'`, e.g. `settings/profile.blade.php`, `settings/user-edit.blade.php`, `widgets/settings/system/database.blade.php`) share the root cause but only convert by duplicating the condition, and several nest ternaries. Three more compute the class string outright (`components/state.blade.php`, `features/calendar/calendar-event.blade.php`, `support/widgets/charts/bar-chart.blade.php`) and have no object form. Their failure mode is a wrong colour rather than an unusable UI, so they are left for a follow-up.

## Test

`tests/Browser/Features/Contact/EditLockTest.php` hit-tests the VAT field with `document.elementFromPoint()` instead of asserting on a class name, so it also catches `pointer-events` inherited from an ancestor. It fails on the second `Edit` without the fix.

## Summary by Sourcery

Normalize Alpine class bindings to use the object form across views to prevent stale classes after Livewire morphs and ensure interactive states update correctly.

Enhancements:
- Update single-branch Alpine x-bind:class usages in multiple views to the object syntax for more reliable class toggling with Livewire morphs.
- Adjust various visual state bindings (e.g., rotations, opacity, fullscreen/layout states) to the object form for consistent UI behaviour.

Tests:
- Add a browser test for the contact accounting tab to verify fields remain interactable across edit/save/edit cycles by hit-testing the VAT field instead of class names.