### PR TITLE
feat(accounting): attach a receipt to a transaction

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -421,6 +421,7 @@
     "At": "Um",
     "At least one of the fields user_id or employee_id must be provided.": "Mindestens ein der Felder user_id oder employee_id muss angegeben werden.",
     "At least two records are required for merging": "Mindestens zwei Datensätze sind für die Zusammenführung erforderlich",
+    "Attachment": "Anhang",
     "Attachments": "Anhänge",
     "Attempt": "Versuch",
     "Attend": "Teilnehmen",

--- a/resources/views/components/features/media/upload-form-object.blade.php
+++ b/resources/views/components/features/media/upload-form-object.blade.php
@@ -114,49 +114,61 @@
             />
         </div>
         <div class="flex flex-col gap-4">
-            <template
-                x-for="(file, index) in $wire.{{ $wireModel }}.stagedFiles"
-            >
-                <x-card class="px-0! py-0!" x-show="!file.shouldDelete" x-cloak>
-                    <div class="flex items-center justify-between text-sm">
-                        <div class="flex w-0 flex-1 items-center gap-1.5">
-                            <div class="shrink-0 rounded-md object-contain">
-                                <img
-                                    x-bind:src="
-                                        file.preview_url
-                                            ? file.preview_url
-                                            : '#'
-                                    "
-                                    class="h-16 w-16 rounded-md object-cover"
-                                    alt=""
-                                />
+            <div class="flex flex-col gap-4" wire:ignore>
+                <template
+                    x-for="(file, index) in $wire.{{ $wireModel }}.stagedFiles"
+                    x-bind:key="file.id ?? file.temporary_filename ?? index"
+                >
+                    <div x-show="!file.shouldDelete" x-cloak>
+                        <x-card class="px-0! py-0!">
+                            <div
+                                class="flex items-center justify-between text-sm"
+                            >
+                                <div
+                                    class="flex w-0 flex-1 items-center gap-1.5"
+                                >
+                                    <div
+                                        class="shrink-0 rounded-md object-contain"
+                                    >
+                                        <img
+                                            x-bind:src="
+                                                file.preview_url
+                                                    ? file.preview_url
+                                                    : '#'
+                                            "
+                                            class="h-16 w-16 rounded-md object-cover"
+                                            alt=""
+                                        />
+                                    </div>
+                                    <span
+                                        class="w-0 flex-1 truncate pl-1"
+                                        x-text="file.name"
+                                    ></span>
+                                </div>
+                                <template x-if="file.id">
+                                    <div>
+                                        <x-button
+                                            color="indigo"
+                                            icon="arrow-down-tray"
+                                            x-on:click="
+                                                file?.id &&
+                                                    $wire.download(file.id)
+                                            "
+                                        />
+                                    </div>
+                                </template>
+                                <div class="flex shrink-0 px-4">
+                                    <x-button
+                                        color="red"
+                                        x-on:click="file.shouldDelete = true"
+                                        :text="__('Delete')"
+                                    />
+                                </div>
                             </div>
-                            <span
-                                class="w-0 flex-1 truncate pl-1"
-                                x-text="file.name"
-                            ></span>
-                        </div>
-                        <template x-if="file.id">
-                            <div>
-                                <x-button
-                                    color="indigo"
-                                    icon="arrow-down-tray"
-                                    x-on:click="
-                                        file?.id && $wire.download(file.id)
-                                    "
-                                />
-                            </div>
-                        </template>
-                        <div class="flex shrink-0 px-4">
-                            <x-button
-                                color="red"
-                                x-on:click="file.shouldDelete = true"
-                                :text="__('Delete')"
-                            />
-                        </div>
+                        </x-card>
                     </div>
-                </x-card>
-            </template>
+                </template>
+            </div>
             {{ $footer ?? '' }}
         </div>
     </div>

--- a/resources/views/livewire/accounting/transaction-assignments.blade.php
+++ b/resources/views/livewire/accounting/transaction-assignments.blade.php
@@ -99,6 +99,32 @@
         </x-slot:footer>
     </x-modal>
 
+    <x-modal id="transaction-attachment-modal" :title="__('Attachment')">
+        <x-flux::features.media.upload-form-object
+            wire:model="attachment"
+            :multiple="false"
+            accept="application/pdf, image/jpeg, image/png, image/svg+xml"
+        />
+        <x-slot:footer>
+            <x-button
+                color="secondary"
+                :text="__('Cancel')"
+                x-on:click="$tsui.close.modal('transaction-attachment-modal')"
+            />
+            @stack('transaction-attachment-modal-footer')
+            <x-button
+                :text="__('Save')"
+                x-on:click="
+                    $wire.saveAttachment().then((success) => {
+                        if (success)
+                            $tsui.close.modal('transaction-attachment-modal');
+                    })
+                "
+                loading="saveAttachment()"
+            />
+        </x-slot:footer>
+    </x-modal>
+
     <x-modal
         id="order-transaction-modal"
         x-on:open="$tsui.focus('order-transaction-amount')"
@@ -728,6 +754,24 @@
                                                                 "
                                                             ></span>
                                                         </div>
+                                                    </x-slot:text>
+                                                </x-button>
+                                                <x-button
+                                                    sm
+                                                    light
+                                                    color="gray"
+                                                    icon="paper-clip"
+                                                    wire:click="attachmentModal(transaction.id)"
+                                                >
+                                                    <x-slot:text>
+                                                        <span
+                                                            x-text="
+                                                                transaction
+                                                                    .media?.[0]
+                                                                    ?.file_name ??
+                                                                '{{ __('Attachment') }}'
+                                                            "
+                                                        ></span>
                                                     </x-slot:text>
                                                 </x-button>
                                                 <x-button

--- a/src/Livewire/Accounting/TransactionAssignments.php
+++ b/src/Livewire/Accounting/TransactionAssignments.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\Accounting;
 use FluxErp\Actions\OrderTransaction\CreateOrderTransaction;
 use FluxErp\Actions\OrderTransaction\UpdateOrderTransaction;
 use FluxErp\Livewire\Forms\LedgerAccountTransactionForm;
+use FluxErp\Livewire\Forms\MediaUploadForm;
 use FluxErp\Livewire\Forms\OrderTransactionForm;
 use FluxErp\Livewire\Forms\TransactionForm;
 use FluxErp\Models\BankConnection;
@@ -14,9 +15,11 @@ use FluxErp\Models\Pivots\LedgerAccountTransaction;
 use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Models\Transaction;
 use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\WithFileUploads;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Livewire\Attributes\Url;
@@ -26,7 +29,9 @@ use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class TransactionAssignments extends Component
 {
-    use Actions, WithPagination;
+    use Actions, WithFileUploads, WithPagination;
+
+    public MediaUploadForm $attachment;
 
     public ?array $bankAccounts = null;
 
@@ -180,6 +185,21 @@ class TransactionAssignments extends Component
     }
 
     #[Renderless]
+    public function attachmentModal(Transaction $transaction): void
+    {
+        $this->resetErrorBag();
+        $this->attachment->reset();
+        $this->attachment->fill($transaction->getFirstMedia('attachment') ?? []);
+        $this->attachment->model_type = $transaction->getMorphClass();
+        $this->attachment->model_id = $transaction->getKey();
+        $this->attachment->collection_name = 'attachment';
+
+        $this->js(<<<'JS'
+            $tsui.open.modal('transaction-attachment-modal');
+        JS);
+    }
+
+    #[Renderless]
     public function deleteLedgerAccountTransaction(LedgerAccountTransaction $ledgerAccountTransaction): void
     {
         $this->ledgerAccountTransactionForm->reset();
@@ -306,6 +326,7 @@ class TransactionAssignments extends Component
                         ->withPivot(['pivot_id', 'amount', 'exchange_rate', 'order_currency_amount', 'is_accepted']);
                 },
                 'ledgerAccountTransactions.ledgerAccount:id,name,number',
+                'media' => fn (MorphMany $query) => $query->where('collection_name', 'attachment'),
                 'orders.addressInvoice:id,name',
                 'orders.currency:id,iso,symbol',
                 'bankConnection:id,name,bank_name,iban',
@@ -324,6 +345,24 @@ class TransactionAssignments extends Component
                 return $transaction->toArray();
             })
             ->toArray();
+    }
+
+    #[Renderless]
+    public function saveAttachment(): bool
+    {
+        $this->resetErrorBag();
+
+        try {
+            $this->attachment->save();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        $this->refreshTransactions();
+
+        return true;
     }
 
     #[Renderless]

--- a/src/Livewire/Forms/MediaUploadForm.php
+++ b/src/Livewire/Forms/MediaUploadForm.php
@@ -86,6 +86,10 @@ class MediaUploadForm extends MediaForm
 
             $this->fill($file);
 
+            if ($this->shouldDelete && ! $this->id) {
+                continue;
+            }
+
             if ($this->id && $this->media && ! $this->shouldDelete) {
                 $this->replace();
             } elseif ($this->id) {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -14,6 +14,7 @@ use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasTags;
 use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
+use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\LogsActivity;
 use FluxErp\Traits\Model\SoftDeletes;
 use FluxErp\Traits\Scout\Searchable;
@@ -21,12 +22,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
+use Spatie\MediaLibrary\HasMedia;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
-class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscribable
+class Transaction extends FluxModel implements HasMedia, InteractsWithDataTables, IsSubscribable
 {
     use Categorizable, Commentable, HasFrontendAttributes, HasPackageFactory, HasParentChildRelations, HasTags,
-        HasUserModification, HasUuid, LogsActivity, Searchable, SoftDeletes;
+        HasUserModification, HasUuid, InteractsWithMedia, LogsActivity, Searchable, SoftDeletes;
 
     protected static function booted(): void
     {
@@ -125,5 +127,12 @@ class Transaction extends FluxModel implements InteractsWithDataTables, IsSubscr
     public function getUrl(): ?string
     {
         return null;
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('attachment')
+            ->acceptsMimeTypes(['application/pdf', 'image/jpeg', 'image/png', 'image/svg+xml'])
+            ->singleFile();
     }
 }

--- a/tests/Livewire/Accounting/TransactionAssignmentsTest.php
+++ b/tests/Livewire/Accounting/TransactionAssignmentsTest.php
@@ -13,6 +13,7 @@ use FluxErp\Models\Pivots\OrderTransaction;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Tenant;
 use FluxErp\Models\Transaction;
+use Illuminate\Http\UploadedFile;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -196,4 +197,58 @@ test('opening the ledger account modal resets a previous validation error', func
         ->assertHasErrors()
         ->call('assignLedgerAccountModal', $transaction)
         ->assertHasNoErrors();
+});
+
+test('saveAttachment stores a single attachment on the transaction', function (): void {
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => BankConnection::factory()->create()->getKey(),
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('attachmentModal', $transaction)
+        ->set('attachment.file', [UploadedFile::fake()->image('receipt.jpg')])
+        ->call('saveAttachment')
+        ->assertHasNoErrors();
+
+    expect($transaction->refresh()->getFirstMedia('attachment')?->file_name)->toBe('receipt.jpg');
+});
+
+test('uploading a second attachment replaces the first one', function (): void {
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => BankConnection::factory()->create()->getKey(),
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('attachmentModal', $transaction)
+        ->set('attachment.file', [UploadedFile::fake()->image('first.jpg')])
+        ->call('saveAttachment')
+        ->assertHasNoErrors()
+        ->call('attachmentModal', $transaction->refresh())
+        ->set('attachment.file', [UploadedFile::fake()->image('second.jpg')])
+        ->call('saveAttachment')
+        ->assertHasNoErrors();
+
+    $media = $transaction->refresh()->getMedia('attachment');
+
+    expect($media)->toHaveCount(1)
+        ->and($media->first()->file_name)->toBe('second.jpg');
+});
+
+test('replacing a staged file before saving stores only the newly picked file', function (): void {
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => BankConnection::factory()->create()->getKey(),
+    ]);
+
+    Livewire::test(TransactionAssignments::class)
+        ->call('attachmentModal', $transaction)
+        ->set('attachment.file', [UploadedFile::fake()->image('wrong.jpg')])
+        ->set('attachment.stagedFiles.0.shouldDelete', true)
+        ->set('attachment.file', [UploadedFile::fake()->image('right.jpg')])
+        ->call('saveAttachment')
+        ->assertHasNoErrors();
+
+    $media = $transaction->refresh()->getMedia('attachment');
+
+    expect($media)->toHaveCount(1)
+        ->and($media->first()->file_name)->toBe('right.jpg');
 });


### PR DESCRIPTION
Transactions can be booked without a document since #1896, so the receipt needs somewhere to live.

Every transaction takes exactly one attachment, enforced by a `singleFile()` media collection on `Transaction` -- uploading a second file replaces the first instead of piling up. The button sits on the transaction card next to the comments one and shows the file name once something is attached. Upload, preview, download and delete come from the existing `MediaUploadForm` + `x-flux::features.media.upload-form-object` pair, the same way `SepaMandate` handles its signed mandate. No migration, no new action.

## Also fixes the shared upload component

Driving this in the browser surfaced two pre-existing defects in `upload-form-object.blade.php`, which all seven consumers share (sepa mandates, plugins, tenant logos, communications, purchase invoices):

- **Duplicate rows.** Livewire's morph touched the nodes Alpine's `x-for` owns, leaving one orphaned row per re-render -- measurable as `stagedFiles = 1` while the DOM held 2. `x-card` as the template root made it worse, bringing its own `x-data` and `wire:ignore.self`. Fixed by keeping the morph off the list, adding the missing `x-bind:key`, and moving `x-show` onto a plain root element.
- **`x-show` never hid the row.** TallStackUI forwards foreign attributes to the card *body*, so a removed row kept its card frame and Delete button on screen.

`MediaUploadForm::save()` had a matching data bug: a staged upload the user removed before saving has no media record, fell through to the `create()` branch and got stored anyway. On a `singleFile()` collection it then overwrote the file the user actually picked -- so picking a wrong file, removing it, and picking the right one saved the wrong one.

## Summary by Sourcery

Add support for attaching a single receipt file to accounting transactions and ensure the shared media upload flow correctly handles staged file replacement and UI rendering.

New Features:
- Allow transactions to store a single attachment via a dedicated media collection and Livewire modal backed by MediaUploadForm.
- Expose an attachment button on transaction cards that opens the upload modal and displays the current attachment filename.

Enhancements:
- Fix the shared media upload component to avoid duplicate staged rows and ensure deleted rows are properly hidden.
- Prevent removed staged uploads from being unintentionally saved and overwriting the selected file in single-file media collections.

Tests:
- Add Livewire tests verifying that transactions persist a single attachment, that re-uploads replace the previous file, and that replacing a staged file before saving stores only the final selection.