### PR TITLE
docs: rewrite README for package-based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,223 +1,79 @@
 <p align="center"><a href="https://team-nifty.com" target="_blank"><img src="https://user-images.githubusercontent.com/40495041/160839207-0e1593e0-ff3d-4407-b9d2-d3513c366ab9.svg" width="400"></a></p>
 
-### 1. Installation
+# Flux ERP
 
-Remove the welcome route from `routes/web.php`.
+Flux ERP is a modern, open-source ERP built on Laravel and Livewire. It ships as a
+**Composer package** that you install into a Laravel application.
 
-Add the following to your `config/filesystem.php` config file
+> [!IMPORTANT]
+> Flux is a **package, not a standalone app.** That is why this repository has no
+> `artisan` file and no `bootstrap/app.php` — those belong to the Laravel host
+> application. You cannot run `php artisan …` inside this repository directly. Install
+> it into a fresh Laravel app as shown below.
 
-```php
-    'links' => [
-        ...
-        public_path('flux') => base_path('vendor/team-nifty-gmbh/flux-erp/public'),
-    ],
-```
+## Requirements
 
-link the flux-erp assets
+- PHP **8.4** (`bcmath`, `intl`, `json`, `pdo`, `zip`)
+- MySQL 8 / MariaDB
+- [Meilisearch](https://www.meilisearch.com/) — search (Laravel Scout)
+- Composer 2
+
+No Node.js or frontend build is needed on the project side. Flux serves its compiled
+assets straight from the package at runtime.
+
+## Installation
 
 ```bash
+# 1. Create a fresh Laravel app
+composer create-project laravel/laravel flux-app
+cd flux-app
+
+# 2. Require Flux (service provider, migrations, routes and assets auto-register)
+composer require team-nifty-gmbh/flux-erp
+
+# 3. Migrate the database
+php artisan migrate
+
+# 4. Set up roles and permissions
+php artisan init:permissions
+
+# 5. Link storage for uploaded media
 php artisan storage:link
 ```
 
-This will create a symlink in `public/flux` to `vendor/team-nifty-gmbh/flux/public` which is where the flux-erp assets are stored.
+Configure your database, Meilisearch and mail credentials in `.env` before migrating,
+and remove the default welcome route from `routes/web.php` (Flux registers its own).
 
-If you want to use seeders add the following to your DatabaseSeeder.php file:
+### Seeding base data
+
+Add the seeder to `database/seeders/DatabaseSeeder.php`:
 
 ```php
 $this->call(\FluxErp\Database\Seeders\FluxSeeder::class);
 ```
 
-Because vite includes the pusher data into the build process its neccessary to rebuild the assets after the installation.
+then run `php artisan db:seed`.
+
+Serve the app with `php artisan serve` (or Sail) and log in.
+
+## Frontend assets
+
+Assets are compiled inside the package and served through its own `/flux/…` routes.
+The `@fluxStyles` and `@fluxScripts` Blade directives inject them — add these to your
+`<head>` and before `</body>` only if you use a custom layout instead of the shipped
+one. Nothing to build or publish.
+
+## Realtime (Laravel Reverb)
+
+Flux uses [Laravel Reverb](https://reverb.laravel.com/) for realtime features.
+Broadcasting credentials are read from `.env` at runtime, so no rebuild is required
+when they change.
 
 ```bash
-vite build
+php artisan reverb:start
 ```
-
-Please keep in mind to do so after setting the pusher credentials in the .env file.
-
-### 2. Development
-
-If you want to develop for flux-erp you should publish the docker files (this runs nginx instead of artisan serve)
-
-```bash
-php artisan vendor:publish --tag="flux-docker"
-```
-
-Alternative you can change your docker-compose.yml file to use the flux-erp docker files from the vendor folder.
-
-```yaml
-    laravel.test:
-        build:
-            context: ./vendor/team-nifty-gmbh/flux-erp/docker/8.4 # <--- Here
-   ...
-```
-
-You should also mount the MySQL config file in your `docker-compose.yml` to improve database performance:
-
-```yaml
-    mysql:
-        ...
-        volumes:
-            - 'sail-mysql:/var/lib/mysql'
-            - './vendor/team-nifty-gmbh/flux-erp/docker/mysql/my.cnf:/etc/my.cnf:ro' # <--- Add this line
-        ...
-```
-
-If you have already built the Docker images, you should rebuild them.
-
-```bash
-sail build --no-cache
-```
-
-### 3. Running tests
-
-```bash
-cd vendor/flux-erp
-composer i
-composer test
-```
-
-# 2. Websockets
-
-I expect you to run your flux application in nginx with certbot ssl.
-Its important to understand that nginx serves as a proxy for the websockets running with supervisor.
-
-This means that your supervisor config file should use a different port than the one you use for your nginx config.
-You should build the Pusher config with port 443 as it should be the production port for your app.
-
-```js
-// resources/js/bootstrap.js
-import Echo from 'laravel-echo';
-import Pusher from 'pusher-js';
-
-window.Pusher = Pusher;
-
-window.Echo = new Echo({
-    broadcaster: 'pusher',
-    key: import.meta.env.VITE_PUSHER_APP_KEY,
-    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
-    wsHost: window.location.hostname, // <-- important if you dont build the js file on the prod server
-    wsPort: 80, // <-- this ensures that nginx will receive the request
-    wssPort: 443, // <-- this ensures that nginx will receive the request
-    disableStats: true,
-    enabledTransports: ['ws', 'wss'],
-});
-```
-
-Your nginx config should look like this
-
-```nginx
-# Virtual Host configuration for tnconnect
-#
-# You can move that to a different file under sites-available/ and symlink that
-# to sites-enabled/ to enable it.
-#
-
-map $http_upgrade $type {
-    default "web";
-    websocket "wss";
-}
-
-server {
-
-    # SSL configuration
-    #
-    # listen 443 ssl default_server;
-    # listen [::]:443 ssl default_server;
-    #
-    # Note: You should disable gzip for SSL traffic.
-    # See: https://bugs.debian.org/773332
-    #
-    # Read up on ssl_ciphers to ensure a secure configuration.
-    # See: https://bugs.debian.org/765782
-    #
-    # Self signed certs generated by the ssl-cert package
-    # Don't use them in a production server!
-    #
-    # include snippets/snakeoil.conf;
-
-    root /var/www/your.domain.com/public;
-
-    charset utf-8;
-
-    error_page 404 /index.php;
-
-    add_header X-Content-Type-Options "nosniff";
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Frame-Options "SAMEORIGIN";
-
-    # Add index.php to the list if you are using PHP
-    index index.php;
-    server_name your.domain.com;
-
-    location / {
-        try_files /nonexistent @$type;
-    }
-
-    location @web {
-        # First attempt to serve request as file, then
-        # as directory, then fall back to displaying a 404.
-        try_files $uri $uri/ /index.php?$args;
-    }
-
-    location @wss {
-        proxy_pass http://127.0.0.1:6001;
-        proxy_set_header Host $host;
-        proxy_read_timeout 60;
-        proxy_connect_timeout 60;
-        proxy_redirect off;
-
-        # Allow the use of websockets
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-    }
-
-    # pass PHP scripts to FastCGI server
-    #
-    location ~ \.php$ {
-        include fastcgi_params;
-        fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-        fastcgi_pass unix:/run/php/php8.2-fpm.sock;
-    }
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    location ~ /\.ht {
-        deny all;
-    }
-
-    ssl on;
-    listen [::]:443 ssl ipv6only=on; # managed by Certbot
-    listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/your.domain.com/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/your.domain.com/privkey.pem; # managed by Certbot
-    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-
-}
-
-server {
-    if ($host = your.domain.com) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
-
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    server_name your.domain.com;
-    return 404; # managed by Certbot
-}
-```
-
-Your .env file should look something like this:
 
 ```dotenv
-# .env
 REVERB_APP_ID=local
 REVERB_APP_KEY=local
 REVERB_APP_SECRET=local
@@ -226,18 +82,49 @@ REVERB_SCHEME=https
 REVERB_PORT=443
 ```
 
-This ensures that nginx handles your request, if you have mutliple instances of websockets running on the same server nginx will handle the request to the correct instance.
+In production run Reverb behind your web server as a reverse proxy so websocket
+traffic reaches it on port 443.
 
-If you have only one instance of websockets running you can use the default port 6001 and remove the `PUSHER_PORT` from your .env file.
+## Publishing package resources (optional)
 
-```dotenv
-# .env
-REVERB_APP_ID=local
-REVERB_APP_KEY=local
-REVERB_APP_SECRET=local
-REVERB_HOST=0.0.0.0
-REVERB_PORT=8080
-REVERB_SCHEME=http
+Only needed to override defaults:
+
+| Tag                 | Publishes                                      |
+|---------------------|------------------------------------------------|
+| `flux-config`       | `config/flux.php`                              |
+| `flux-views`        | Blade views into `resources/views/vendor/flux` |
+| `flux-translations` | Language files                                 |
+| `flux-migrations`   | Migrations into `database/migrations`          |
+| `flux-seeders`      | Seeders into `database/seeders`                |
+| `flux-docker`       | Docker/Sail setup                              |
+
+```bash
+php artisan vendor:publish --tag=flux-config
 ```
 
-This will not be piped through nginx and will be handled by the websocket server directly.
+## Development
+
+Flux publishes a Docker/Sail setup that runs nginx instead of `artisan serve`:
+
+```bash
+php artisan vendor:publish --tag=flux-docker
+```
+
+Run the package test suite (uses [Testbench](https://github.com/orchestral/testbench))
+from the package directory:
+
+```bash
+composer install
+composer test
+```
+
+## Documentation
+
+Guides for extending Flux live in [`docs`](./docs):
+[routes](./docs/routes.md), [views](./docs/views.md), [widgets](./docs/widgets.md),
+[print views](./docs/print-views.md), [monitorable jobs](./docs/monitorable-jobs.md),
+[backend customization](./docs/customizing-backend.md).
+
+## License
+
+Flux ERP is open-sourced software licensed under the [MIT license](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -31,18 +31,24 @@ cd flux-app
 # 2. Require Flux (service provider, migrations, routes and assets auto-register)
 composer require team-nifty-gmbh/flux-erp
 
-# 3. Migrate the database
-php artisan migrate
+# 3. Require the license package (provides the install wizard)
+composer require team-nifty-gmbh/flux-license
 
-# 4. Set up roles and permissions
-php artisan init:permissions
+# 4. Run the interactive install wizard
+php artisan flux:install
 
 # 5. Link storage for uploaded media
 php artisan storage:link
 ```
 
-Configure your database, Meilisearch and mail credentials in `.env` before migrating,
-and remove the default welcome route from `routes/web.php` (Flux registers its own).
+Configure your database, Meilisearch and mail credentials in `.env` before running the
+wizard, and remove the default welcome route from `routes/web.php` (Flux registers its
+own).
+
+The `php artisan flux:install` wizard guides you through the remaining setup
+(migrations, roles and permissions, base data, payment types, and so on). If you
+prefer to run the steps manually instead, use `php artisan migrate` and
+`php artisan init:permissions`.
 
 ### Seeding base data
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ traffic reaches it on port 443.
 Only needed to override defaults:
 
 | Tag                 | Publishes                                      |
-|---------------------|------------------------------------------------|
+| ------------------- | ---------------------------------------------- |
 | `flux-config`       | `config/flux.php`                              |
 | `flux-views`        | Blade views into `resources/views/vendor/flux` |
 | `flux-translations` | Language files                                 |


### PR DESCRIPTION
## Why

New users try to install Flux like a standalone Laravel app and get stuck: the repository has no `artisan` file, so `php artisan` fails. The README also documented an outdated install flow (frontend build, asset publishing, Pusher config) that no longer applies now that assets are served by the package at runtime.

## What

Rewrote the README from scratch:

- State up front that Flux is a Composer package, not a standalone app, and explain why there is no `artisan` / `bootstrap/app.php`.
- Document the correct install flow into a fresh Laravel app (`composer require`, `migrate`, `init:permissions`, `storage:link`, seeding).
- Note that no project-side frontend build is needed; assets are served by the package via its own routes and the `@fluxStyles` / `@fluxScripts` directives.
- Replace the Pusher/legacy nginx section with a concise Reverb section (credentials read at runtime).
- Keep publishable resource tags, Docker/Sail development setup and test instructions.

## Summary by Sourcery

Rewrite the README to document Flux ERP as a Composer package installed into a host Laravel app, with updated installation, runtime, and supporting docs sections.

Documentation:
- Update installation instructions to clearly state Flux ERP is a package for a fresh Laravel application and outline the correct setup steps including migrations, permissions, storage linking, and seeding.
- Document that frontend assets are served by the package at runtime via Blade directives, removing the need for project-side asset builds.
- Replace legacy Pusher and nginx websocket guidance with concise Laravel Reverb-based configuration and deployment notes.
- Describe optional resource publishing tags, Docker/Sail-based development setup, and how to run the package test suite using Testbench.
- Add pointers to the dedicated docs directory for extending Flux (routes, views, widgets, print views, jobs, and backend customization).