### PR TITLE
Add the department field to the new-contact dialog

### DIFF
--- a/src/Livewire/Forms/ContactForm.php
+++ b/src/Livewire/Forms/ContactForm.php
@@ -113,6 +113,8 @@ class ContactForm extends FluxForm
 
     public ?string $company = null;
 
+    public ?string $department = null;
+
     #[RenderAs(
         type: RenderAs::SELECT,
         options: [
@@ -212,6 +214,7 @@ class ContactForm extends FluxForm
             'country_id',
             'language_id',
             'company',
+            'department',
             'title',
             'salutation',
             'firstname',

--- a/tests/Livewire/DataTables/ContactListTest.php
+++ b/tests/Livewire/DataTables/ContactListTest.php
@@ -7,3 +7,11 @@ test('renders successfully', function (): void {
     Livewire::test(ContactList::class)
         ->assertOk();
 });
+
+test('maps the department into the main address of a new contact', function (): void {
+    $form = Livewire::test(ContactList::class)->instance()->createContactForm;
+    $form->company = 'Test Corp';
+    $form->department = 'Research';
+
+    expect(data_get($form->toActionData(), 'main_address.department'))->toBe('Research');
+});


### PR DESCRIPTION
The address `department` field already exists on the addresses table, the create/update address rulesets, `AddressForm` and the address edit view, but the create-contact form did not expose it. A department could therefore only be filled in after the contact was created.

Add `department` to `ContactForm` (auto-rendered as a labelled input) and include it in the flat address fields mapped into the new contact's main address, so it can be set directly in the new-contact dialog.

Covered by a test asserting the form maps `department` into `main_address`.

## Summary by Sourcery

Expose the existing address department field in the new-contact flow and ensure it is persisted on the main address.

New Features:
- Allow entering a department when creating a new contact so it is stored on the main address.

Tests:
- Add a Livewire ContactList test verifying the department field is mapped into the new contact's main address.