### PR TITLE
fix(media): guard file download against null media

### DIFF
--- a/resources/views/components/features/media/upload-form-object.blade.php
+++ b/resources/views/components/features/media/upload-form-object.blade.php
@@ -136,13 +136,17 @@
                                 x-text="file.name"
                             ></span>
                         </div>
-                        <div x-cloak x-show="file.id">
-                            <x-button
-                                color="indigo"
-                                icon="arrow-down-tray"
-                                wire:click="download(file.id)"
-                            />
-                        </div>
+                        <template x-if="file.id">
+                            <div>
+                                <x-button
+                                    color="indigo"
+                                    icon="arrow-down-tray"
+                                    x-on:click="
+                                        file?.id && $wire.download(file.id)
+                                    "
+                                />
+                            </div>
+                        </template>
                         <div class="flex shrink-0 px-4">
                             <x-button
                                 color="red"

--- a/src/Traits/Livewire/SupportsFileDownloads.php
+++ b/src/Traits/Livewire/SupportsFileDownloads.php
@@ -19,9 +19,14 @@ trait SupportsFileDownloads
     use EnsureUsedInLivewire;
 
     #[Renderless]
-    public function download(Media $media): void
+    public function download(?Media $media): void
     {
-        if (! Storage::disk($media->disk)->exists($media->getPathRelativeToRoot())) {
+        // Guards against stale frontend state calling download without an id,
+        // e.g. a staged upload whose media row does not exist yet.
+        if (
+            ! $media?->exists
+            || ! Storage::disk($media->disk)->exists($media->getPathRelativeToRoot())
+        ) {
             $this->toast()
                 ->error(__('The file does not exist anymore.'))
                 ->send();

--- a/tests/Livewire/Settings/TenantsTest.php
+++ b/tests/Livewire/Settings/TenantsTest.php
@@ -32,3 +32,11 @@ test('edit with model fills form and opens modal', function (): void {
         ->assertSet('tenant.name', $tenant->name)
         ->assertOpensModal('edit-tenant');
 });
+
+test('download with null media shows an error toast instead of crashing', function (): void {
+    Livewire::actingAs($this->user)
+        ->test(Tenants::class)
+        ->call('download', null)
+        ->assertOk()
+        ->assertHasNoErrors();
+});


### PR DESCRIPTION
## Problem

`SupportsFileDownloads::download()` requires a `Media` instance, but the media upload component can emit `download(null)` when the frontend state is stale — e.g. a staged upload whose media row does not exist yet, or an Alpine re-render race after saving. This crashes with

```
FluxErp\Livewire\Settings\Tenants::download(): Argument #1 ($media) must be of type FluxErp\Models\Media, null given
```

(seen in production via Flare on the tenant logo upload).

## Fix

Accept `?Media` and reuse the existing "file does not exist anymore" error toast when no media is resolved. Applies to every component using the trait.

## Tests

- `download with null media shows an error toast instead of crashing` — reproduces the production TypeError without the fix
- Existing download tests (MediaList, remote disk) stay green

## Summary by Sourcery

Guard Livewire file download handling against null or non-existent media to prevent crashes and show a user-facing error instead.

Bug Fixes:
- Prevent a TypeError when the media upload components trigger a download with null or non-existent media by treating it as a missing file and showing an error toast.

Tests:
- Add a Livewire test for tenant downloads that verifies calling download with null media returns OK and does not produce errors.