### PR TITLE
fix(contact): reset error bag when switching addresses

### DIFF
--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -245,6 +245,7 @@ class Addresses extends Component
     #[Renderless]
     public function new(): void
     {
+        $this->resetErrorBag();
         $this->address->reset();
 
         $this->address->contact_id = $this->contact->id;
@@ -282,6 +283,7 @@ class Addresses extends Component
     public function replicate(): void
     {
         $this->tab = 'address.address';
+        $this->resetErrorBag();
         $this->address->reset(
             'id',
             'email',
@@ -332,6 +334,7 @@ class Addresses extends Component
             $this->skipRender();
         }
 
+        $this->resetErrorBag();
         $this->address->reset();
         $this->address->fill($address);
 

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -63,3 +63,34 @@ test('switch tabs', function (): void {
         ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
         ->cycleTabs();
 });
+
+test('invalid salutation blocks saving', function (): void {
+    Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
+        ->set('address.salutation', 'Firma')
+        ->set('address.street', $street = Str::uuid())
+        ->set('edit', true)
+        ->call('save')
+        ->assertOk()
+        ->assertHasErrors('address.salutation')
+        ->assertSet('edit', true);
+
+    $this->assertDatabaseMissing('addresses', ['id' => $this->addressForm->id, 'street' => $street]);
+});
+
+test('selecting another address resets validation errors', function (): void {
+    $otherAddress = Address::factory()->create([
+        'contact_id' => $this->contactForm->id,
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
+        ->set('address.salutation', 'Firma')
+        ->set('edit', true)
+        ->call('save')
+        ->assertHasErrors('address.salutation')
+        ->call('select', $otherAddress->id)
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('address.id', $otherAddress->id);
+});


### PR DESCRIPTION
## Problem

When saving an address fails validation (e.g. a legacy salutation value that is not a valid SalutationEnum case), the validation errors stick to the Addresses component. Selecting another address, creating a new one or replicating one still shows the stale errors from the previous address.

## Fix

Reset the error bag in `select()`, `new()` and `replicate()` before the form is refilled.

## Tests

- `selecting another address resets validation errors` — fails without the fix
- `invalid salutation blocks saving` — regression test pinning that an invalid salutation is rejected by `PostalAddressRuleset` and no other field changes are persisted

## Summary by Sourcery

Reset validation errors when switching or creating contact addresses to avoid stale error messages.

Bug Fixes:
- Clear the Livewire error bag when selecting, creating, or replicating a contact address so validation errors do not persist across address changes.

Tests:
- Add regression tests ensuring invalid salutations prevent saving and that switching addresses clears previous validation errors.