### PR TITLE
feat(calendar): upgrade FullCalendar from v6 to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,19 +6,15 @@
         "": {
             "dependencies": {
                 "@simplewebauthn/browser": "^13.3.0",
-                "@techstark/opencv-js": "^4.12.0-release.1"
+                "@techstark/opencv-js": "^4.12.0-release.1",
+                "fullcalendar": "^7.0.1",
+                "temporal-polyfill": "^1.0.1"
             },
             "devDependencies": {
                 "@alpinejs/collapse": "^3.15.12",
                 "@alpinejs/sort": "^3.15.12",
                 "@floating-ui/dom": "^1.8.0",
                 "@fontsource/inter": "^5.0.18",
-                "@fullcalendar/core": "^6.1.21",
-                "@fullcalendar/daygrid": "^6.1.21",
-                "@fullcalendar/interaction": "^6.1.21",
-                "@fullcalendar/list": "^6.1.21",
-                "@fullcalendar/moment-timezone": "^6.1.21",
-                "@fullcalendar/timegrid": "^6.1.21",
                 "@phosphor-icons/web": "^2.1.1",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.20",
@@ -146,68 +142,23 @@
                 "url": "https://github.com/sponsors/ayuhito"
             }
         },
+        "node_modules/@full-ui/headless-calendar": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@full-ui/headless-calendar/-/headless-calendar-7.0.1.tgz",
+            "integrity": "sha512-ridxaPRKiSzfeXkk8kta1wC9asYqPWXf4q0KbUW5hRvWQ1rkxeUbhBarcMEOFC7FvJHczPSAm0JzSrXv/ykuKw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "temporal-polyfill": "^1.0.1"
+            }
+        },
         "node_modules/@fullcalendar/core": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.21.tgz",
-            "integrity": "sha512-t3u/+sqh3Iq7TWtUnVLcGDUE6OWZh0UD3c04bI/l7lSLAgAKr3kngBmhHiQD1QXpwC8ZN5iNqG7a7gOVixhSKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "preact": "~10.12.1"
-            }
-        },
-        "node_modules/@fullcalendar/daygrid": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.21.tgz",
-            "integrity": "sha512-QYb1y40RGYLlOxKpYWg8O+7njEnKnFG8Tt7qjnubJGR35s1phQg67E+81y2TyAbbm59p2JFOCXGDk9t6KDujIA==",
-            "dev": true,
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-7.0.1.tgz",
+            "integrity": "sha512-SRJT4lSRZZGVCz6ss48pFCNiIS7iutpQVID73GFQufH94MTYs+akCW9aKCjMwsnEWad5UV7Mcm4xndFQ4dDi0g==",
             "license": "MIT",
             "peerDependencies": {
-                "@fullcalendar/core": "~6.1.21"
-            }
-        },
-        "node_modules/@fullcalendar/interaction": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.21.tgz",
-            "integrity": "sha512-WPYpqtljDWmU0Xm2cOtFrLlocgxv7cgkOppj34Q6OUUat8a6Cnd6kYo2JR+irP223PE5lBYHFNp1qh7SIpJc0w==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@fullcalendar/core": "~6.1.21"
-            }
-        },
-        "node_modules/@fullcalendar/list": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.21.tgz",
-            "integrity": "sha512-2rpIhs5pJmV7jyk4oX4bckNqurt6iHcsweE3FDYDdNpmRukPrARnyQYcaVFNVw2bnBFeR/jQW/St2MlauxF3GQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@fullcalendar/core": "~6.1.21"
-            }
-        },
-        "node_modules/@fullcalendar/moment-timezone": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/moment-timezone/-/moment-timezone-6.1.21.tgz",
-            "integrity": "sha512-1H5voLR6PGiIf+JM6TCWq8oMTMOOqs+Am8lo/3GzHnBPo81RN72h87zm50YgGq9HjIsMdNs7RgdMVAUcXByerQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@fullcalendar/core": "~6.1.21",
-                "moment-timezone": "^0.5.40"
-            }
-        },
-        "node_modules/@fullcalendar/timegrid": {
-            "version": "6.1.21",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.21.tgz",
-            "integrity": "sha512-2DnShx/jallGmb8QCkr6pAOu/zuPhJrP7+uTrAtSnbqsX7GF3lTxqSeNGkTQwsgF5g/ia8udhQ+JNYaE+TN1cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@fullcalendar/daygrid": "~6.1.21"
-            },
-            "peerDependencies": {
-                "@fullcalendar/core": "~6.1.21"
+                "@full-ui/headless-calendar": "7.0.1",
+                "temporal-polyfill": "^1.0.1"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1724,6 +1675,20 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/fullcalendar": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-7.0.1.tgz",
+            "integrity": "sha512-e4HymMjH93UtKq9srPeN1cwmVsW5w6CmVNIb4qr4q1tMpl8RpMD9zaJAbbtlSjjMH0ELGP9yJwq9l34wDPUenA==",
+            "license": "MIT",
+            "dependencies": {
+                "@full-ui/headless-calendar": "7.0.1",
+                "@fullcalendar/core": "7.0.1",
+                "preact": "^10.29.0"
+            },
+            "peerDependencies": {
+                "temporal-polyfill": "^1.0.1"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2274,31 +2239,6 @@
                 "mini-svg-data-uri": "cli.js"
             }
         },
-        "node_modules/moment": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/moment-timezone": {
-            "version": "0.5.48",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-            "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "moment": "^2.29.4"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2441,14 +2381,21 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.12.1",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
-            "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
-            "dev": true,
+            "version": "10.29.7",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+            "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
+            },
+            "peerDependencies": {
+                "preact-render-to-string": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "preact-render-to-string": {
+                    "optional": true
+                }
             }
         },
         "node_modules/prettier": {
@@ -2924,6 +2871,28 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
+        },
+        "node_modules/temporal-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+            "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+            "license": "MIT",
+            "dependencies": {
+                "temporal-spec": "1.0.0",
+                "temporal-utils": "1.0.1"
+            }
+        },
+        "node_modules/temporal-spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+            "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/temporal-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+            "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+            "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,6 @@
         "@alpinejs/sort": "^3.15.12",
         "@floating-ui/dom": "^1.8.0",
         "@fontsource/inter": "^5.0.18",
-        "@fullcalendar/core": "^6.1.21",
-        "@fullcalendar/daygrid": "^6.1.21",
-        "@fullcalendar/interaction": "^6.1.21",
-        "@fullcalendar/list": "^6.1.21",
-        "@fullcalendar/moment-timezone": "^6.1.21",
-        "@fullcalendar/timegrid": "^6.1.21",
         "@phosphor-icons/web": "^2.1.1",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.20",
@@ -57,6 +51,8 @@
     },
     "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",
-        "@techstark/opencv-js": "^4.12.0-release.1"
+        "@techstark/opencv-js": "^4.12.0-release.1",
+        "fullcalendar": "^7.0.1",
+        "temporal-polyfill": "^1.0.1"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,6 +9,10 @@
 @import 'gridstack/dist/gridstack.min.css' layer(base);
 @import './components/grid-stack.css' layer(base);
 @import './components/apex-charts.css' layer(base);
+
+@import 'fullcalendar/skeleton.css' layer(base);
+@import 'fullcalendar/themes/classic/theme.css' layer(base);
+@import 'fullcalendar/themes/classic/palette.css' layer(base);
 @import './components/full-calendar.css' layer(base);
 
 @import '../../node_modules/@phosphor-icons/web/src/regular/style.css'

--- a/resources/css/components/full-calendar.css
+++ b/resources/css/components/full-calendar.css
@@ -1,65 +1,45 @@
-.fc .fc-toolbar.fc-header-toolbar {
+/*
+FullCalendar v7 hashes its internal class names, so the calendar is themed through
+the classic theme's CSS variables instead of by overriding `.fc-*` selectors.
+The few stable class names used below are attached explicitly via the `*Class`
+options in resources/js/components/calendar.js.
+*/
+
+:root {
+    --fc-classic-primary: var(--color-indigo-600);
+    --fc-classic-primary-foreground: #fff;
+    --fc-classic-background: var(--color-white);
+    --fc-classic-border: var(--color-gray-200);
+    --fc-classic-strong-border: var(--color-gray-300);
+    --fc-classic-today: --alpha(var(--color-indigo-500) / 12%);
+}
+
+@media not print {
+    [data-color-scheme='dark'] {
+        --fc-classic-background: var(--color-slate-800);
+        --fc-classic-faint: var(--color-slate-700);
+        --fc-classic-border: var(--color-slate-600);
+        --fc-classic-strong-border: var(--color-slate-500);
+        --fc-classic-today: --alpha(var(--color-indigo-400) / 18%);
+    }
+}
+
+.fc-header-toolbar {
     @apply mb-0 p-4;
 }
 
-.fc .fc-daygrid-day.fc-day-today .fc-daygrid-day-top a {
-    @apply rounded-full bg-indigo-600 font-semibold text-white;
+.fc-toolbar-title {
+    @apply text-lg font-semibold;
 }
 
-.fc-day {
-    @apply bg-white text-gray-800 dark:bg-slate-800;
-}
-
-.fc-day.fc-day-other {
-    @apply bg-gray-50 text-gray-500 dark:bg-slate-700;
-}
-
-.fc-daygrid-day-top {
-    @apply text-sm text-gray-700;
-}
-
-.fc-h-event {
-    @apply opacity-75 hover:opacity-100;
-}
-
-.fc-button {
-    @apply capitalize!;
-}
-
-.fc-scrollgrid {
-    @apply border-r-0! border-b-0! border-l-0! border-gray-200!;
-}
-
-.fc-col-header-cell .fc-scrollgrid-sync-inner {
+.fc-day-header {
     @apply py-2 font-semibold;
 }
 
-.fc-col-header-cell-cushion {
-    @apply dark:text-white;
+.fc-block-event {
+    @apply opacity-75 hover:opacity-100;
 }
 
-.fc-event-time {
-    @apply dark:text-white;
-}
-
-.fc-event-title {
-    @apply dark:text-white;
-}
-
-.fc-daygrid-day-number {
-    @apply dark:text-white;
-}
-
-.fc-theme-standard td,
-.fc-theme-standard th,
-.fc-theme-standard .fc-scrollgrid {
-    @apply border dark:border-slate-600;
-}
-
-.fc table {
-    @apply border-collapse text-sm;
-}
-
-.fc-toolbar-title {
-    @apply text-lg! font-semibold!;
+.fc-view {
+    @apply text-sm;
 }

--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -23,12 +23,13 @@ import selectComponent from './tallstackui/select.js';
 import toastComponent from './tallstackui/toast.js';
 import nuxbe from '../nuxbe.js';
 
-import { Calendar } from '@fullcalendar/core';
-import allLocales from '@fullcalendar/core/locales-all';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import timeGridPlugin from '@fullcalendar/timegrid';
-import listPlugin from '@fullcalendar/list';
-import interactionPlugin from '@fullcalendar/interaction';
+import { Calendar } from 'fullcalendar';
+import allLocales from 'fullcalendar/locales-all';
+import dayGridPlugin from 'fullcalendar/daygrid';
+import timeGridPlugin from 'fullcalendar/timegrid';
+import listPlugin from 'fullcalendar/list';
+import interactionPlugin from 'fullcalendar/interaction';
+import classicThemePlugin from 'fullcalendar/themes/classic';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import isoWeek from 'dayjs/plugin/isoWeek';
@@ -56,6 +57,7 @@ window.dayGridPlugin = dayGridPlugin;
 window.timeGridPlugin = timeGridPlugin;
 window.listPlugin = listPlugin;
 window.interactionPlugin = interactionPlugin;
+window.classicThemePlugin = classicThemePlugin;
 window.allLocales = allLocales;
 
 navigationSpinner();

--- a/resources/js/components/calendar.js
+++ b/resources/js/components/calendar.js
@@ -1,5 +1,3 @@
-import momentTimezonePlugin from '@fullcalendar/moment-timezone';
-
 const calendar = () => {
     return {
         calendarItem: {},
@@ -376,8 +374,15 @@ const calendar = () => {
                     timeGridPlugin,
                     listPlugin,
                     interactionPlugin,
-                    momentTimezonePlugin,
+                    classicThemePlugin,
                 ],
+                // v7 hashes its own class names, so expose stable hooks for the
+                // application stylesheet and the calendar-week title suffix below.
+                viewClass: 'fc-view',
+                toolbarTitleClass: 'fc-toolbar-title',
+                headerToolbarClass: 'fc-header-toolbar',
+                dayHeaderClass: 'fc-day-header',
+                blockEventClass: 'fc-block-event',
                 initialView: 'dayGridMonth',
                 slotDuration: '00:15:00',
                 initialDate: new Date(),

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,7 @@
         'dark bg-secondary-800': darkTheme,
         'bg-slate-50': !darkTheme,
     }"
+    x-bind:data-color-scheme="darkTheme ? 'dark' : 'light'"
     class="text-secondary-600 dark:text-secondary-50 h-full transition duration-300"
 >
     @section('wire.navigate.spinner')

--- a/src/Livewire/Features/Calendar/Calendar.php
+++ b/src/Livewire/Features/Calendar/Calendar.php
@@ -320,11 +320,11 @@ class Calendar extends Component
                         ],
                         'nowIndicator' => true,
                         'calendarWeekAbbreviation' => __('CW'),
-                        'buttonText' => [
-                            'today' => __('Today'),
-                            'month' => __('Month'),
-                            'week' => __('Week'),
-                            'day' => __('Day'),
+                        'buttons' => [
+                            'today' => ['text' => __('Today')],
+                            'dayGridMonth' => ['text' => __('Month')],
+                            'timeGridWeek' => ['text' => __('Week')],
+                            'timeGridDay' => ['text' => __('Day')],
                         ],
                     ]
                 ),

--- a/tests/Browser/Features/Calendar/CalendarEventTest.php
+++ b/tests/Browser/Features/Calendar/CalendarEventTest.php
@@ -29,7 +29,7 @@ function visitCalendar(): mixed
         ->assertRoute('calendars')
         ->assertNoSmoke();
 
-    waitForElement($page, '[calendar-root] .fc', 10000);
+    waitForElement($page, '[calendar-root] .fc-view', 10000);
 
     return $page;
 }


### PR DESCRIPTION
Upgrades FullCalendar from 6.1.21 to 7.0.1.

## Package changes

v7 renames the vanilla-JS distribution from `@fullcalendar/core` to `fullcalendar` and moves every plugin to a subpath entrypoint of that single package, so the six scoped dependencies collapse into one plus the new `temporal-polyfill` peer dependency. The moment-timezone plugin is gone: named time zones (used here for the user's timezone setting) are handled natively via the polyfill.

## Theming

v7 no longer ships bundled CSS and hashes its internal class names, so the previous `.fc-*` overrides no longer match anything. The classic theme plugin and its stylesheets are now registered explicitly, and the calendar is themed through the theme's CSS variables — brand indigo for the primary/today accent, slate borders and backgrounds in dark mode. The handful of layout tweaks that genuinely differ from the theme (toolbar padding, title size, day-header weight, event hover opacity) are applied to stable class names attached through v7's `*Class` options.

Dark mode: the theme reads `data-color-scheme`, which is now bound on the body alongside the existing `dark` class, so it follows the app's theme toggle.

## Option changes

`buttonText` was removed in favour of `buttons`, whose entries are keyed by button name — for view buttons that is the view name (`dayGridMonth`), not the old shorthand (`month`).

## Verification

The existing calendar browser tests cover page load, event create/edit, date click, and drag-and-drop for recurring and non-recurring events; all pass against v7. Light and dark rendering were checked visually against the v6 output — the calendar-week suffix in the toolbar title, today highlighting, other-month dimming and the toolbar layout all match.

## Summary by Sourcery

Upgrade the calendar implementation to FullCalendar v7 and adapt the app’s configuration, theming, and tests to the new distribution and API.

New Features:
- Adopt FullCalendar v7’s classic theme and palette, including CSS variable-driven theming that integrates with the app’s light/dark mode toggle.
- Expose stable CSS hooks for calendar views, headers, and events via v7’s `*Class` options for consistent styling and browser test selectors.

Bug Fixes:
- Align calendar button configuration with FullCalendar v7’s `buttons` option to ensure toolbar labels render correctly.

Enhancements:
- Replace multiple scoped FullCalendar packages and the moment-timezone plugin with the unified v7 `fullcalendar` package and `temporal-polyfill` for timezone handling.
- Refine calendar layout and typography (toolbar padding, title size, day-header weight, event hover) using v7-compatible classes while keeping the visual appearance consistent with the previous version.

Build:
- Update package dependencies to remove FullCalendar v6 packages and add the v7 `fullcalendar` bundle and `temporal-polyfill`.
- Import FullCalendar v7’s skeleton and classic theme stylesheets into the main CSS pipeline.

Tests:
- Update calendar browser tests to wait on the new stable view class instead of the old `.fc` root selector, preserving coverage for calendar interactions.