### PR TITLE
fix(tests): raise the composer process timeout to 15 minutes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
         ]
     },
     "config": {
+        "process-timeout": 900,
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,


### PR DESCRIPTION
Follow-up to #1914. The parallel feature suite runs close to composer's 300s default process timeout; under runner load it exceeds it and the run dies mid-suite without ever printing the test summary — #1912's run failed exactly that way, hiding which tests actually failed.

Sets `config.process-timeout` to 900 in `composer.json`, which applies to all `composer test-*` scripts.