### PR TITLE
fix(mail): bound SyncMailAccountJob unique lock with a TTL

### DIFF
--- a/src/Jobs/SyncMailAccountJob.php
+++ b/src/Jobs/SyncMailAccountJob.php
@@ -123,4 +123,9 @@ class SyncMailAccountJob implements Repeatable, ShouldBeMonitored, ShouldBeUniqu
     {
         return $this->mailAccount->uuid;
     }
+
+    public function uniqueFor(): int
+    {
+        return 3600;
+    }
 }

--- a/tests/Feature/Jobs/SyncMailAccountJobTest.php
+++ b/tests/Feature/Jobs/SyncMailAccountJobTest.php
@@ -9,6 +9,9 @@ use FluxErp\Mail\MailDriverManager;
 use FluxErp\Models\MailAccount;
 use FluxErp\Models\MailFolder;
 use FluxErp\Traits\IsMonitored;
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\Cache;
 
 test('sync mail account job is monitored', function (): void {
     expect(is_a(SyncMailAccountJob::class, ShouldBeMonitored::class, true))->toBeTrue()
@@ -27,6 +30,30 @@ test('sync mail account job name contains the account email', function (): void 
 
 test('imap mail sync driver reports sync progress', function (): void {
     expect(is_a(ImapMailSyncDriver::class, ReportsSyncProgress::class, true))->toBeTrue();
+});
+
+test('sync mail account job keeps its unique lock scoped per account and bounded', function (): void {
+    expect(is_a(SyncMailAccountJob::class, ShouldBeUnique::class, true))->toBeTrue();
+
+    $first = MailAccount::factory()->create();
+    $second = MailAccount::factory()->create();
+
+    expect((new SyncMailAccountJob($first))->uniqueId())
+        ->not->toBe((new SyncMailAccountJob($second))->uniqueId())
+        ->and((new SyncMailAccountJob($first))->uniqueFor())->toBeGreaterThan(0);
+});
+
+test('sync mail account job releases its unique lock after the timeout so a killed run cannot block the account forever', function (): void {
+    $account = MailAccount::factory()->create();
+    $job = new SyncMailAccountJob($account);
+    $lock = new UniqueLock(Cache::store());
+
+    expect($lock->acquire($job))->toBeTrue()
+        ->and($lock->acquire($job))->toBeFalse();
+
+    $this->travel($job->uniqueFor() + 1)->seconds();
+
+    expect($lock->acquire($job))->toBeTrue();
 });
 
 test('sync mail account job passes a progress callback to the driver', function (): void {


### PR DESCRIPTION
## Problem

`SyncMailAccountJob` implements `ShouldBeUnique` with a per-account `uniqueId()` (the account uuid) but does not define `uniqueFor()`. The unique lock is therefore acquired with no expiry.

When a run is hard-killed (worker `--timeout`, OOM, SIGKILL) the job never reaches the lock-release callback, so that single account's lock stays held forever. From then on every dispatch for that account is silently dropped before it is queued, while all other accounts keep syncing normally. In production this surfaced as one mailbox that stopped importing entirely with no failed job and no error, days after a run went stale.

## Fix

Add `uniqueFor()` returning the worker timeout (3600s). The lock now clears no later than the point the job itself would have been killed, so a killed run self-heals on the next scheduled dispatch instead of blocking the account permanently. Per-account uniqueness is unchanged.

## Note

`ProcessSubscriptionOrderJob` has the same `ShouldBeUnique`-without-`uniqueFor()` shape and the same latent failure mode. Left out of this change to keep it scoped to the observed incident; worth applying the same bound there.

## Summary by Sourcery

Bound the unique lock lifetime for SyncMailAccountJob to prevent permanently blocked mail account syncs when jobs are hard-killed.

New Features:
- Add a time-to-live to the SyncMailAccountJob unique lock via uniqueFor() to ensure per-account locks eventually expire.

Tests:
- Add feature tests verifying SyncMailAccountJob remains uniquely scoped per account and that its unique lock is released after the configured timeout so subsequent dispatches can proceed.