### PR TITLE
fix(accounting): exclude unbounced direct debits from dunning and hide sent reminders

### DIFF
--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -31,6 +31,14 @@ class PaymentReminderRun extends Component
     /** Editable recipient email per group, keyed by group key. */
     public array $recipientEmails = [];
 
+    /**
+     * Orders whose reminders were dispatched in this session. The sends run as a
+     * queued batch, so the database still lists them as due when the component
+     * reloads; hide them optimistically instead of forcing a manual reload.
+     */
+    #[Locked]
+    public array $sentOrderIds = [];
+
     public ?string $filterLevel = null;
 
     public ?string $search = null;
@@ -73,6 +81,10 @@ class PaymentReminderRun extends Component
 
         $orders = resolve_static(Order::class, 'query')
             ->wherePaymentReminderDue()
+            ->when(
+                $this->sentOrderIds,
+                fn (Builder $query, array $sentOrderIds) => $query->whereIntegerNotInRaw('id', $sentOrderIds)
+            )
             ->when(
                 filled($this->filterLevel),
                 fn (Builder $query) => $query->where(
@@ -191,7 +203,10 @@ class PaymentReminderRun extends Component
         $groupIds = array_column($group['orders'], 'id');
         $orderIds = array_values(array_intersect($groupIds, $this->selectedOrders)) ?: $groupIds;
 
-        $this->sendBundle($orderIds);
+        if ($this->sendBundle($orderIds)) {
+            $this->markAsSent($orderIds);
+        }
+
         $this->loadData();
     }
 
@@ -201,7 +216,10 @@ class PaymentReminderRun extends Component
             return;
         }
 
-        $this->sendBundle($this->selectedOrders);
+        if ($this->sendBundle($this->selectedOrders)) {
+            $this->markAsSent($this->selectedOrders);
+        }
+
         $this->loadData();
     }
 
@@ -221,10 +239,23 @@ class PaymentReminderRun extends Component
             : array_values(array_unique(array_merge($this->selectedOrders, $groupIds)));
     }
 
-    protected function sendBundle(array $orderIds): void
+    protected function markAsSent(array $orderIds): void
+    {
+        $this->sentOrderIds = array_values(array_unique(array_merge(
+            $this->sentOrderIds,
+            array_map('intval', $orderIds)
+        )));
+
+        $this->selectedOrders = array_values(array_diff(
+            $this->selectedOrders,
+            array_map('strval', $orderIds)
+        ));
+    }
+
+    protected function sendBundle(array $orderIds): bool
     {
         if (! $orderIds) {
-            return;
+            return false;
         }
 
         $orderIds = array_map('intval', $orderIds);
@@ -255,7 +286,11 @@ class PaymentReminderRun extends Component
                 ->execute();
         } catch (ValidationException|UnauthorizedException $e) {
             exception_to_notifications($e, $this);
+
+            return false;
         }
+
+        return true;
     }
 
     protected function sortGroups(Collection $groups): Collection

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -83,7 +83,7 @@ class PaymentReminderRun extends Component
             ->wherePaymentReminderDue()
             ->when(
                 $this->sentOrderIds,
-                fn (Builder $query, array $sentOrderIds) => $query->whereIntegerNotInRaw('id', $sentOrderIds)
+                fn (Builder $query, array $sentOrderIds) => $query->whereKeyNot($sentOrderIds)
             )
             ->when(
                 filled($this->filterLevel),

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -15,6 +15,7 @@ use FluxErp\Contracts\IsSubscribable;
 use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Contracts\Targetable;
 use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Enums\PaymentRunTypeEnum;
 use FluxErp\Events\Order\OrderApprovalRequestEvent;
 use FluxErp\Models\Pivots\AddressAddressTypeOrder;
 use FluxErp\Models\Pivots\OrderPaymentRun;
@@ -31,6 +32,7 @@ use FluxErp\States\Order\PaymentState\Open;
 use FluxErp\States\Order\PaymentState\Paid;
 use FluxErp\States\Order\PaymentState\PartialPaid;
 use FluxErp\States\Order\PaymentState\PaymentState;
+use FluxErp\States\PaymentRun\NotSuccessful;
 use FluxErp\Support\Calculation\Rounding;
 use FluxErp\Support\Collection\OrderCollection;
 use FluxErp\Traits\HasStates;
@@ -1461,6 +1463,17 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
             ->whereHas(
                 'orderType',
                 fn (Builder $query) => $query->whereIn('order_type_enum', $remindableOrderTypes)
+            )
+            // Direct debit invoices are collected by us, so they only become
+            // remindable once at least one debit run for them has failed.
+            ->where(fn (Builder $query) => $query
+                ->whereRelation('paymentType', 'is_direct_debit', false)
+                ->orWhereHas(
+                    'paymentRuns',
+                    fn (Builder $query) => $query
+                        ->where('payment_run_type_enum', PaymentRunTypeEnum::DirectDebit)
+                        ->where('state', NotSuccessful::$name)
+                )
             )
             ->whereHasMailablePaymentReminderAddress();
     }

--- a/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
+++ b/tests/Feature/Actions/PaymentReminder/BundlePaymentRemindersTest.php
@@ -26,7 +26,9 @@ beforeEach(function (): void {
     ]);
     $paymentType = PaymentType::factory()
         ->hasAttached($this->dbTenant, relationship: 'tenants')
-        ->create();
+        ->create([
+            'is_direct_debit' => false,
+        ]);
 
     $this->order = Order::factory()->create([
         'order_type_id' => $orderType->getKey(),

--- a/tests/Feature/Jobs/Accounting/SendPaymentReminderJobTest.php
+++ b/tests/Feature/Jobs/Accounting/SendPaymentReminderJobTest.php
@@ -26,7 +26,9 @@ beforeEach(function (): void {
     ]);
     $paymentType = PaymentType::factory()
         ->hasAttached($this->dbTenant, relationship: 'tenants')
-        ->create();
+        ->create([
+            'is_direct_debit' => false,
+        ]);
 
     $this->order = Order::factory()->create([
         'order_type_id' => $orderType->getKey(),

--- a/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
+++ b/tests/Feature/Jobs/AutoSendPaymentRemindersJobTest.php
@@ -62,7 +62,7 @@ test('sends payment reminders for overdue orders', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -98,7 +98,7 @@ test('does not send payment reminders when setting is disabled', function (): vo
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -123,7 +123,7 @@ test('does not send payment reminders for orders without invoice number', functi
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -148,7 +148,7 @@ test('does not send payment reminders for orders with zero balance', function ()
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -173,7 +173,7 @@ test('does not send payment reminders for paid orders', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -204,7 +204,7 @@ test('does not send payment reminders for overpaid orders', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -231,7 +231,7 @@ test('does not send payment reminders for not yet due orders', function (): void
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -263,7 +263,7 @@ test('does not send payment reminders for purchase orders', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($purchaseOrderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -288,7 +288,7 @@ test('does not send payment reminders for orders at maximum reminder level', fun
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -339,7 +339,7 @@ test('falls back to contact invoice address when order address has no email', fu
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -380,7 +380,7 @@ test('falls back to contact main address when no invoice addresses have email', 
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -427,7 +427,7 @@ test('does not send payment reminders when no address has email', function (): v
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -452,7 +452,7 @@ test('resolveMailableInvoiceAddress prefers order invoice address', function ():
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -497,7 +497,7 @@ test('resolveMailableInvoiceAddress falls back to contact invoice address', func
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -527,7 +527,7 @@ test('resolveMailableInvoiceAddress falls back to contact main address', functio
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -546,7 +546,7 @@ test('processes only specified order ids when provided', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),
@@ -567,7 +567,7 @@ test('processes only specified order ids when provided', function (): void {
         ->for(Currency::factory(), 'currency')
         ->for(Language::factory(), 'language')
         ->for(PriceList::factory(), 'priceList')
-        ->for(PaymentType::factory(), 'paymentType')
+        ->for(PaymentType::factory()->state(['is_direct_debit' => false]), 'paymentType')
         ->for($this->orderType, 'orderType')
         ->state([
             'tenant_id' => $this->dbTenant->getKey(),

--- a/tests/Feature/Models/Order/PaymentReminderDueScopeTest.php
+++ b/tests/Feature/Models/Order/PaymentReminderDueScopeTest.php
@@ -6,6 +6,7 @@ use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentRun;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 
@@ -24,7 +25,9 @@ beforeEach(function (): void {
     ]);
     $this->paymentType = PaymentType::factory()
         ->hasAttached($this->dbTenant, relationship: 'tenants')
-        ->create();
+        ->create([
+            'is_direct_debit' => false,
+        ]);
     $this->contact = $contact;
 
     $this->makeDueOrder = function (string $paymentState): Order {
@@ -87,4 +90,55 @@ test('open and partial paid orders remain in the dunning run', function (): void
 
     expect($dueIds)->toContain($open->getKey())
         ->and($dueIds)->toContain($partial->getKey());
+});
+
+test('direct debit orders are excluded until a debit has failed', function (): void {
+    $directDebitPaymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => true,
+        ]);
+
+    $order = ($this->makeDueOrder)('open');
+    $order->update(['payment_type_id' => $directDebitPaymentType->getKey()]);
+
+    expect(Order::query()->wherePaymentReminderDue()->whereKey($order->getKey())->exists())->toBeFalse();
+});
+
+test('direct debit orders with a failed debit run are included', function (): void {
+    $directDebitPaymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => true,
+        ]);
+
+    $order = ($this->makeDueOrder)('open');
+    $order->update(['payment_type_id' => $directDebitPaymentType->getKey()]);
+
+    $failedRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'direct_debit',
+        'state' => 'not_successful',
+    ]);
+    $order->paymentRuns()->attach($failedRun->getKey(), ['amount' => 100]);
+
+    expect(Order::query()->wherePaymentReminderDue()->whereKey($order->getKey())->exists())->toBeTrue();
+});
+
+test('direct debit orders with only successful debit runs stay excluded', function (): void {
+    $directDebitPaymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => true,
+        ]);
+
+    $order = ($this->makeDueOrder)('open');
+    $order->update(['payment_type_id' => $directDebitPaymentType->getKey()]);
+
+    $successfulRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'direct_debit',
+        'state' => 'successful',
+    ]);
+    $order->paymentRuns()->attach($successfulRun->getKey(), ['amount' => 100]);
+
+    expect(Order::query()->wherePaymentReminderDue()->whereKey($order->getKey())->exists())->toBeFalse();
 });

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -30,7 +30,9 @@ test('payment reminder run lists due orders and preselects them', function (): v
     ]);
     $paymentType = PaymentType::factory()
         ->hasAttached($this->dbTenant, relationship: 'tenants')
-        ->create();
+        ->create([
+            'is_direct_debit' => false,
+        ]);
 
     $order = Order::factory()->create([
         'order_type_id' => $orderType->getKey(),
@@ -61,4 +63,54 @@ test('payment reminder run lists due orders and preselects them', function (): v
         // A non-matching level filter yields no groups.
         ->set('filterLevel', '3')
         ->assertSet('groups', []);
+});
+
+test('sent orders disappear from the list without a manual reload', function (): void {
+    Illuminate\Support\Facades\Queue::fake();
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => false,
+        ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-201',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update([
+        'balance' => 250,
+        'payment_state' => 'open',
+        'payment_reminder_next_date' => now()->subDays(5)->toDateString(),
+    ]);
+
+    // The sends run as a queued batch; the database has not changed yet when the
+    // component reloads, so the sent orders must be hidden optimistically.
+    Livewire::actingAs($this->user)
+        ->test(PaymentReminderRun::class)
+        ->assertSet('groups', fn (array $groups) => count($groups) === 1)
+        ->call('sendSelected')
+        ->assertSet('groups', fn (array $groups) => $groups === [])
+        ->assertSet('selectedOrders', []);
 });


### PR DESCRIPTION
Two issues from first real use of the reworked payment reminder run (#1845).

## Direct debit invoices were dunned before the debit ever bounced

Direct debit invoices are collected by us — reminding the customer while the debit has not even been attempted (or succeeded) is wrong. `wherePaymentReminderEligible` now only admits direct debit orders that carry at least one **not successful** direct debit payment run; money transfer invoices are unaffected. Since the guard sits in the shared scope, the run list, `AutoSendPaymentRemindersJob` and the bundle validation all follow the same rule.

## Sent reminders stayed in the list until a manual reload

The sends run as a queued batch, so the reload directly after dispatch found the database unchanged and kept listing the sent orders — to the user it looked like nothing was sent. Dispatched order ids are now tracked on the component (`#[Locked]`) and hidden optimistically until the batch catches up; the selection is cleared with them. If a send fails, the batch toast reports it and a fresh page load shows the order again.

## Tests

* Scope: direct debit without failed run excluded, with `not_successful` run included, with only `successful` runs excluded
* Component: after `sendSelected` with a faked queue the group list is empty and the selection cleared, no manual reload
* `PaymentTypeFactory` randomizes `is_direct_debit` — all reminder fixtures pin it now

## Summary by Sourcery

Adjust payment reminder eligibility and UI behaviour to avoid dunning unbounced direct debit invoices and to hide sent reminders immediately.

New Features:
- Track dispatched payment reminder order IDs in the payment reminder run component to optimistically hide them from subsequent loads.

Bug Fixes:
- Exclude direct debit orders from payment reminders until at least one direct debit payment run has failed.
- Ensure orders removed by sending payment reminders disappear from the run list and selection without requiring a manual page reload.

Tests:
- Extend payment reminder due scope tests to cover direct debit orders with no runs, failed runs, and only successful runs.
- Add a Livewire test verifying that sending selected reminders clears the groups and selected orders without a manual reload.
- Pin payment type fixtures to non-direct-debit in reminder-related feature and job tests to avoid randomness affecting dunning behaviour.