### PR TITLE
chore(deps): upgrade gridstack from 12 to 13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "dayjs": "^1.11.21",
                 "filepond": "^4.31.3",
                 "filepond-plugin-image-preview": "^4.6.12",
-                "gridstack": "^12.6.0",
+                "gridstack": "^13.0.0",
                 "laravel-echo": "^2.4.0",
                 "laravel-vite-plugin": "^3.1.3",
                 "leaflet": "^1.9.4",
@@ -1794,9 +1794,9 @@
             "license": "ISC"
         },
         "node_modules/gridstack": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-12.6.0.tgz",
-            "integrity": "sha512-dUrqsormSybFn/2P4Dz8AgprftKD5e/IiV7UmC0XLQU+G+/WtkAeFiCSNLoAGhPDXoJ/O61Xtj3gljY/Ds83yQ==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-13.0.0.tgz",
+            "integrity": "sha512-40+5jod7Lp6T2Dq/9wIXRoQ7ebSuAyeKLpVHgDrq0F7W0d4D2+DRQxLFoB/VlEyMMZkWfnbbqYzaQx+XO4rY+w==",
             "dev": true,
             "funding": [
                 {
@@ -1808,6 +1808,7 @@
                     "url": "https://www.venmo.com/adumesny"
                 }
             ],
+            "hasInstallScript": true,
             "license": "MIT"
         },
         "node_modules/has-symbols": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "dayjs": "^1.11.21",
         "filepond": "^4.31.3",
         "filepond-plugin-image-preview": "^4.6.12",
-        "gridstack": "^12.6.0",
+        "gridstack": "^13.0.0",
         "laravel-echo": "^2.4.0",
         "laravel-vite-plugin": "^3.1.3",
         "leaflet": "^1.9.4",


### PR DESCRIPTION
Upgrades gridstack from 12.6.0 to 13.0.0.

## Why now

v13 carries the fix for [#3231](https://github.com/gridstack/gridstack.js/issues/3231): dragging broke in Chrome 144+ and Firefox 147+ because `navigator.maxTouchPoints` began returning a non-zero value on desktop machines with a trackpad, so gridstack took the touch code path. That affects dashboard widget drag-and-drop directly.

## Breaking changes

v13 lists a single breaking change, and it is the Angular wrapper switching from selector+input to component+props. The dashboard drives GridStack through the vanilla API (`GridStack.init`, `addWidget`, `removeWidget`, `getGridItems`, `gridstackNode`), so nothing here is affected. No option we pass is deprecated in v13 — the one deprecation in the option interface is `styleInHead`, which we do not set.

## Verification

Beyond the existing dashboard tests, the live grid was inspected in the browser to confirm the integration surface behaves under v13:

- the grid initialises with the options we pass — 6 columns from the configured breakpoints, cell height 250, float enabled
- `addWidget` / `removeWidget` round-trip correctly and the returned element carries a populated `gridstackNode`
- `update()` repositions and resizes a rendered widget, clamping x to the column count as expected
- widgets render with the application's card styling intact, so the `grid-stack`, `grid-stack-item` and `grid-stack-item-content` class names our stylesheet targets are unchanged

## Unrelated observation

`database/factories/WidgetFactory.php` calls `method_exists()` on an array (`$widget` comes from `Widget::all()`, which yields arrays), so `Widget::factory()` throws a TypeError. It is pre-existing and unrelated to this upgrade, so it is left alone here.

## Summary by Sourcery

Build:
- Bump gridstack in package.json and package-lock.json from 12.6.0 to 13.0.0.