### PR TITLE
Re-initialize the dashboard grid after SPA navigation

### DIFF
--- a/resources/views/livewire/support/dashboard.blade.php
+++ b/resources/views/livewire/support/dashboard.blade.php
@@ -1,6 +1,7 @@
 <div
     x-data="dashboard()"
     x-init.once="reInit().disable()"
+    x-on:livewire:navigated.window="reInit().disable()"
     x-on:gridstack-reinit.window="reinitWithPositionSaving()"
     x-on:remove-group.window="removeNewGroup($event.detail.groupName)"
 >


### PR DESCRIPTION
## Problem

On the dashboard, GridStack is initialized only through `x-init.once`. That expression does not run again when Livewire restores the cached dashboard DOM on browser back/forward navigation. Because the grid is destroyed on page leave, navigating back left the widgets rendered but their Alpine bindings dead (e.g. clickable data-table rows no longer respond).

## Fix

Also re-initialize the grid on `livewire:navigated`. `GridStack.init` returns the existing instance when the grid is already initialized, so navigating to the dashboard normally is unaffected; the listener is scoped to the dashboard component, so it only fires while the dashboard is mounted.

## Verification

Reasoned against the existing `livewire:navigated` idiom already used in the codebase (e.g. `resources/views/components/flash.blade.php`). Final behavior should be confirmed in a browser on a deployed instance: open the dashboard, click a widget row to a detail page, press browser Back, and confirm the rows are clickable again.

## Summary by Sourcery

Bug Fixes:
- Ensure the dashboard grid and its Alpine bindings are re-initialized on Livewire SPA navigation so widget interactions remain functional after returning via browser history.