### PR TITLE
feat(widgets): payment reminders jump from the outstanding widget

### DIFF
--- a/src/Livewire/Widgets/Outstanding.php
+++ b/src/Livewire/Widgets/Outstanding.php
@@ -76,6 +76,10 @@ class Outstanding extends ValueBox implements HasWidgetOptions
                 'label' => __('Show overdue'),
                 'method' => 'showOverdue',
             ],
+            [
+                'label' => __('Payment Reminders'),
+                'method' => 'showPaymentReminders',
+            ],
         ];
     }
 
@@ -103,6 +107,12 @@ class Outstanding extends ValueBox implements HasWidgetOptions
             ->store();
 
         $this->redirectRoute('orders.orders', navigate: true);
+    }
+
+    #[Renderless]
+    public function showPaymentReminders(): void
+    {
+        $this->redirectRoute('accounting.payment-reminder-run', navigate: true);
     }
 
     protected function getListeners(): array

--- a/tests/Livewire/Widgets/OutstandingTest.php
+++ b/tests/Livewire/Widgets/OutstandingTest.php
@@ -185,6 +185,14 @@ test('redirect to over due', function (): void {
         ->assertOk();
 });
 
+test('redirect to payment reminders', function (): void {
+    Livewire::test(Outstanding::class)
+        ->call('showPaymentReminders')
+        ->assertRedirect(route('accounting.payment-reminder-run'))
+        ->assertHasNoErrors()
+        ->assertOk();
+});
+
 test('renders successfully', function (): void {
     createData(collect(), $this->dbTenant, $this->currency);
 


### PR DESCRIPTION
## What

The dunning screen was rebuilt into `PaymentReminderRun` (route `accounting.payment-reminder-run`). The outstanding widget had no way to jump there.

## Changes

- Add a **Payment Reminders** entry to the outstanding widget option menu that navigates to the payment reminder run.

## Tests

- New: widget redirects to `accounting.payment-reminder-run`.

## Summary by Sourcery

Add navigation from the outstanding widget to the payment reminder run screen.

New Features:
- Add a Payment Reminders option to the outstanding widget menu that routes to the payment reminder run screen.

Tests:
- Add a Livewire widget test covering redirection to the payment reminder run route from the outstanding widget.