### PR TITLE
fix(comments): restore confirm dialog before deleting a comment

### DIFF
--- a/resources/views/components/features/comments/comment.blade.php
+++ b/resources/views/components/features/comments/comment.blade.php
@@ -43,11 +43,9 @@
                         <x-dropdown.items>
                             <span
                                 x-bind:disabled="!comment.is_current_user"
-                                x-on:click="
-                                    $wire.delete(comment.id).then((success) => {
-                                        if (success) removeNode(comment);
-                                    })
-                                "
+                                wire:click="delete(comment.id).then((success) => {
+                                    if (success) removeNode(comment);
+                                })"
                                 wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Comment')]) }}"
                             >
                                 {{ __('Delete') }}


### PR DESCRIPTION
## Problem

Deleting a comment skipped the confirmation dialog and removed the comment on the first click. The delete control ran its action through `x-on:click`, but the `wire:flux-confirm` directive only intercepts `wire:click` (it reads the `wire:click` attribute and re-evaluates it through Alpine once the user confirms). With the action on `x-on:click`, the directive never fired, so the comment was deleted immediately with no prompt.

## Fix

Move the delete expression to `wire:click`, matching the established pattern (e.g. the tag prompt in `product/general.blade.php`). The `flux-confirm` directive now intercepts it, shows the error-style confirmation, and evaluates the expression through Alpine on confirm — so the promise-based node removal (`.then(removeNode)`) keeps working.

## Summary by Sourcery

Bug Fixes:
- Ensure comment deletions trigger the flux confirmation dialog instead of deleting immediately on first click.