### PR TITLE
fix(tests): drop a colliding seeded language before creating fr

### DIFF
--- a/tests/Feature/Actions/Language/LanguageActionTest.php
+++ b/tests/Feature/Actions/Language/LanguageActionTest.php
@@ -6,6 +6,10 @@ use FluxErp\Actions\Language\UpdateLanguage;
 use FluxErp\Models\Language;
 
 test('create language', function (): void {
+    // The per-process seeded default language draws a random faker code and
+    // occasionally lands on 'fr', which the unique rule then rejects.
+    Language::query()->where('language_code', 'fr')->forceDelete();
+
     $language = CreateLanguage::make([
         'name' => 'Französisch',
         'iso_name' => 'French',


### PR DESCRIPTION
Sibling of #1916, same collision family: the per-process seeded default language draws a random faker code and occasionally lands on `fr`, which `LanguageActionTest > create language` then trips over with "The Language Code has already been taken" (#1919 lost a run to it).

The test force-deletes any existing `fr` row inside its transaction before creating; the deletion rolls back with the test.

## Summary by Sourcery

Tests:
- Add a pre-test cleanup step that force-deletes any existing `fr` language record to avoid uniqueness collisions in the language creation test.