### PR TITLE
fix(media): return 404 for missing files and stop the download test flake

### DIFF
--- a/src/Actions/Media/DownloadMedia.php
+++ b/src/Actions/Media/DownloadMedia.php
@@ -81,6 +81,14 @@ class DownloadMedia extends FluxAction
             throw UnauthorizedException::forPermissions(['action.' . static::name()]);
         }
 
+        // A missing physical file otherwise surfaces as a 500 from response()->download().
+        if (! file_exists($media->getPath($this->getData('conversion') ?? ''))) {
+            throw ValidationException::withMessages([
+                'media' => 'File not found',
+            ])
+                ->status(404);
+        }
+
         parent::validateData();
 
         $this->data['id'] ??= $media?->getKey();

--- a/src/Actions/Media/DownloadMedia.php
+++ b/src/Actions/Media/DownloadMedia.php
@@ -6,6 +6,7 @@ use FluxErp\Actions\FluxAction;
 use FluxErp\Models\Media;
 use FluxErp\Rulesets\Media\DownloadMediaRuleset;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 
@@ -81,8 +82,11 @@ class DownloadMedia extends FluxAction
             throw UnauthorizedException::forPermissions(['action.' . static::name()]);
         }
 
-        // A missing physical file otherwise surfaces as a 500 from response()->download().
-        if (! file_exists($media->getPath($this->getData('conversion') ?? ''))) {
+        // A missing file otherwise surfaces as a 500 from response()->download().
+        // Check through the disk, remote disks have no local path.
+        if (! Storage::disk($media->disk)->exists(
+            $media->getPathRelativeToRoot($this->getData('conversion') ?? '')
+        )) {
             throw ValidationException::withMessages([
                 'media' => 'File not found',
             ])

--- a/tests/Feature/Api/MediaTest.php
+++ b/tests/Feature/Api/MediaTest.php
@@ -637,6 +637,15 @@ function createMedia(array $attributes, Task $task, Illuminate\Http\Testing\File
 {
     $disk = data_get($attributes, 'disk', 'local');
 
+    // The factory names files via fake()->word(), whose small pool produced
+    // colliding file names across media rows and intermittently matched the
+    // wrong row in DownloadMedia's file_name lookup.
+    if (! array_key_exists('file_name', $attributes)) {
+        $fileName = Str::uuid()->toString() . '.png';
+        $attributes['name'] = $fileName;
+        $attributes['file_name'] = $fileName;
+    }
+
     Storage::fake($disk);
 
     /** @var Media $media */
@@ -655,3 +664,18 @@ function createMedia(array $attributes, Task $task, Illuminate\Http\Testing\File
 
     return $media;
 }
+
+test('download media returns 404 when the physical file is missing', function (): void {
+    $media = createMedia([
+        'disk' => 'public',
+    ],
+        $this->task,
+        $this->testFile
+    );
+    Storage::disk('public')->delete($media->getPathRelativeToRoot());
+    $queryParams = '?model_type=' . $this->task->getMorphClass() . '&model_id=' . $this->task->getKey();
+
+    $download = $this->get('/api/media/' . $media->file_name . $queryParams);
+
+    $download->assertNotFound();
+});


### PR DESCRIPTION
`MediaTest > download media unauthenticated private media` failed intermittently in CI with a 500 instead of 403 (#1912 and #1915 both lost runs to it).

## Root cause

`MediaTest`'s `beforeEach` creates a media row on the same task with factory defaults: **public disk, `fake()->word()` file name, and no physical file on disk**. Faker's word pool is small, so when `createMedia` drew the same word for the test's own private media, `DownloadMedia`'s `file_name + model_type + model_id` lookup matched **both** rows and `first()` picked the older public one. The guest check passed (public disk), and `response()->download()` then hit a file that never existed:

```
The file ".../storage/app/public/18/asperiores.png" does not exist
```

## Fix

* `createMedia` defaults to a uuid file name unless the test provides one — the collision class is gone.
* `DownloadMedia` now validates that the physical file exists and answers **404** instead of the 500 that `response()->download()` produced. That part is a real production fix: a deleted or never-synced file previously surfaced as an internal server error for any caller. Regression test included.

## Summary by Sourcery

Ensure media downloads return 404 for missing physical files and make test media filenames collision-resistant to stop intermittent download test failures.

Bug Fixes:
- Return a 404 instead of a 500 when attempting to download media whose underlying file is missing.
- Eliminate intermittent MediaTest download failures caused by colliding factory-generated file names across media rows.

Tests:
- Add a regression test verifying that downloading media with a missing physical file responds with 404.