### PR TITLE
feat(accounting): flag vat rates as usable for purchase and sales

### DIFF
--- a/database/migrations/2026_07_21_000001_add_is_purchase_is_sales_to_vat_rates_table.php
+++ b/database/migrations/2026_07_21_000001_add_is_purchase_is_sales_to_vat_rates_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('vat_rates', function (Blueprint $table): void {
+            // Both default to true so existing rates keep appearing in every select.
+            $table->boolean('is_purchase')->default(true)->after('is_default');
+            $table->boolean('is_sales')->default(true)->after('is_purchase');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vat_rates', function (Blueprint $table): void {
+            $table->dropColumn(['is_purchase', 'is_sales']);
+        });
+    }
+};

--- a/resources/views/livewire/settings/vat-rates.blade.php
+++ b/resources/views/livewire/settings/vat-rates.blade.php
@@ -19,6 +19,14 @@
                 />
             </div>
             <x-toggle
+                wire:model.boolean="vatRate.is_purchase"
+                :label="__('Is Purchase')"
+            />
+            <x-toggle
+                wire:model.boolean="vatRate.is_sales"
+                :label="__('Is Sales')"
+            />
+            <x-toggle
                 wire:model.boolean="vatRate.is_tax_exemption"
                 :label="__('Is Tax Exemption')"
             />

--- a/src/Livewire/DataTables/PurchaseInvoiceList.php
+++ b/src/Livewire/DataTables/PurchaseInvoiceList.php
@@ -365,6 +365,7 @@ class PurchaseInvoiceList extends BaseDataTable
                     ->get(['id', 'name', 'requires_manual_transfer'])
                     ->toArray(),
                 'vatRates' => resolve_static(VatRate::class, 'query')
+                    ->where('is_purchase', true)
                     ->get(['id', 'name', 'rate_percentage'])
                     ->toArray(),
             ]

--- a/src/Livewire/Forms/VatRateForm.php
+++ b/src/Livewire/Forms/VatRateForm.php
@@ -17,6 +17,10 @@ class VatRateForm extends FluxForm
 
     public bool $is_default = false;
 
+    public bool $is_purchase = true;
+
+    public bool $is_sales = true;
+
     public bool $is_tax_exemption = false;
 
     public ?string $name = null;

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -159,6 +159,7 @@ class Order extends Component
                     ->get(['id', 'contact_id', 'iban'])
                     ?->toArray() ?? [],
                 'vatRates' => resolve_static(VatRate::class, 'query')
+                    ->where($this->order->isPurchase ? 'is_purchase' : 'is_sales', true)
                     ->where('is_tax_exemption', true)
                     ->get(['id', 'name'])
                     ->toArray(),

--- a/src/Livewire/Order/OrderPositions.php
+++ b/src/Livewire/Order/OrderPositions.php
@@ -424,6 +424,7 @@ class OrderPositions extends OrderPositionList
             parent::getViewData(),
             [
                 'vatRates' => resolve_static(VatRate::class, 'query')
+                    ->where($this->order->isPurchase ? 'is_purchase' : 'is_sales', true)
                     ->get(['id', 'name', 'rate_percentage'])
                     ->toArray(),
             ]

--- a/src/Livewire/Product/Product.php
+++ b/src/Livewire/Product/Product.php
@@ -474,7 +474,10 @@ class Product extends Component
     #[Computed]
     public function vatRates(): array
     {
-        return app(VatRate::class)->all(['id', 'name', 'rate_percentage'])->toArray();
+        return resolve_static(VatRate::class, 'query')
+            ->where('is_sales', true)
+            ->get(['id', 'name', 'rate_percentage'])
+            ->toArray();
     }
 
     #[Computed(persist: true)]

--- a/src/Livewire/Product/ProductList.php
+++ b/src/Livewire/Product/ProductList.php
@@ -46,6 +46,7 @@ class ProductList extends BaseProductList
         parent::mount();
 
         $this->vatRates = resolve_static(VatRate::class, 'query')
+            ->where('is_sales', true)
             ->get(['id', 'name', 'rate_percentage'])
             ->toArray();
         $priceList = resolve_static(PriceList::class, 'default')?->toArray() ?? [];
@@ -204,6 +205,7 @@ class ProductList extends BaseProductList
                     ->get(['id', 'name'])
                     ->toArray(),
                 'vatRates' => resolve_static(VatRate::class, 'query')
+                    ->where('is_sales', true)
                     ->get(['id', 'name', 'rate_percentage'])
                     ->toArray(),
                 'roundingMethods' => resolve_static(RoundingMethodEnum::class, 'valuesLocalized'),

--- a/src/Models/VatRate.php
+++ b/src/Models/VatRate.php
@@ -22,6 +22,8 @@ class VatRate extends FluxModel
     {
         return [
             'is_default' => 'boolean',
+            'is_purchase' => 'boolean',
+            'is_sales' => 'boolean',
             'is_tax_exemption' => 'boolean',
         ];
     }

--- a/src/Rulesets/Product/CreateProductRuleset.php
+++ b/src/Rulesets/Product/CreateProductRuleset.php
@@ -55,7 +55,8 @@ class CreateProductRuleset extends FluxRuleset
             'vat_rate_id' => [
                 'required',
                 'integer',
-                app(ModelExists::class, ['model' => VatRate::class]),
+                app(ModelExists::class, ['model' => VatRate::class])
+                    ->where('is_sales', true),
             ],
             'unit_id' => [
                 'integer',

--- a/src/Rulesets/Product/UpdateProductRuleset.php
+++ b/src/Rulesets/Product/UpdateProductRuleset.php
@@ -73,7 +73,8 @@ class UpdateProductRuleset extends FluxRuleset
                 'sometimes',
                 'required',
                 'integer',
-                app(ModelExists::class, ['model' => VatRate::class]),
+                app(ModelExists::class, ['model' => VatRate::class])
+                    ->where('is_sales', true),
             ],
             'unit_id' => [
                 'integer',

--- a/src/Rulesets/PurchaseInvoicePosition/CreatePurchaseInvoicePositionRuleset.php
+++ b/src/Rulesets/PurchaseInvoicePosition/CreatePurchaseInvoicePositionRuleset.php
@@ -41,7 +41,8 @@ class CreatePurchaseInvoicePositionRuleset extends FluxRuleset
             'vat_rate_id' => [
                 'nullable',
                 'integer',
-                app(ModelExists::class, ['model' => VatRate::class]),
+                app(ModelExists::class, ['model' => VatRate::class])
+                    ->where('is_purchase', true),
             ],
             'name' => 'nullable|string|max:255',
             'amount' => [

--- a/src/Rulesets/PurchaseInvoicePosition/UpdatePurchaseInvoicePositionRuleset.php
+++ b/src/Rulesets/PurchaseInvoicePosition/UpdatePurchaseInvoicePositionRuleset.php
@@ -35,7 +35,8 @@ class UpdatePurchaseInvoicePositionRuleset extends FluxRuleset
             'vat_rate_id' => [
                 'nullable',
                 'integer',
-                app(ModelExists::class, ['model' => VatRate::class]),
+                app(ModelExists::class, ['model' => VatRate::class])
+                    ->where('is_purchase', true),
             ],
             'name' => 'nullable|string|max:255',
             'amount' => app(Numeric::class),

--- a/src/Rulesets/VatRate/CreateVatRateRuleset.php
+++ b/src/Rulesets/VatRate/CreateVatRateRuleset.php
@@ -17,6 +17,8 @@ class CreateVatRateRuleset extends FluxRuleset
             'rate_percentage' => 'required|numeric|lt:1|min:0',
             'footer_text' => 'string|nullable',
             'is_default' => 'boolean',
+            'is_purchase' => 'boolean',
+            'is_sales' => 'boolean',
             'is_tax_exemption' => 'boolean',
         ];
     }

--- a/src/Rulesets/VatRate/UpdateVatRateRuleset.php
+++ b/src/Rulesets/VatRate/UpdateVatRateRuleset.php
@@ -22,6 +22,8 @@ class UpdateVatRateRuleset extends FluxRuleset
             'rate_percentage' => 'required|numeric|lt:1|min:0',
             'footer_text' => 'string|nullable',
             'is_default' => 'boolean',
+            'is_purchase' => 'boolean',
+            'is_sales' => 'boolean',
             'is_tax_exemption' => 'boolean',
         ];
     }

--- a/tests/Feature/Actions/Product/ProductActionTest.php
+++ b/tests/Feature/Actions/Product/ProductActionTest.php
@@ -4,6 +4,7 @@ use FluxErp\Actions\Product\CreateProduct;
 use FluxErp\Actions\Product\DeleteProduct;
 use FluxErp\Actions\Product\UpdateProduct;
 use FluxErp\Models\Product;
+use FluxErp\Models\VatRate;
 
 test('create product with defaults', function (): void {
     $product = CreateProduct::make([
@@ -57,4 +58,16 @@ test('delete product with children fails', function (): void {
     expect(fn () => DeleteProduct::make(['id' => $parent->getKey()])
         ->validate()->execute()
     )->toThrow(Illuminate\Validation\ValidationException::class);
+});
+
+test('create product rejects a purchase-only vat rate', function (): void {
+    $purchaseOnlyVatRate = VatRate::factory()->create([
+        'is_purchase' => true,
+        'is_sales' => false,
+    ]);
+
+    CreateProduct::assertValidationErrors([
+        'name' => 'Test Widget',
+        'vat_rate_id' => $purchaseOnlyVatRate->getKey(),
+    ], 'vat_rate_id');
 });

--- a/tests/Feature/Actions/PurchaseInvoicePosition/PurchaseInvoicePositionActionTest.php
+++ b/tests/Feature/Actions/PurchaseInvoicePosition/PurchaseInvoicePositionActionTest.php
@@ -48,3 +48,20 @@ test('delete purchase invoice position', function (): void {
     expect(DeletePurchaseInvoicePosition::make(['id' => $position->getKey()])
         ->validate()->execute())->toBeTrue();
 });
+
+test('create purchase invoice position rejects a sales-only vat rate', function (): void {
+    $salesOnlyVatRate = VatRate::factory()->create([
+        'is_purchase' => false,
+        'is_sales' => true,
+    ]);
+
+    CreatePurchaseInvoicePosition::assertValidationErrors([
+        'purchase_invoice_id' => $this->purchaseInvoice->getKey(),
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'vat_rate_id' => $salesOnlyVatRate->getKey(),
+        'name' => 'Office Supplies',
+        'amount' => 1,
+        'unit_price' => 100.00,
+        'total_price' => 100.00,
+    ], 'vat_rate_id');
+});

--- a/tests/Feature/Actions/VatRate/VatRateActionTest.php
+++ b/tests/Feature/Actions/VatRate/VatRateActionTest.php
@@ -40,3 +40,42 @@ test('delete vat rate', function (): void {
     expect(DeleteVatRate::make(['id' => $vat->getKey()])
         ->validate()->execute())->toBeTrue();
 });
+
+test('vat rate defaults to usable for purchase and sales', function (): void {
+    $vat = CreateVatRate::make([
+        'name' => 'Standard',
+        'rate_percentage' => 0.19,
+    ])
+        ->validate()
+        ->execute();
+
+    expect($vat->refresh())
+        ->is_purchase->toBeTrue()
+        ->is_sales->toBeTrue();
+});
+
+test('vat rate purchase and sales flags can be set', function (): void {
+    $vat = CreateVatRate::make([
+        'name' => 'Import VAT',
+        'rate_percentage' => 0.19,
+        'is_purchase' => true,
+        'is_sales' => false,
+    ])
+        ->validate()
+        ->execute();
+
+    expect($vat->refresh())
+        ->is_purchase->toBeTrue()
+        ->is_sales->toBeFalse();
+
+    $updated = UpdateVatRate::make([
+        'id' => $vat->getKey(),
+        'name' => $vat->name,
+        'rate_percentage' => 0.19,
+        'is_sales' => true,
+    ])
+        ->validate()
+        ->execute();
+
+    expect($updated->is_sales)->toBeTrue();
+});

--- a/tests/Livewire/Product/ProductTest.php
+++ b/tests/Livewire/Product/ProductTest.php
@@ -233,11 +233,17 @@ test('tab visibility for variant product', function (): void {
 });
 
 test('vat rates computed property', function (): void {
+    $purchaseOnlyVatRate = VatRate::factory()->create([
+        'is_purchase' => true,
+        'is_sales' => false,
+    ]);
+
     $component = Livewire::test(Product::class, ['id' => $this->product->id]);
 
     $vatRates = $component->instance()->vatRates();
     expect($vatRates)->toBeArray();
     expect($vatRates)->not->toBeEmpty();
+    expect(array_column($vatRates, 'id'))->not->toContain($purchaseOnlyVatRate->getKey());
 });
 
 test('view name computed property', function (): void {


### PR DESCRIPTION
## Change

`vat_rates` gets `is_purchase` and `is_sales` booleans, mirroring the naming on `payment_types`. Both default to `true`, so existing rates keep appearing in every select and the migration is non breaking.

## Selects

Every VAT rate option source now filters on the flags:

| Surface | Filter |
|---|---|
| Order header tax exemption + order position select | by the order's purchase flag (`OrderForm::$isPurchase`) |
| Purchase invoice form | `is_purchase` |
| Product detail, product list bulk edit | `is_sales` |
| Contact accounting tax exemption | unfiltered, `contact.vat_rate_id` feeds `CreateOrder` for both sale and purchase orders |

## Validation

Purchase invoice position and product rulesets constrain `vat_rate_id` to a rate carrying the matching flag, so the API cannot assign a sales-only rate to a purchase document or vice versa.

Order positions are filtered in the UI only: `PriceCalculation` intentionally auto-fills the product's sales rate on purchase orders, and a hard constraint would break that.

## Settings

The vat rate settings modal exposes both flags as toggles; the `Is Purchase` / `Is Sales` translation keys already existed.

## Tests

New coverage: default flags on create, setting flags via create/update, the product select excluding purchase-only rates, and both ruleset guards (purchase invoice position rejects sales-only, product rejects purchase-only).

## Summary by Sourcery

Introduce purchase and sales usability flags on VAT rates and propagate them through forms, validation rules, UI selects, and database schema.

New Features:
- Add is_purchase and is_sales boolean flags to VAT rates with default true values.
- Expose purchase and sales usability toggles in the VAT rate settings UI.
- Filter VAT rate selections in product, order, purchase invoice, and product list UIs based on the appropriate purchase/sales flags.

Bug Fixes:
- Prevent assigning sales-only VAT rates to purchase invoice positions via validation rules.
- Prevent assigning purchase-only VAT rates to products via validation rules.

Enhancements:
- Restrict product VAT rate queries and rulesets to sales-usable rates.
- Restrict purchase invoice VAT rate queries and rulesets to purchase-usable rates.
- Align order VAT rate selection with the order's purchase/sales context while respecting tax exemption filtering.

Tests:
- Add tests for VAT rate default flag values and explicit flag setting on create/update.
- Add tests ensuring purchase invoice positions reject sales-only VAT rates.
- Add tests ensuring products reject purchase-only VAT rates.
- Add tests verifying product VAT rate selections exclude purchase-only rates.