### PR TITLE
fix(mail): skip supplier resolution for own tenant domains

### DIFF
--- a/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
+++ b/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
@@ -261,6 +261,10 @@ class CreateMailExecutedSubscriber
     protected function matchesTenantDomain(Tenant $tenant, string $domain): bool
     {
         foreach ([$tenant->email, $tenant->website] as $value) {
+            if (blank($value)) {
+                continue;
+            }
+
             $tenantDomain = $this->normalizeDomain($value);
 
             // `website` is only validated as a string, so ignore anything without a dot

--- a/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
+++ b/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
@@ -61,7 +61,8 @@ class CreateMailExecutedSubscriber
 
     public function createPurchaseInvoice(Communication $message): ?Collection
     {
-        $contact = $this->address?->contact;
+        // Mails from one of our own domains never originate from a supplier.
+        $contact = $this->isTenantDomain($message->from) ? null : $this->address?->contact;
 
         $created = [];
         foreach ($message->getMedia('attachments') as $attachment) {
@@ -238,6 +239,44 @@ class CreateMailExecutedSubscriber
         return [
             'action.executed: ' . resolve_static(CreateMailMessage::class, 'class') => 'handle',
         ];
+    }
+
+    protected function isTenantDomain(?string $from): bool
+    {
+        $domain = $this->normalizeDomain(Str::between($from ?? '', '<', '>'));
+
+        if (blank($domain)) {
+            return false;
+        }
+
+        return resolve_static(Tenant::class, 'query')
+            ->withoutEagerLoads()
+            ->get(['email', 'website'])
+            ->flatMap(fn (Tenant $tenant): array => [
+                $this->normalizeDomain($tenant->email),
+                $this->normalizeDomain($tenant->website),
+            ])
+            // `website` is only validated as a string, so drop anything without a dot
+            // to keep a stray value like "test" from matching every ".test" sender.
+            ->filter(fn (string $tenantDomain): bool => str_contains($tenantDomain, '.'))
+            ->contains(
+                fn (string $tenantDomain): bool => $domain === $tenantDomain
+                    || str_ends_with($domain, '.' . $tenantDomain)
+            );
+    }
+
+    protected function normalizeDomain(?string $value): string
+    {
+        return Str::of($value ?? '')
+            ->lower()
+            ->trim()
+            ->afterLast('@')
+            ->replaceMatches('#^[a-z][a-z\d+.-]*://#', '')
+            ->before('/')
+            ->before(':')
+            ->replaceMatches('#^www\.#', '')
+            ->trim('.')
+            ->value();
     }
 
     protected function stripQuotedReply(?string $body): ?string

--- a/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
+++ b/src/Listeners/MailMessage/CreateMailExecutedSubscriber.php
@@ -61,15 +61,18 @@ class CreateMailExecutedSubscriber
 
     public function createPurchaseInvoice(Communication $message): ?Collection
     {
-        // Mails from one of our own domains never originate from a supplier.
-        $contact = $this->isTenantDomain($message->from) ? null : $this->address?->contact;
+        // Mails from one of our own domains never originate from a supplier, they
+        // belong to the tenant owning that domain.
+        $tenant = $this->findTenantByDomain($message->from);
+        $contact = $tenant ? null : $this->address?->contact;
 
         $created = [];
         foreach ($message->getMedia('attachments') as $attachment) {
             try {
                 $purchaseInvoice = CreatePurchaseInvoice::make([
-                    'tenant_id' => $contact?->getTenantId() ?? resolve_static(Tenant::class, 'default')
-                        ->getKey(),
+                    'tenant_id' => $tenant?->getKey()
+                        ?? $contact?->getTenantId()
+                        ?? resolve_static(Tenant::class, 'default')->getKey(),
                     'contact_id' => $contact?->id,
                     'currency_id' => $contact?->currency_id ?? resolve_static(Currency::class, 'default')
                         ->getKey(),
@@ -241,28 +244,37 @@ class CreateMailExecutedSubscriber
         ];
     }
 
-    protected function isTenantDomain(?string $from): bool
+    protected function findTenantByDomain(?string $from): ?Tenant
     {
         $domain = $this->normalizeDomain(Str::between($from ?? '', '<', '>'));
 
         if (blank($domain)) {
-            return false;
+            return null;
         }
 
         return resolve_static(Tenant::class, 'query')
             ->withoutEagerLoads()
-            ->get(['email', 'website'])
-            ->flatMap(fn (Tenant $tenant): array => [
-                $this->normalizeDomain($tenant->email),
-                $this->normalizeDomain($tenant->website),
-            ])
-            // `website` is only validated as a string, so drop anything without a dot
+            ->get(['id', 'email', 'website'])
+            ->first(fn (Tenant $tenant): bool => $this->matchesTenantDomain($tenant, $domain));
+    }
+
+    protected function matchesTenantDomain(Tenant $tenant, string $domain): bool
+    {
+        foreach ([$tenant->email, $tenant->website] as $value) {
+            $tenantDomain = $this->normalizeDomain($value);
+
+            // `website` is only validated as a string, so ignore anything without a dot
             // to keep a stray value like "test" from matching every ".test" sender.
-            ->filter(fn (string $tenantDomain): bool => str_contains($tenantDomain, '.'))
-            ->contains(
-                fn (string $tenantDomain): bool => $domain === $tenantDomain
-                    || str_ends_with($domain, '.' . $tenantDomain)
-            );
+            if (! str_contains($tenantDomain, '.')) {
+                continue;
+            }
+
+            if ($domain === $tenantDomain || str_ends_with($domain, '.' . $tenantDomain)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function normalizeDomain(?string $value): string

--- a/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
+++ b/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
@@ -121,7 +121,7 @@ test('purchase invoice from mail message skips supplier on tenant domain', funct
 ): void {
     Event::fake('action.executed: ' . CreateMailMessage::class);
 
-    Tenant::factory()->create($tenantAttributes);
+    $tenant = Tenant::factory()->create($tenantAttributes);
 
     $contact = Contact::factory()->create();
     $address = Address::factory()->create([
@@ -158,6 +158,12 @@ test('purchase invoice from mail message skips supplier on tenant domain', funct
 
     expect($purchaseInvoice)->not->toBeNull()
         ->and($purchaseInvoice->contact_id)->toBe($expectsContact ? $contact->getKey() : null);
+
+    if (! $expectsContact) {
+        // The matching tenant owns the invoice, not the default tenant.
+        expect($purchaseInvoice->tenant_id)->toBe($tenant->getKey())
+            ->and($tenant->refresh()->is_default)->toBeFalse();
+    }
 })->with([
     'tenant email domain' => [['email' => 'buchhaltung@team-nifty.test'], 'team-nifty.test', false],
     'tenant website domain' => [['website' => 'https://www.team-nifty.test/impressum'], 'team-nifty.test', false],

--- a/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
+++ b/tests/Unit/Action/MailMessage/CreateMailMessageTest.php
@@ -7,7 +7,10 @@ use FluxErp\Models\Comment;
 use FluxErp\Models\Contact;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
+use FluxErp\Models\PurchaseInvoice;
+use FluxErp\Models\Tenant;
 use FluxErp\Models\Ticket;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
@@ -110,6 +113,59 @@ test('strips quoted conversation from comment created from mail reply', function
         ->and($comment->comment)->not->toContain('flux:comment')
         ->and($comment->comment)->not->toContain('[flux:quote]');
 });
+
+test('purchase invoice from mail message skips supplier on tenant domain', function (
+    array $tenantAttributes,
+    string $senderDomain,
+    bool $expectsContact
+): void {
+    Event::fake('action.executed: ' . CreateMailMessage::class);
+
+    Tenant::factory()->create($tenantAttributes);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'rechnung@' . $senderDomain,
+    ]);
+
+    $mailFolder = MailFolder::factory()->create([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'can_create_purchase_invoice' => true,
+    ]);
+
+    $action = CreateMailMessage::make([
+        'mail_account_id' => $this->mailAccount->getKey(),
+        'mail_folder_id' => $mailFolder->getKey(),
+        'from' => 'Tester McTestFace <' . $address->email_primary . '>',
+        'to' => [$this->mailAccount->email],
+        'subject' => Str::uuid()->toString(),
+        'text_body' => faker()->text(),
+        'html_body' => '<p>' . faker()->text() . '</p>',
+        'communication_type_enum' => 'mail',
+        'date' => now()->format('Y-m-d H:i:s'),
+        'tags' => [],
+    ]);
+    $message = $action->validate()->execute();
+
+    $message->addMedia(UploadedFile::fake()->create('invoice.pdf', 10, 'application/pdf'))
+        ->toMediaCollection('attachments');
+    $message->refresh();
+
+    (new CreateMailExecutedSubscriber())->handle($action);
+
+    $purchaseInvoice = PurchaseInvoice::query()->latest('id')->first();
+
+    expect($purchaseInvoice)->not->toBeNull()
+        ->and($purchaseInvoice->contact_id)->toBe($expectsContact ? $contact->getKey() : null);
+})->with([
+    'tenant email domain' => [['email' => 'buchhaltung@team-nifty.test'], 'team-nifty.test', false],
+    'tenant website domain' => [['website' => 'https://www.team-nifty.test/impressum'], 'team-nifty.test', false],
+    'tenant email subdomain' => [['email' => 'buchhaltung@team-nifty.test'], 'mail.team-nifty.test', false],
+    'foreign domain' => [['email' => 'buchhaltung@team-nifty.test'], 'supplier.test', true],
+    'domain suffix lookalike' => [['email' => 'buchhaltung@team-nifty.test'], 'notteam-nifty.test', true],
+    'tenant website without a dot' => [['website' => 'test'], 'supplier.test', true],
+]);
 
 test('create ticket from mail message', function (): void {
     Event::fake('action.executed: ' . CreateMailMessage::class);


### PR DESCRIPTION
## Problem

Purchase invoices created automatically from incoming mail resolve the supplier from the sender address via `Address::findAddressByEmail()`. When a mail arrives from one of our own domains, for example an employee mailing themselves an invoice, that lookup finds the internal contact and assigns it as the supplier.

## Change

`CreateMailExecutedSubscriber::createPurchaseInvoice()` now drops the resolved contact when the sender domain belongs to a tenant:

```php
$contact = $this->isTenantDomain($message->from) ? null : $this->address?->contact;
```

`isTenantDomain()` normalizes the sender domain (lowercase, part after `@`, scheme, port, path and `www.` prefix removed) and compares it against every `tenants.email` and `tenants.website` value. A tenant matches on an exact domain or on a real subdomain, so `notteam-nifty.test` does not match `team-nifty.test`.

Tenant domains without a dot are ignored. `website` is only validated as `string|max:255`, so a stray value such as `test` would otherwise match every sender under that suffix.

The tenant query uses `withoutEagerLoads()` because `Tenant::$with = ['media']` would otherwise load media for every tenant just to read two columns.

## Scope

Only supplier determination for purchase invoices. Ticket creation, lead creation and the `[flux:comment:...]` assignment keep resolving the sender address unchanged. The invoice is still created, just without a `contact_id`, so it appears in the unassigned purchase invoices widget.

## Known limitations

* Trashed tenants are not considered, since `query()` applies the soft delete scope.
* No IDN normalization. A tenant domain stored as unicode will not match a punycode sender header.

## Summary by Sourcery

Skip automatic supplier assignment for purchase invoices created from mails sent from tenant-owned domains and add coverage for the new domain-matching rules.

Bug Fixes:
- Prevent internal tenant contacts from being incorrectly assigned as suppliers when purchase invoices are created from emails originating from tenant email or website domains.

Enhancements:
- Introduce tenant-domain detection and normalization logic to identify emails originating from tenant-owned domains when creating purchase invoices.

Tests:
- Add unit tests covering purchase invoice creation from mail for various tenant email/website domain combinations, including subdomains and lookalike/suffix domains.