### PR TITLE
fix(comments): open attachment previews in the lightbox instead of the detail modal

### DIFF
--- a/resources/views/components/features/comments/comment.blade.php
+++ b/resources/views/components/features/comments/comment.blade.php
@@ -93,8 +93,11 @@
                                 x-cloak
                                 x-show="file.preview_url !== ''"
                                 class="h-full"
+                                data-testid="comment-attachment-preview"
                                 x-on:click="
-                                    $nuxbe.openDetailModal(file.original_url)
+                                    $nuxbe.openLightbox(file.original_url, {
+                                        title: file.name,
+                                    })
                                 "
                                 icon="eye"
                             />

--- a/tests/Browser/Features/Comments/CommentsTest.php
+++ b/tests/Browser/Features/Comments/CommentsTest.php
@@ -46,6 +46,10 @@ test('comment editor initializes with tiptap', function (): void {
 });
 
 test('comment attachment preview opens the lightbox', function (): void {
+    // The preview button only renders once the preview conversion exists; run
+    // conversions synchronously as no queue worker is available in tests.
+    config(['media-library.queue_conversions_by_default' => false]);
+
     $comment = Comment::factory()->create([
         'model_type' => morph_alias(Order::class),
         'model_id' => $this->order->getKey(),

--- a/tests/Browser/Features/Comments/CommentsTest.php
+++ b/tests/Browser/Features/Comments/CommentsTest.php
@@ -2,12 +2,14 @@
 
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Models\Address;
+use FluxErp\Models\Comment;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
+use Illuminate\Http\UploadedFile;
 
 beforeEach(function (): void {
     $contact = Contact::factory()->create();
@@ -41,4 +43,37 @@ test('comment editor initializes with tiptap', function (): void {
     clickTab($page, 'Comments', 'Kommentare');
 
     $page->assertScript('!!document.querySelector(".ProseMirror, [contenteditable=\\"true\\"]")');
+});
+
+test('comment attachment preview opens the lightbox', function (): void {
+    $comment = Comment::factory()->create([
+        'model_type' => morph_alias(Order::class),
+        'model_id' => $this->order->getKey(),
+        'is_internal' => false,
+    ]);
+    $comment->addMedia(UploadedFile::fake()->image('attachment.png'))
+        ->toMediaCollection();
+
+    $page = visit(route('orders.id', ['id' => $this->order->getKey()]))
+        ->assertNoSmoke();
+
+    waitForElement($page, '[data-tab-name="order.comments"]');
+    $page->click('[data-tab-name="order.comments"]');
+
+    $page->script(<<<'JS'
+        () => {
+            window.__lightboxOpened = false;
+            window.addEventListener('nuxbe:lightbox:open', () => {
+                window.__lightboxOpened = true;
+            });
+        }
+    JS);
+
+    waitForElement($page, '[data-testid="comment-attachment-preview"]', 10000);
+
+    $page->click('[data-testid="comment-attachment-preview"]');
+
+    $page->wait(0.5)
+        ->assertScript('window.__lightboxOpened === true')
+        ->assertNoJavascriptErrors();
 });


### PR DESCRIPTION
## Problem

The eye button on a comment attachment opens the global detail modal (iframe). That modal shares `z-50` with regular TallStackUI modals and sits early in the DOM, so when the comments section lives inside another modal, the preview renders behind that modal and is unusable.

## Fix

Open comment attachment previews via the core lightbox (`$nuxbe.openLightbox`) instead. The lightbox overlay renders at `z-[60]` above modals and is the intended surface for file previews (image/pdf/audio/video handlers with a download fallback).

## Test

Adds a Pest browser test that attaches an image to a comment, clicks the preview button, and asserts the `nuxbe:lightbox:open` event fires without JS errors.