### PR TITLE
feat(accounting): assign transactions to ledger accounts without a document

### DIFF
--- a/database/factories/LedgerAccountTransactionFactory.php
+++ b/database/factories/LedgerAccountTransactionFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FluxErp\Database\Factories;
+
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LedgerAccountTransactionFactory extends Factory
+{
+    protected $model = LedgerAccountTransaction::class;
+
+    public function definition(): array
+    {
+        return [
+            'amount' => fake()->randomFloat(2, 0, 10000),
+        ];
+    }
+}

--- a/database/migrations/2026_07_15_000001_create_ledger_account_transaction_table.php
+++ b/database/migrations/2026_07_15_000001_create_ledger_account_transaction_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ledger_account_transaction', function (Blueprint $table): void {
+            $table->id('pivot_id');
+            $table->foreignId('ledger_account_id')->constrained('ledger_accounts')->cascadeOnDelete();
+            $table->foreignId('transaction_id')->constrained('transactions')->cascadeOnDelete();
+            $table->decimal('amount', 40, 10);
+            $table->string('note')->nullable();
+            $table->boolean('is_accepted')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ledger_account_transaction');
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -405,6 +405,7 @@
     "Asset": "Anlage",
     "Assign": "Zuordnen",
     "Assign leads to the agent stored in the contact. If no agent is set, leads will be assigned to you.": "Leads dem im Kontakt hinterlegten Vertreter zuordnen. Wenn kein Vertreter hinterlegt ist, werden die Leads Ihnen zugeordnet.",
+    "Assign ledger account": "Sachkonto zuordnen",
     "Assign order": "Auftrag zuweisen",
     "Assign product": "Produkt zuordnen",
     "Assign serial number": "Seriennummer zuordnen",

--- a/lang/de.json
+++ b/lang/de.json
@@ -390,6 +390,7 @@
     "Apply Discount Amount": "Skonto-Betrag anwenden",
     "Apply Gross Total": "Bruttosumme anwenden",
     "Apply Payment Amount": "Zahlbetrag anwenden",
+    "Apply transaction amount": "Transaktionsbetrag übernehmen",
     "Approval": "Genehmigung",
     "Approval Required": "Genehmigung erforderlich",
     "Approval User": "Freigabeberechtigter",

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -236,6 +236,48 @@
         </x-slot:footer>
     </x-modal>
 
+    <x-modal
+        id="ledger-account-transaction-modal"
+        :title="__('Assign ledger account')"
+    >
+        <div class="flex flex-col gap-4">
+            <x-select.styled
+                :label="__('Ledger Account')"
+                wire:model.number="ledgerAccountTransactionForm.ledger_account_id"
+                select="label:name|value:id|description:number"
+                unfiltered
+                :request="[
+                    'url' => route('search', \FluxErp\Models\LedgerAccount::class),
+                    'method' => 'POST',
+                ]"
+            />
+            <x-number
+                :label="__('Amount')"
+                wire:model="ledgerAccountTransactionForm.amount"
+                step="0.01"
+                placeholder="0.00"
+            />
+            <x-input
+                :label="__('Note')"
+                wire:model="ledgerAccountTransactionForm.note"
+            />
+        </div>
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="
+                    $tsui.close.modal('ledger-account-transaction-modal')
+                "
+            />
+            @stack('ledger-account-transaction-modal-footer')
+            <x-button
+                :text="__('Save')"
+                x-on:click="$wire.saveLedgerAccountTransaction()"
+            />
+        </x-slot:footer>
+    </x-modal>
+
     <div class="flex flex-col gap-4 text-sm">
         <div class="flex flex-col">
             <x-tab wire:model.live="tab">
@@ -535,6 +577,80 @@
                                         </div>
                                     </div>
                                 </template>
+                                <template
+                                    x-for="
+                                        ledgerAccountTransaction in
+                                        transaction.ledger_account_transactions
+                                    "
+                                >
+                                    <div
+                                        class="group flex flex-row items-center gap-2 px-2"
+                                    >
+                                        <div
+                                            class="group/button relative w-fit rounded-full"
+                                        >
+                                            <x-button.circle
+                                                color="emerald"
+                                                rounded
+                                                icon="book-open"
+                                                class="block transition-opacity duration-200 group-hover/button:opacity-0"
+                                            />
+                                            <x-button.circle
+                                                color="red"
+                                                rounded
+                                                icon="link-slash"
+                                                wire:click="deleteLedgerAccountTransaction(ledgerAccountTransaction.pivot_id)"
+                                                wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Assignment')]) }}"
+                                                class="absolute top-0 left-0 opacity-0 transition-opacity duration-200 group-hover/button:opacity-100"
+                                            />
+                                        </div>
+                                        <div
+                                            class="flex w-full justify-between rounded bg-slate-100 p-2 font-semibold"
+                                        >
+                                            <div>
+                                                <div
+                                                    x-text="
+                                                        ledgerAccountTransaction
+                                                            .ledger_account
+                                                            ?.number +
+                                                        ' ' +
+                                                        ledgerAccountTransaction
+                                                            .ledger_account
+                                                            ?.name
+                                                    "
+                                                ></div>
+                                                <div
+                                                    class="text-xs font-normal text-slate-500"
+                                                    x-text="
+                                                        ledgerAccountTransaction.note
+                                                    "
+                                                ></div>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <div
+                                                    class="flex items-center justify-end font-semibold"
+                                                    x-html="
+                                                        $nuxbe.format.money(
+                                                            ledgerAccountTransaction.amount,
+                                                            {
+                                                                colored: true,
+                                                            },
+                                                        )
+                                                    "
+                                                ></div>
+                                                <div class="block">
+                                                    <x-button
+                                                        class="h-full"
+                                                        color="secondary"
+                                                        sm
+                                                        icon="pencil"
+                                                        wire:click="editLedgerAccountTransaction(ledgerAccountTransaction.pivot_id)"
+                                                    />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
                                 <div class="px-2 pt-2">
                                     <div class="flex flex-col">
                                         <div
@@ -595,11 +711,26 @@
                                                 />
                                                 <x-button
                                                     sm
+                                                    light
+                                                    color="gray"
+                                                    wire:click="assignLedgerAccountModal(transaction.id)"
+                                                    x-cloak
+                                                    x-show="
+                                                        parseFloat(
+                                                            transaction.balance,
+                                                        ) !== 0
+                                                    "
+                                                    :text="__('Assign ledger account')"
+                                                />
+                                                <x-button
+                                                    sm
                                                     color="red"
                                                     wire:click="toggleIgnoreTransaction(transaction.id)"
                                                     x-cloak
                                                     x-show="
                                                         transaction.order_transactions_count ===
+                                                            0 &&
+                                                        transaction.ledger_account_transactions_count ===
                                                             0 &&
                                                         !transaction.is_ignored
                                                     "

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -232,6 +232,7 @@
             <x-button
                 :text="__('Save')"
                 x-on:click="$wire.saveOrderTransaction()"
+                loading="saveOrderTransaction()"
             />
         </x-slot:footer>
     </x-modal>
@@ -305,7 +306,7 @@
             @stack('ledger-account-transaction-modal-footer')
             <x-button
                 :text="__('Save')"
-                wire:click="saveLedgerAccountTransaction()"
+                x-on:click="$wire.saveLedgerAccountTransaction()"
                 loading="saveLedgerAccountTransaction()"
             />
         </x-slot:footer>

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -251,12 +251,44 @@
                     'method' => 'POST',
                 ]"
             />
-            <x-number
-                :label="__('Amount')"
-                wire:model="ledgerAccountTransactionForm.amount"
-                step="0.01"
-                placeholder="0.00"
-            />
+            <div class="flex flex-col gap-2">
+                <x-number
+                    :label="__('Amount')"
+                    wire:model="ledgerAccountTransactionForm.amount"
+                    step="0.01"
+                    placeholder="0.00"
+                />
+                <div>
+                    <x-button
+                        sm
+                        color="secondary"
+                        x-cloak
+                        x-show="
+                            $wire.ledgerAccountTransactionForm
+                                .transactionBalance !== null &&
+                            $wire.ledgerAccountTransactionForm.amount !==
+                                $wire.ledgerAccountTransactionForm
+                                    .transactionBalance
+                        "
+                        x-on:click="
+                            $wire.ledgerAccountTransactionForm.amount =
+                                $wire.ledgerAccountTransactionForm.transactionBalance
+                        "
+                    >
+                        <x-slot:text>
+                            {{ __('Apply transaction amount') }} (<span
+                                x-html="
+                                    $nuxbe.format.money(
+                                        $wire.ledgerAccountTransactionForm
+                                            .transactionBalance,
+                                    )
+                                "
+                            ></span
+                            >)
+                        </x-slot:text>
+                    </x-button>
+                </div>
+            </div>
             <x-input
                 :label="__('Note')"
                 wire:model="ledgerAccountTransactionForm.note"

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -305,7 +305,8 @@
             @stack('ledger-account-transaction-modal-footer')
             <x-button
                 :text="__('Save')"
-                x-on:click="$wire.saveLedgerAccountTransaction()"
+                wire:click="saveLedgerAccountTransaction()"
+                loading="saveLedgerAccountTransaction()"
             />
         </x-slot:footer>
     </x-modal>

--- a/routes/api.php
+++ b/routes/api.php
@@ -121,6 +121,9 @@ use FluxErp\Actions\LeadState\UpdateLeadState;
 use FluxErp\Actions\LedgerAccount\CreateLedgerAccount;
 use FluxErp\Actions\LedgerAccount\DeleteLedgerAccount;
 use FluxErp\Actions\LedgerAccount\UpdateLedgerAccount;
+use FluxErp\Actions\LedgerAccountTransaction\CreateLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\DeleteLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\UpdateLedgerAccountTransaction;
 use FluxErp\Actions\Location\CreateLocation;
 use FluxErp\Actions\Location\DeleteLocation;
 use FluxErp\Actions\Location\UpdateLocation;
@@ -365,6 +368,7 @@ use FluxErp\Models\PaymentType;
 use FluxErp\Models\Permission;
 use FluxErp\Models\Pivots\BundleProductProduct;
 use FluxErp\Models\Pivots\EmployeeWorkTimeModel;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Models\Pivots\PrinterUser;
 use FluxErp\Models\Price;
@@ -842,6 +846,15 @@ Route::prefix('api')
                 Route::post('/order-transactions', CreateOrderTransaction::class);
                 Route::put('/order-transactions', UpdateOrderTransaction::class);
                 Route::delete('/order-transactions/{id}', DeleteOrderTransaction::class);
+
+                // LedgerAccountTransactions
+                Route::get('/ledger-account-transactions/{id}', [BaseController::class, 'show'])
+                    ->defaults('model', LedgerAccountTransaction::class);
+                Route::get('/ledger-account-transactions', [BaseController::class, 'index'])
+                    ->defaults('model', LedgerAccountTransaction::class);
+                Route::post('/ledger-account-transactions', CreateLedgerAccountTransaction::class);
+                Route::put('/ledger-account-transactions', UpdateLedgerAccountTransaction::class);
+                Route::delete('/ledger-account-transactions/{id}', DeleteLedgerAccountTransaction::class);
 
                 // OrderTypes
                 Route::get('/order-types/{id}', [BaseController::class, 'show'])->defaults('model', OrderType::class);

--- a/src/Actions/LedgerAccountTransaction/CreateLedgerAccountTransaction.php
+++ b/src/Actions/LedgerAccountTransaction/CreateLedgerAccountTransaction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FluxErp\Actions\LedgerAccountTransaction;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Rulesets\LedgerAccountTransaction\CreateLedgerAccountTransactionRuleset;
+
+class CreateLedgerAccountTransaction extends FluxAction
+{
+    public static function models(): array
+    {
+        return [LedgerAccountTransaction::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return CreateLedgerAccountTransactionRuleset::class;
+    }
+
+    public function performAction(): LedgerAccountTransaction
+    {
+        /** @var LedgerAccountTransaction $ledgerAccountTransaction */
+        $ledgerAccountTransaction = app(LedgerAccountTransaction::class, ['attributes' => $this->getData()]);
+        $ledgerAccountTransaction->save();
+
+        return $ledgerAccountTransaction->refresh();
+    }
+}

--- a/src/Actions/LedgerAccountTransaction/DeleteLedgerAccountTransaction.php
+++ b/src/Actions/LedgerAccountTransaction/DeleteLedgerAccountTransaction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FluxErp\Actions\LedgerAccountTransaction;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Rulesets\LedgerAccountTransaction\DeleteLedgerAccountTransactionRuleset;
+
+class DeleteLedgerAccountTransaction extends FluxAction
+{
+    public static function models(): array
+    {
+        return [LedgerAccountTransaction::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return DeleteLedgerAccountTransactionRuleset::class;
+    }
+
+    public function performAction(): bool
+    {
+        return resolve_static(LedgerAccountTransaction::class, 'query')
+            ->whereKey($this->getData('pivot_id'))
+            ->first()
+            ->delete();
+    }
+}

--- a/src/Actions/LedgerAccountTransaction/UpdateLedgerAccountTransaction.php
+++ b/src/Actions/LedgerAccountTransaction/UpdateLedgerAccountTransaction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FluxErp\Actions\LedgerAccountTransaction;
+
+use FluxErp\Actions\FluxAction;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Rulesets\LedgerAccountTransaction\UpdateLedgerAccountTransactionRuleset;
+
+class UpdateLedgerAccountTransaction extends FluxAction
+{
+    public static function models(): array
+    {
+        return [LedgerAccountTransaction::class];
+    }
+
+    protected function getRulesets(): string|array
+    {
+        return UpdateLedgerAccountTransactionRuleset::class;
+    }
+
+    public function performAction(): LedgerAccountTransaction
+    {
+        $ledgerAccountTransaction = resolve_static(LedgerAccountTransaction::class, 'query')
+            ->whereKey($this->getData('pivot_id'))
+            ->first();
+        $ledgerAccountTransaction->fill($this->getData());
+        $ledgerAccountTransaction->save();
+
+        return $ledgerAccountTransaction->withoutRelations()->fresh();
+    }
+}

--- a/src/Livewire/Accounting/TransactionAssignments.php
+++ b/src/Livewire/Accounting/TransactionAssignments.php
@@ -4,11 +4,13 @@ namespace FluxErp\Livewire\Accounting;
 
 use FluxErp\Actions\OrderTransaction\CreateOrderTransaction;
 use FluxErp\Actions\OrderTransaction\UpdateOrderTransaction;
+use FluxErp\Livewire\Forms\LedgerAccountTransactionForm;
 use FluxErp\Livewire\Forms\OrderTransactionForm;
 use FluxErp\Livewire\Forms\TransactionForm;
 use FluxErp\Models\BankConnection;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Order;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Models\Transaction;
 use FluxErp\Traits\Livewire\Actions;
@@ -27,6 +29,8 @@ class TransactionAssignments extends Component
     use Actions, WithPagination;
 
     public ?array $bankAccounts = null;
+
+    public LedgerAccountTransactionForm $ledgerAccountTransactionForm;
 
     public OrderTransactionForm $orderTransactionForm;
 
@@ -161,6 +165,35 @@ class TransactionAssignments extends Component
     }
 
     #[Renderless]
+    public function assignLedgerAccountModal(Transaction $transaction): void
+    {
+        $this->ledgerAccountTransactionForm->reset();
+        $this->ledgerAccountTransactionForm->transaction_id = $transaction->getKey();
+        $this->ledgerAccountTransactionForm->amount = (float) $transaction->balance;
+
+        $this->js(<<<'JS'
+            $tsui.open.modal('ledger-account-transaction-modal');
+        JS);
+    }
+
+    #[Renderless]
+    public function deleteLedgerAccountTransaction(LedgerAccountTransaction $ledgerAccountTransaction): void
+    {
+        $this->ledgerAccountTransactionForm->reset();
+        $this->ledgerAccountTransactionForm->fill($ledgerAccountTransaction);
+
+        try {
+            $this->ledgerAccountTransactionForm->delete();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->refreshTransactions();
+    }
+
+    #[Renderless]
     public function deleteOrderTransaction(OrderTransaction $orderTransaction): void
     {
         $this->orderTransactionForm->reset();
@@ -175,6 +208,17 @@ class TransactionAssignments extends Component
         }
 
         $this->refreshTransactions();
+    }
+
+    #[Renderless]
+    public function editLedgerAccountTransaction(LedgerAccountTransaction $ledgerAccountTransaction): void
+    {
+        $this->ledgerAccountTransactionForm->reset();
+        $this->ledgerAccountTransactionForm->fill($ledgerAccountTransaction);
+
+        $this->js(<<<'JS'
+            $tsui.open.modal('ledger-account-transaction-modal');
+        JS);
     }
 
     #[Renderless]
@@ -222,6 +266,7 @@ class TransactionAssignments extends Component
             )
             ->withCount([
                 'orderTransactions',
+                'ledgerAccountTransactions',
                 'comments',
                 'orderTransactions as suggestions' => fn ($query) => $query->where('is_accepted', false),
             ])
@@ -247,6 +292,7 @@ class TransactionAssignments extends Component
                     ])
                         ->withPivot(['pivot_id', 'amount', 'exchange_rate', 'order_currency_amount', 'is_accepted']);
                 },
+                'ledgerAccountTransactions.ledgerAccount:id,name,number',
                 'orders.addressInvoice:id,name',
                 'orders.currency:id,iso,symbol',
                 'bankConnection:id,name,bank_name,iban',
@@ -265,6 +311,23 @@ class TransactionAssignments extends Component
                 return $transaction->toArray();
             })
             ->toArray();
+    }
+
+    #[Renderless]
+    public function saveLedgerAccountTransaction(): void
+    {
+        try {
+            $this->ledgerAccountTransactionForm->save();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->refreshTransactions();
+        $this->js(<<<'JS'
+            $tsui.close.modal('ledger-account-transaction-modal');
+        JS);
     }
 
     #[Renderless]

--- a/src/Livewire/Accounting/TransactionAssignments.php
+++ b/src/Livewire/Accounting/TransactionAssignments.php
@@ -169,6 +169,7 @@ class TransactionAssignments extends Component
     {
         $this->ledgerAccountTransactionForm->reset();
         $this->ledgerAccountTransactionForm->transaction_id = $transaction->getKey();
+        $this->ledgerAccountTransactionForm->transactionBalance = (float) $transaction->balance;
         $this->ledgerAccountTransactionForm->amount = (float) $transaction->balance;
 
         $this->js(<<<'JS'
@@ -215,6 +216,14 @@ class TransactionAssignments extends Component
     {
         $this->ledgerAccountTransactionForm->reset();
         $this->ledgerAccountTransactionForm->fill($ledgerAccountTransaction);
+
+        // Remaining balance the transaction would have without this assignment,
+        // so "apply transaction amount" targets the full open amount again.
+        $this->ledgerAccountTransactionForm->transactionBalance = bcadd(
+            $ledgerAccountTransaction->transaction->balance,
+            $ledgerAccountTransaction->is_accepted ? $ledgerAccountTransaction->amount : '0',
+            2
+        );
 
         $this->js(<<<'JS'
             $tsui.open.modal('ledger-account-transaction-modal');

--- a/src/Livewire/Accounting/TransactionAssignments.php
+++ b/src/Livewire/Accounting/TransactionAssignments.php
@@ -156,6 +156,7 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function assignOrdersModal(Transaction $transaction): void
     {
+        $this->resetErrorBag();
         $this->transactionForm->reset();
         $this->transactionForm->fill($transaction);
 
@@ -167,6 +168,7 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function assignLedgerAccountModal(Transaction $transaction): void
     {
+        $this->resetErrorBag();
         $this->ledgerAccountTransactionForm->reset();
         $this->ledgerAccountTransactionForm->transaction_id = $transaction->getKey();
         $this->ledgerAccountTransactionForm->transactionBalance = (float) $transaction->balance;
@@ -214,6 +216,7 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function editLedgerAccountTransaction(LedgerAccountTransaction $ledgerAccountTransaction): void
     {
+        $this->resetErrorBag();
         $this->ledgerAccountTransactionForm->reset();
         $this->ledgerAccountTransactionForm->fill($ledgerAccountTransaction);
 
@@ -233,6 +236,7 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function editOrderTransaction(OrderTransaction $orderTransaction): void
     {
+        $this->resetErrorBag();
         $this->orderTransactionForm->reset();
         $this->orderTransactionForm->fill($orderTransaction);
 
@@ -325,6 +329,8 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function saveLedgerAccountTransaction(): void
     {
+        $this->resetErrorBag();
+
         try {
             $this->ledgerAccountTransactionForm->save();
         } catch (ValidationException|UnauthorizedException $e) {
@@ -342,6 +348,8 @@ class TransactionAssignments extends Component
     #[Renderless]
     public function saveOrderTransaction(): void
     {
+        $this->resetErrorBag();
+
         try {
             $this->orderTransactionForm->save();
         } catch (ValidationException|UnauthorizedException $e) {

--- a/src/Livewire/Forms/LedgerAccountTransactionForm.php
+++ b/src/Livewire/Forms/LedgerAccountTransactionForm.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\Forms;
 use FluxErp\Actions\LedgerAccountTransaction\CreateLedgerAccountTransaction;
 use FluxErp\Actions\LedgerAccountTransaction\DeleteLedgerAccountTransaction;
 use FluxErp\Actions\LedgerAccountTransaction\UpdateLedgerAccountTransaction;
+use FluxErp\Support\Livewire\Attributes\ExcludeFromActionData;
 use Livewire\Attributes\Locked;
 
 class LedgerAccountTransactionForm extends FluxForm
@@ -22,6 +23,10 @@ class LedgerAccountTransactionForm extends FluxForm
 
     #[Locked]
     public ?int $transaction_id = null;
+
+    #[Locked]
+    #[ExcludeFromActionData]
+    public ?float $transactionBalance = null;
 
     protected function getActions(): array
     {

--- a/src/Livewire/Forms/LedgerAccountTransactionForm.php
+++ b/src/Livewire/Forms/LedgerAccountTransactionForm.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FluxErp\Livewire\Forms;
+
+use FluxErp\Actions\LedgerAccountTransaction\CreateLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\DeleteLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\UpdateLedgerAccountTransaction;
+use Livewire\Attributes\Locked;
+
+class LedgerAccountTransactionForm extends FluxForm
+{
+    public ?float $amount = null;
+
+    public bool $is_accepted = true;
+
+    public ?int $ledger_account_id = null;
+
+    public ?string $note = null;
+
+    #[Locked]
+    public ?int $pivot_id = null;
+
+    #[Locked]
+    public ?int $transaction_id = null;
+
+    protected function getActions(): array
+    {
+        return [
+            'create' => CreateLedgerAccountTransaction::class,
+            'update' => UpdateLedgerAccountTransaction::class,
+            'delete' => DeleteLedgerAccountTransaction::class,
+        ];
+    }
+
+    protected function getKey(): string
+    {
+        return 'pivot_id';
+    }
+}

--- a/src/Models/LedgerAccount.php
+++ b/src/Models/LedgerAccount.php
@@ -3,12 +3,14 @@
 namespace FluxErp\Models;
 
 use FluxErp\Enums\LedgerAccountTypeEnum;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasTenantAssignment;
 use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\SoftDeletes;
 use FluxErp\Traits\Scout\Searchable;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class LedgerAccount extends FluxModel
@@ -41,5 +43,11 @@ class LedgerAccount extends FluxModel
     public function orderPositions(): HasMany
     {
         return $this->hasMany(OrderPosition::class);
+    }
+
+    public function transactions(): BelongsToMany
+    {
+        return $this->belongsToMany(Transaction::class)
+            ->using(LedgerAccountTransaction::class);
     }
 }

--- a/src/Models/Pivots/LedgerAccountTransaction.php
+++ b/src/Models/Pivots/LedgerAccountTransaction.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FluxErp\Models\Pivots;
+
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Transaction;
+use FluxErp\Traits\Model\HasPackageFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LedgerAccountTransaction extends FluxPivot
+{
+    use HasPackageFactory;
+
+    public $timestamps = true;
+
+    protected $table = 'ledger_account_transaction';
+
+    protected static function booted(): void
+    {
+        static::saved(function (LedgerAccountTransaction $ledgerAccountTransaction): void {
+            if ($ledgerAccountTransaction->transaction_id && $ledgerAccountTransaction->is_accepted) {
+                $ledgerAccountTransaction->transaction->is_ignored = false;
+                $ledgerAccountTransaction->transaction->calculateBalance()->save();
+            }
+        });
+
+        static::deleted(function (LedgerAccountTransaction $ledgerAccountTransaction): void {
+            if ($ledgerAccountTransaction->is_accepted) {
+                $ledgerAccountTransaction->transaction->calculateBalance()->save();
+            }
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'is_accepted' => 'boolean',
+        ];
+    }
+
+    // Relations
+    public function ledgerAccount(): BelongsTo
+    {
+        return $this->belongsTo(LedgerAccount::class);
+    }
+
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+}

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -95,10 +95,9 @@ class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscr
                         $this->orders()->withPivot('amount')->sum('order_transaction.amount'),
                         9
                     ),
-                    $this->ledgerAccounts()
-                        ->withPivot('amount')
-                        ->wherePivot('is_accepted', true)
-                        ->sum('ledger_account_transaction.amount'),
+                    $this->ledgerAccountTransactions()
+                        ->where('is_accepted', true)
+                        ->sum('amount'),
                     9
                 ),
                 2

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -4,6 +4,7 @@ namespace FluxErp\Models;
 
 use FluxErp\Casts\Money;
 use FluxErp\Contracts\IsSubscribable;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Traits\Model\Categorizable;
 use FluxErp\Traits\Model\Commentable;
@@ -59,6 +60,17 @@ class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscr
         return $this->belongsTo(Currency::class);
     }
 
+    public function ledgerAccounts(): BelongsToMany
+    {
+        return $this->belongsToMany(LedgerAccount::class)
+            ->using(LedgerAccountTransaction::class);
+    }
+
+    public function ledgerAccountTransactions(): HasMany
+    {
+        return $this->hasMany(LedgerAccountTransaction::class);
+    }
+
     public function orders(): BelongsToMany
     {
         return $this->belongsToMany(Order::class)
@@ -78,8 +90,15 @@ class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscr
         } else {
             $this->balance = bcround(
                 bcsub(
-                    $this->amount,
-                    $this->orders()->withPivot('amount')->sum('order_transaction.amount'),
+                    bcsub(
+                        $this->amount,
+                        $this->orders()->withPivot('amount')->sum('order_transaction.amount'),
+                        9
+                    ),
+                    $this->ledgerAccounts()
+                        ->withPivot('amount')
+                        ->wherePivot('is_accepted', true)
+                        ->sum('ledger_account_transaction.amount'),
                     9
                 ),
                 2

--- a/src/Providers/MorphMapServiceProvider.php
+++ b/src/Providers/MorphMapServiceProvider.php
@@ -86,6 +86,7 @@ use FluxErp\Models\Pivots\EmployeeVacationBlackout;
 use FluxErp\Models\Pivots\EmployeeWorkTimeModel;
 use FluxErp\Models\Pivots\HolidayLocation;
 use FluxErp\Models\Pivots\JobBatchable;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Models\Pivots\LocationVacationBlackout;
 use FluxErp\Models\Pivots\MailAccountUser;
 use FluxErp\Models\Pivots\MediaFolderModel;
@@ -286,6 +287,7 @@ class MorphMapServiceProvider extends ServiceProvider
             'employee_work_time_model' => EmployeeWorkTimeModel::class,
             'holiday_location' => HolidayLocation::class,
             'job_batchable' => JobBatchable::class,
+            'ledger_account_transaction' => LedgerAccountTransaction::class,
             'location_vacation_blackout' => LocationVacationBlackout::class,
             'mail_account_user' => MailAccountUser::class,
             'media_folder_model' => MediaFolderModel::class,

--- a/src/Rulesets/LedgerAccountTransaction/CreateLedgerAccountTransactionRuleset.php
+++ b/src/Rulesets/LedgerAccountTransaction/CreateLedgerAccountTransactionRuleset.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FluxErp\Rulesets\LedgerAccountTransaction;
+
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Transaction;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\Numeric;
+use FluxErp\Rulesets\FluxRuleset;
+
+class CreateLedgerAccountTransactionRuleset extends FluxRuleset
+{
+    public function rules(): array
+    {
+        return [
+            'ledger_account_id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => LedgerAccount::class]),
+            ],
+            'transaction_id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => Transaction::class]),
+            ],
+            'amount' => [
+                'required',
+                app(Numeric::class),
+            ],
+            'note' => 'string|max:255|nullable',
+            'is_accepted' => 'boolean',
+        ];
+    }
+}

--- a/src/Rulesets/LedgerAccountTransaction/DeleteLedgerAccountTransactionRuleset.php
+++ b/src/Rulesets/LedgerAccountTransaction/DeleteLedgerAccountTransactionRuleset.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FluxErp\Rulesets\LedgerAccountTransaction;
+
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rulesets\FluxRuleset;
+
+class DeleteLedgerAccountTransactionRuleset extends FluxRuleset
+{
+    public function rules(): array
+    {
+        return [
+            'pivot_id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => LedgerAccountTransaction::class]),
+            ],
+        ];
+    }
+}

--- a/src/Rulesets/LedgerAccountTransaction/UpdateLedgerAccountTransactionRuleset.php
+++ b/src/Rulesets/LedgerAccountTransaction/UpdateLedgerAccountTransactionRuleset.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FluxErp\Rulesets\LedgerAccountTransaction;
+
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\Numeric;
+use FluxErp\Rulesets\FluxRuleset;
+
+class UpdateLedgerAccountTransactionRuleset extends FluxRuleset
+{
+    public function rules(): array
+    {
+        return [
+            'pivot_id' => [
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => LedgerAccountTransaction::class]),
+            ],
+            'ledger_account_id' => [
+                'sometimes',
+                'required',
+                'integer',
+                app(ModelExists::class, ['model' => LedgerAccount::class]),
+            ],
+            'amount' => [
+                'sometimes',
+                'required',
+                app(Numeric::class),
+            ],
+            'note' => 'string|max:255|nullable',
+            'is_accepted' => 'boolean',
+        ];
+    }
+}

--- a/tests/Feature/Actions/LedgerAccountTransaction/LedgerAccountTransactionActionTest.php
+++ b/tests/Feature/Actions/LedgerAccountTransaction/LedgerAccountTransactionActionTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use FluxErp\Actions\LedgerAccountTransaction\CreateLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\DeleteLedgerAccountTransaction;
+use FluxErp\Actions\LedgerAccountTransaction\UpdateLedgerAccountTransaction;
+use FluxErp\Actions\OrderTransaction\CreateOrderTransaction;
+use FluxErp\Enums\LedgerAccountTypeEnum;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\Pivots\LedgerAccountTransaction;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Transaction;
+
+beforeEach(function (): void {
+    $this->ledgerAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Expense,
+    ]);
+    $this->transaction = Transaction::factory()->create([
+        'amount' => 203,
+        'balance' => 203,
+    ]);
+});
+
+test('create ledger account transaction', function (): void {
+    $ledgerAccountTransaction = CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 3,
+        'note' => 'Dunning fee',
+    ])
+        ->validate()
+        ->execute();
+
+    expect($ledgerAccountTransaction)->toBeInstanceOf(LedgerAccountTransaction::class)
+        ->and($ledgerAccountTransaction->note)->toBe('Dunning fee')
+        ->and($ledgerAccountTransaction->is_accepted)->toBeFalse();
+});
+
+test('create ledger account transaction requires ledger_account_id transaction_id amount', function (): void {
+    CreateLedgerAccountTransaction::assertValidationErrors(
+        [],
+        ['ledger_account_id', 'transaction_id', 'amount']
+    );
+});
+
+test('accepted ledger account transaction recalculates the transaction balance', function (): void {
+    CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 203,
+        'is_accepted' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(0.0);
+});
+
+test('unaccepted ledger account transaction does not change the transaction balance', function (): void {
+    CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 203,
+        'is_accepted' => false,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(203.0);
+});
+
+test('update ledger account transaction recalculates the transaction balance', function (): void {
+    $ledgerAccountTransaction = CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 3,
+        'is_accepted' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    UpdateLedgerAccountTransaction::make([
+        'pivot_id' => $ledgerAccountTransaction->getKey(),
+        'amount' => 103,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(100.0);
+});
+
+test('delete ledger account transaction restores the transaction balance', function (): void {
+    $ledgerAccountTransaction = CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 203,
+        'is_accepted' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(0.0);
+
+    DeleteLedgerAccountTransaction::make([
+        'pivot_id' => $ledgerAccountTransaction->getKey(),
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(203.0);
+});
+
+test('mixed split between order and ledger account settles the transaction', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $order = Order::factory()->create([
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'balance' => 200,
+    ]);
+
+    CreateOrderTransaction::make([
+        'transaction_id' => $this->transaction->getKey(),
+        'order_id' => $order->getKey(),
+        'amount' => 200,
+        'is_accepted' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(3.0);
+
+    CreateLedgerAccountTransaction::make([
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => 3,
+        'note' => 'Dunning fee',
+        'is_accepted' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $this->transaction->fresh()->balance)->toBe(0.0);
+});

--- a/tests/Livewire/Accounting/TransactionAssignmentsTest.php
+++ b/tests/Livewire/Accounting/TransactionAssignmentsTest.php
@@ -182,3 +182,18 @@ test('assignLedgerAccountModal prefills the transaction balance for the apply bu
         ->assertSet('ledgerAccountTransactionForm.amount', -4250.0)
         ->assertSet('ledgerAccountTransactionForm.transactionBalance', -4250.0);
 });
+
+test('opening the ledger account modal resets a previous validation error', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'amount' => 100,
+        'balance' => 100,
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('saveLedgerAccountTransaction')
+        ->assertHasErrors()
+        ->call('assignLedgerAccountModal', $transaction)
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Accounting/TransactionAssignmentsTest.php
+++ b/tests/Livewire/Accounting/TransactionAssignmentsTest.php
@@ -139,3 +139,32 @@ test('editOrderTransaction populates the transaction payment amount', function (
         ->call('editOrderTransaction', $orderTransaction->getAttribute('pivot_id'))
         ->assertSet('orderTransactionForm.transactionAmount', 175.5);
 });
+
+test('assign ledger account through the modal', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'amount' => 3000,
+        'balance' => 3000,
+    ]);
+    $ledgerAccount = FluxErp\Models\LedgerAccount::factory()->create([
+        'tenant_id' => Tenant::default()->getKey(),
+        'ledger_account_type_enum' => FluxErp\Enums\LedgerAccountTypeEnum::Expense,
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('assignLedgerAccountModal', $transaction)
+        ->assertSet('ledgerAccountTransactionForm.transaction_id', $transaction->getKey())
+        ->assertSet('ledgerAccountTransactionForm.amount', 3000.0)
+        ->set('ledgerAccountTransactionForm.ledger_account_id', $ledgerAccount->getKey())
+        ->call('saveLedgerAccountTransaction')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect(FluxErp\Models\Pivots\LedgerAccountTransaction::query()
+        ->where('ledger_account_id', $ledgerAccount->getKey())
+        ->where('transaction_id', $transaction->getKey())
+        ->exists()
+    )->toBeTrue()
+        ->and((float) $transaction->fresh()->balance)->toBe(0.0);
+});

--- a/tests/Livewire/Accounting/TransactionAssignmentsTest.php
+++ b/tests/Livewire/Accounting/TransactionAssignmentsTest.php
@@ -168,3 +168,17 @@ test('assign ledger account through the modal', function (): void {
     )->toBeTrue()
         ->and((float) $transaction->fresh()->balance)->toBe(0.0);
 });
+
+test('assignLedgerAccountModal prefills the transaction balance for the apply button', function (): void {
+    $bankConnection = BankConnection::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => $bankConnection->getKey(),
+        'amount' => -4250,
+        'balance' => -4250,
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('assignLedgerAccountModal', $transaction)
+        ->assertSet('ledgerAccountTransactionForm.amount', -4250.0)
+        ->assertSet('ledgerAccountTransactionForm.transactionBalance', -4250.0);
+});


### PR DESCRIPTION
## Problem

Bank transactions without a document (salaries, bank fees, taxes, dunning fees) could not be cleared from the open transactions — the only assignment path was through orders, so they stayed in the unassigned list forever or had to be misused as ignored.

## Solution

Following the lexoffice pattern (document tab vs. category tab with partial amounts), a transaction can now be assigned to one or more ledger accounts:

- `ledger_account_transaction` pivot (`amount`, `note`, `is_accepted`) that recalculates the transaction balance on save/delete
- `Transaction::calculateBalance()` subtracts accepted ledger account assignments alongside order assignments — mixed splits work naturally (e.g. 200 € on the invoice, 3 € dunning fee on an expense account)
- Create/Update/Delete actions with rulesets and API routes (`/ledger-account-transactions`)
- Assignment dialog: new "Assign ledger account" modal with async ledger account select, the amount prefilled with the remaining balance and an optional note; assigned ledger accounts render with edit/delete next to the assigned orders
- "Ignore transaction" now also hides once a ledger account assignment exists

DATEV export of these assignments is intentionally out of scope and will follow separately.

## Tests

- Action tests: create/update/delete incl. balance recalculation and validation
- Mixed split: 203 € transaction → 200 € order + 3 € ledger account → balance 0
- Livewire: modal prefill and assignment through the component

## Summary by Sourcery

Allow assigning bank transactions to ledger accounts and include these assignments in transaction balance calculations.

New Features:
- Introduce ledger account transaction pivot and relationships between transactions and ledger accounts.
- Add UI modal and controls to assign, edit, and delete ledger account allocations for a transaction.
- Expose CRUD API endpoints and Livewire form handling for ledger account transactions.

Enhancements:
- Extend transaction balance calculation to consider accepted ledger account assignments alongside order assignments.
- Hide the ignore transaction option when a transaction has either order or ledger account assignments.
- Register the ledger account transaction pivot in the morph map and add supporting factory and migration.

Tests:
- Add feature tests for ledger account transaction actions including balance recalculation and mixed splits with orders.
- Add Livewire test for assigning ledger accounts via the transaction assignments modal.