### PR TITLE
fix(ui): repair prompt dialogs broken by Livewire 4 expression evaluation

### DIFF
--- a/resources/js/components/alpine.js
+++ b/resources/js/components/alpine.js
@@ -163,6 +163,23 @@ document.addEventListener('livewire:init', () => {
                 .wireable(component.id)
                 [type](title, description)
                 .confirm(confirmLabel, () => {
+                    // Livewire 4's own evaluator resolves unknown identifiers
+                    // against $wire, which breaks expressions like
+                    // addTag($nuxbe.promptValue()). Evaluate through Alpine
+                    // instead, where $wire, magics and x-for scope all work.
+                    const expression = el.getAttribute('wire:click');
+
+                    if (expression) {
+                        window.Alpine.evaluate(
+                            el,
+                            expression.trimStart().startsWith('$wire.')
+                                ? expression
+                                : '$wire.' + expression,
+                        );
+
+                        return;
+                    }
+
                     action();
                 })
                 .cancel(cancelLabel)

--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -7,8 +7,32 @@ import './nuxbe/lightbox/handlers/video.js';
 import './nuxbe/lightbox/handlers/audio.js';
 import './nuxbe/lightbox/handlers/fallback.js';
 
+// TallStackUI removes the dialog from the DOM before the confirm callback runs,
+// so inputs rendered inside it are gone by the time a wire:click expression
+// calls promptValue(). Snapshot every input the moment the dialog is accepted
+// and fall back to that snapshot when the element no longer exists.
+let promptValueStash = {};
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('dialog:accepted', () => {
+        promptValueStash = {};
+
+        document
+            .querySelectorAll('input[id], textarea[id], select[id]')
+            .forEach((el) => {
+                promptValueStash[el.id] =
+                    el.type === 'checkbox' ? el.checked : el.value;
+            });
+    });
+}
+
 function promptValue(id) {
-    const el = document.getElementById(id ? id : 'prompt-value');
+    const key = id ? id : 'prompt-value';
+    const el = document.getElementById(key);
+
+    if (!el) {
+        return promptValueStash[key];
+    }
 
     if (el.type === 'checkbox') {
         return el.checked;

--- a/tests/Browser/Features/ConfirmDialog/PromptDialogTest.php
+++ b/tests/Browser/Features/ConfirmDialog/PromptDialogTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use FluxErp\Models\Product;
+use FluxErp\Models\Tag;
+
+beforeEach(function (): void {
+    $this->product = Product::factory()->create([
+        'name' => 'Prompt Dialog Product',
+        'is_active' => true,
+    ]);
+});
+
+test('creating a tag through the prompt dialog works', function (): void {
+    $page = visit(route('products.id', ['id' => $this->product->getKey()]))
+        ->assertNoSmoke();
+
+    // Open the prompt dialog via the green plus next to the tag select.
+    $page->script(<<<'JS'
+        () => {
+            [...document.querySelectorAll('button')]
+                .find((button) =>
+                    (button.getAttribute('wire:click') ?? '').includes('addTag'),
+                )
+                .click();
+        }
+    JS);
+
+    waitForElement($page, '#prompt-value', 10000);
+
+    $page->script(<<<'JS'
+        () => {
+            const input = document.getElementById('prompt-value');
+            input.value = 'Prompt Repro Tag';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+    JS);
+
+    $page->script(<<<'JS'
+        () => {
+            [...document.querySelectorAll('button')]
+                .find((button) => button.textContent.trim() === 'Save')
+                .click();
+        }
+    JS);
+
+    $page->wait(1.5)->assertNoJavascriptErrors();
+
+    expect(Tag::query()->where('name', 'Prompt Repro Tag')->exists())->toBeTrue();
+});


### PR DESCRIPTION
Customer report (Drei Masken Verlag): 500 when creating a tag through the green plus button. Their instance predates #1634 and fails server-side with the old `$promptValue()` expression — but reproducing on current main showed the flow is broken here too, just silently.

## Root cause

Livewire 4's action evaluator resolves unknown identifiers against `$wire`. Every `wire:click` carrying a JS expression behind `wire:flux-confirm` dies with:

```
Livewire Expression Error: $wire.$nuxbe.promptValue is not a function
Expression: "addTag($nuxbe.promptValue())"
```

The request never fires, the dialog just closes. Affected: tag creation on products, addresses, tasks, leads, communications, favorites, plugin install/uninstall, the test mail prompt — every `$nuxbe.promptValue()` call site.

A second, masked bug sat behind it: TallStackUI removes the dialog from the DOM **before** the confirm callback runs (`accept()` removes immediately, the callback fires after a 100ms timeout), so `#prompt-value` would not exist anymore even if the expression evaluated.

## Fix — no blade changes

* The `flux-confirm` confirm callback evaluates the `wire:click` expression through **Alpine** (`Alpine.evaluate` with a `$wire.` prefix), where `$wire`, the `$nuxbe` magic and surrounding `x-for` scope all resolve. Plain method calls (`delete()`, `save()`) behave exactly as before.
* `promptValue()` falls back to a snapshot taken on `dialog:accepted` (fires synchronously while the input still exists).

## Test

New browser test drives the real flow: open the prompt via the tag plus button on a product, type a name, confirm, assert the tag row exists and no JS errors surfaced. Red on main, green with the fix.

## Summary by Sourcery

Repair prompt dialog confirm flows by routing wire:click expressions through Alpine and stashing accepted input values, and harden media downloading to return 404s for missing files with supporting tests.

Bug Fixes:
- Restore prompt dialog actions that were broken by Livewire 4 expression evaluation.
- Ensure media downloads return a 404 instead of a 500 when the underlying file is missing.
- Prevent intermittent media download test failures caused by colliding fake file names.

Enhancements:
- Evaluate flux-confirm wire:click expressions through Alpine to maintain access to $wire, magic properties, and loop scope.
- Persist prompt dialog input values via a snapshot taken on dialog acceptance so they remain available after the dialog DOM is removed.

Tests:
- Add a browser test that covers creating a tag via the prompt dialog and asserts the full UI flow works without JavaScript errors.
- Add an API test verifying missing media files result in a 404 response.