### PR TITLE
Keep media folders created below a collection in place

### DIFF
--- a/database/migrations/2026_07_27_000001_add_collection_name_to_media_folders_table.php
+++ b/database/migrations/2026_07_27_000001_add_collection_name_to_media_folders_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('media_folders', function (Blueprint $table): void {
+            $table->string('collection_name')
+                ->nullable()
+                ->after('parent_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('media_folders', function (Blueprint $table): void {
+            $table->dropColumn('collection_name');
+        });
+    }
+};

--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -209,6 +209,7 @@
                                             $wire
                                                 .saveFolder({
                                                     parent_id: selection.id,
+                                                    collection_name: getNodePath(selectionProxy, 'slug'),
                                                     name: '{{ __('New folder') }}',
                                                     is_new: true,
                                                     children: [],

--- a/src/Livewire/Forms/MediaFolderForm.php
+++ b/src/Livewire/Forms/MediaFolderForm.php
@@ -13,6 +13,8 @@ class MediaFolderForm extends FluxForm
 
     public ?int $parent_id = null;
 
+    public ?string $collection_name = null;
+
     public ?string $name = null;
 
     public ?int $max_files = null;

--- a/src/Livewire/Support/FolderTree.php
+++ b/src/Livewire/Support/FolderTree.php
@@ -239,11 +239,12 @@ abstract class FolderTree extends Component
     public function saveFolder(array $attributes): false|array
     {
         $isNew = data_get($attributes, 'is_new', false);
-        $hasStringParent = is_string(data_get($attributes, 'parent_id'));
+        $parentId = data_get($attributes, 'parent_id');
+        $hasStringParent = is_string($parentId);
         $hasStringId = is_string(data_get($attributes, 'id'));
 
         // Handle virtual folder updates (renaming collections)
-        if (($hasStringParent || $hasStringId) && ! $isNew) {
+        if ($hasStringId && ! $isNew) {
             $attributes['slug'] = Str::of(data_get($attributes, 'name') ?? '')
                 ->lower()
                 ->replace('.', '')
@@ -268,7 +269,8 @@ abstract class FolderTree extends Component
             return $attributes;
         }
 
-        if ($isNew && $hasStringParent) {
+        // a collection is not a record, the folder is positioned by its path instead
+        if ($hasStringParent) {
             $attributes['parent_id'] = null;
         }
 
@@ -276,9 +278,6 @@ abstract class FolderTree extends Component
         if ($hasStringId) {
             unset($attributes['id']);
         }
-
-        $this->folder->reset();
-        $this->folder->fill($attributes);
 
         try {
             $this->folder->reset();
@@ -293,13 +292,14 @@ abstract class FolderTree extends Component
             return false;
         }
 
-        return array_merge(
-            ['children' => []],
+        $folder = array_merge(
+            ['children' => data_get($attributes, 'children') ?? []],
             array_intersect_key(
                 $this->folder->getActionResult()->toArray(),
                 array_flip([
                     'id',
                     'parent_id',
+                    'collection_name',
                     'name',
                     'slug',
                     'is_readonly',
@@ -308,6 +308,12 @@ abstract class FolderTree extends Component
                 ])
             )
         );
+
+        if ($hasStringParent) {
+            $folder['parent_id'] = $parentId;
+        }
+
+        return $folder;
     }
 
     protected function resolveSubjectPath(array $subject, ?string $subjectPath): ?string

--- a/src/Models/MediaFolder.php
+++ b/src/Models/MediaFolder.php
@@ -17,6 +17,12 @@ class MediaFolder extends FluxModel implements HasMedia
 
     protected static function booted(): void
     {
+        static::saving(function (MediaFolder $model): void {
+            if ($model->parent_id) {
+                $model->collection_name = null;
+            }
+        });
+
         static::creating(function (MediaFolder $model): void {
             $model->slug ??= Str::of($model->name)
                 ->replace('.', '_')
@@ -25,32 +31,14 @@ class MediaFolder extends FluxModel implements HasMedia
         });
 
         static::created(function (MediaFolder $model): void {
-            $model->slug = implode('.',
-                array_filter([
-                    $model->parent?->slug,
-                    Str::of($model->name)
-                        ->replace('.', '_')
-                        ->snake()
-                        ->append('|' . $model->getKey())
-                        ->toString(),
-                ])
-            );
+            $model->slug = $model->buildSlug();
 
             $model->saveQuietly();
         });
 
         static::updating(function (MediaFolder $model): void {
-            if ($model->isDirty(['parent_id', 'name'])) {
-                $model->slug = implode('.',
-                    array_filter([
-                        $model->parent?->slug,
-                        Str::of($model->name)
-                            ->replace('.', '_')
-                            ->snake()
-                            ->append('|' . $model->getKey())
-                            ->toString(),
-                    ])
-                );
+            if ($model->isDirty(['parent_id', 'collection_name', 'name'])) {
+                $model->slug = $model->buildSlug();
             }
         });
 
@@ -79,5 +67,19 @@ class MediaFolder extends FluxModel implements HasMedia
             'mime_types' => 'array',
             'is_readonly' => 'boolean',
         ];
+    }
+
+    public function buildSlug(): string
+    {
+        return implode('.',
+            array_filter([
+                $this->parent?->slug ?? $this->collection_name,
+                Str::of($this->name)
+                    ->replace('.', '_')
+                    ->snake()
+                    ->append('|' . $this->getKey())
+                    ->toString(),
+            ])
+        );
     }
 }

--- a/src/Rulesets/MediaFolder/CreateMediaFolderRuleset.php
+++ b/src/Rulesets/MediaFolder/CreateMediaFolderRuleset.php
@@ -22,6 +22,7 @@ class CreateMediaFolderRuleset extends FluxRuleset
                 'integer',
                 app(ModelExists::class, ['model' => MediaFolder::class]),
             ],
+            'collection_name' => 'nullable|string|max:255',
             'name' => 'required|string|max:255',
             'max_files' => 'nullable|integer|min:0',
             'mime_types' => 'nullable|array',

--- a/src/Traits/Model/InteractsWithMedia.php
+++ b/src/Traits/Model/InteractsWithMedia.php
@@ -82,37 +82,44 @@ trait InteractsWithMedia
         foreach ($mediaCollections as $mediaCollection) {
             $slug = data_get($mediaCollection, 'slug') ?? '';
 
-            if (
-                is_null(data_get($mediaCollection, 'id'))
-                && str_contains($slug, '.')
-            ) {
-                $cursor = &$undotted;
-                $childSlug = '';
+            if (! str_contains($slug, '.')) {
+                Arr::set($undotted, $slug, $mediaCollection);
 
-                foreach (explode('.', $slug) as $part) {
-                    $childSlug = $childSlug === '' ? $part : $childSlug . '.' . $part;
+                continue;
+            }
 
-                    if (! array_key_exists($part, $cursor) || ! is_array($cursor[$part])) {
-                        $cursor[$part] = [
-                            'name' => Str::headline($part),
-                            'slug' => $childSlug,
-                        ];
-                    }
+            $parts = explode('.', $slug);
+            $lastIndex = count($parts) - 1;
+            $cursor = &$undotted;
+            $childSlug = '';
 
-                    if (
-                        ! array_key_exists('children', $cursor[$part])
-                        || ! is_array($cursor[$part]['children'])
-                    ) {
-                        $cursor[$part]['children'] = [];
-                    }
+            foreach ($parts as $index => $part) {
+                $childSlug = $childSlug === '' ? $part : $childSlug . '.' . $part;
 
-                    $cursor = &$cursor[$part]['children'];
+                if ($index === $lastIndex && ! is_null(data_get($mediaCollection, 'id'))) {
+                    $cursor[$part] = $mediaCollection;
+
+                    break;
                 }
 
-                unset($cursor);
-            } else {
-                Arr::set($undotted, $slug, $mediaCollection);
+                if (! array_key_exists($part, $cursor) || ! is_array($cursor[$part])) {
+                    $cursor[$part] = [
+                        'name' => Str::headline($part),
+                        'slug' => $childSlug,
+                    ];
+                }
+
+                if (
+                    ! array_key_exists('children', $cursor[$part])
+                    || ! is_array($cursor[$part]['children'])
+                ) {
+                    $cursor[$part]['children'] = [];
+                }
+
+                $cursor = &$cursor[$part]['children'];
             }
+
+            unset($cursor);
         }
 
         return $this->calculateTree($undotted);

--- a/tests/Livewire/FolderTreeTest.php
+++ b/tests/Livewire/FolderTreeTest.php
@@ -14,8 +14,62 @@ use Livewire\Livewire;
 beforeEach(function (): void {
     $this->contact = Contact::factory()->create();
 
-    $permission = Permission::findOrCreate('action.media-folder.update', 'web');
-    $this->user->givePermissionTo($permission);
+    $this->user->givePermissionTo([
+        Permission::findOrCreate('action.media-folder.create', 'web'),
+        Permission::findOrCreate('action.media-folder.update', 'web'),
+    ]);
+});
+
+test('can create a folder below a collection', function (): void {
+    Storage::fake('local');
+
+    $this->contact
+        ->addMedia(UploadedFile::fake()->image('test.jpg'))
+        ->toMediaCollection('attachments');
+
+    Livewire::test(FolderTreeTestClass::class, ['modelId' => $this->contact->getKey()])
+        ->call('saveFolder', [
+            'parent_id' => Str::uuid()->toString(),
+            'collection_name' => 'attachments',
+            'name' => 'New folder',
+            'is_new' => true,
+            'children' => [],
+        ]);
+
+    $folder = MediaFolder::query()
+        ->where('name', 'New folder')
+        ->firstOrFail();
+
+    expect($folder->collection_name)->toBe('attachments')
+        ->and($folder->slug)->toBe('attachments.new_folder|' . $folder->getKey());
+
+    $collectionNode = collect($this->contact->refresh()->getMediaAsTree())
+        ->firstWhere('slug', 'attachments');
+
+    expect(data_get($collectionNode, 'children.*.id'))->toContain($folder->getKey());
+});
+
+test('can rename a folder below a collection', function (): void {
+    $folder = MediaFolder::create([
+        'name' => 'New folder',
+        'collection_name' => 'attachments',
+        'model_type' => morph_alias(Contact::class),
+        'model_id' => $this->contact->getKey(),
+    ]);
+    $this->contact->mediaFolders()->attach($folder->getKey());
+
+    Livewire::test(FolderTreeTestClass::class, ['modelId' => $this->contact->getKey()])
+        ->call('saveFolder', [
+            'id' => $folder->getKey(),
+            'parent_id' => Str::uuid()->toString(),
+            'name' => 'Renamed folder',
+            'slug' => $folder->slug,
+            'children' => [],
+        ]);
+
+    expect($folder->refresh()->name)->toBe('Renamed folder')
+        ->and($folder->collection_name)->toBe('attachments')
+        ->and($folder->slug)->toBe('attachments.renamed_folder|' . $folder->getKey());
 });
 
 test('renders successfully', function (): void {


### PR DESCRIPTION
## Problem

Creating a subfolder below a collection node in the attachments tree looked like it worked, but the folder was gone from that position after a reload: it showed up at the root of the tree, still named "New folder".

Two causes, both in `FolderTree::saveFolder()`:

- A collection node is derived from media paths, not a record. Its uuid cannot be used as `parent_id`, so the parent was simply dropped and the folder was stored at the root.
- The rename branch for collections was entered whenever the **parent** id was a string. A real folder below a collection has a string parent, so renaming it only rewrote media collection names and never saved the folder.

## Change

- `media_folders.collection_name` (nullable) stores the collection path a folder was created in. It is cleared as soon as the folder has a parent folder, which then defines its position.
- The folder slug is built from that collection path when there is no parent folder, so the whole subtree keeps a consistent path.
- `getMediaAsTree()` places folders with a dotted slug below that path instead of at the root.
- The collection rename branch is keyed on the node itself being a collection.
- `saveFolder()` returns the collection node as the parent again, so the client side tree keeps the folder where the user created it, and no longer drops the children of a renamed folder.

## Tests

`tests/Livewire/FolderTreeTest.php` covers creating and renaming a folder below a collection. Both fail without the change.

## Summary by Sourcery

Keep media folders created under collection nodes anchored to their collection path and correctly represented in the media tree.

New Features:
- Preserve collection context for media folders via a new nullable collection_name field on media_folders and use it to build stable folder slugs and positions in the tree.

Bug Fixes:
- Ensure new folders created under a collection node remain under that collection instead of moving to the root after reloads.
- Fix renaming of folders under collection nodes so their names and slugs update correctly without losing their position.
- Render real media folders under virtual collection nodes in the media tree based on dotted slugs rather than treating them as root nodes.

Enhancements:
- Refine media tree construction to distinguish between virtual collection nodes and persisted folder nodes when resolving dotted slugs.
- Centralize media folder slug generation logic via a reusable buildSlug method on MediaFolder.

Build:
- Add database migration to introduce the collection_name column to the media_folders table and wire it through validation and forms.

Tests:
- Add Livewire tests covering creating and renaming media folders under a collection node and extend test permissions to include folder creation.