### PR TITLE
fix(tests): raise browser and composer timeouts

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Route;
 use Pest\Browser\Api\ArrayablePendingAwaitablePage;
 use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Playwright\Playwright;
 
 if ($auditLocale = env('TRANSLATION_AUDIT_LOCALE')) {
     require_once __DIR__ . '/Support/TranslationAuditCollector.php';
@@ -102,6 +103,12 @@ pest()
         }
 
         BrowserTestCase::installAssets();
+    })
+    ->beforeEach(function (): void {
+        // Heavy pages pay the blade compilation penalty on their first visit in each
+        // parallel worker, which intermittently exceeds the plugin's 5s default under
+        // CI load (CommentsTest flaked on roughly every other pull request run).
+        Playwright::setTimeout(15000);
     })
     ->in('Browser');
 


### PR DESCRIPTION
`CommentsTest > comments section loads without js errors` failed with `Timeout 5000ms exceeded` on four PR runs within two days (#1845, #1910, #1911, #1913), each passing on rerun.

Root cause: the first browser test visiting a heavy page in each parallel worker pays the blade compilation penalty, which intermittently exceeds the pest browser plugin's 5s default assertion timeout under CI load. Not a JS error — the smoke assertion itself never ran.

Fix: set the Playwright timeout to 15s for the whole Browser suite via `beforeEach` in `tests/Pest.php`. Slow-but-working pages stop flaking; genuinely broken pages still fail, just a few seconds later.

## Summary by Sourcery

Tests:
- Raise Playwright timeout to 15 seconds for all browser tests via a global beforeEach hook.