### PR TITLE
feat(accounting): search the payment reminder run by contact name

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1726,6 +1726,7 @@
     "my-profile.get": "Mein Profil anzeigen",
     "Name": "Name",
     "name": "Name",
+    "Name, invoice or customer number": "Name, Rechnungsnummer oder Kundennummer",
     "Nationality": "Nationalität",
     "Navigation styling": "Navigationsleiste",
     "Nearest": "Nächster",

--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -22,7 +22,7 @@
             <div class="min-w-48 flex-1">
                 <x-input
                     wire:model.live.debounce.300ms="search"
-                    :placeholder="__('Invoice or customer number')"
+                    :placeholder="__('Name, invoice or customer number')"
                     icon="magnifying-glass"
                     size="sm"
                 />

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -110,6 +110,14 @@ class PaymentReminderRun extends Component
                             fn (Builder $query) => $query
                                 ->where('customer_number', 'like', '%' . $this->search . '%')
                         )
+                        ->orWhereHas(
+                            'contact.addresses',
+                            fn (Builder $query) => $query
+                                ->where('company', 'like', '%' . $this->search . '%')
+                                ->orWhere('name', 'like', '%' . $this->search . '%')
+                                ->orWhere('firstname', 'like', '%' . $this->search . '%')
+                                ->orWhere('lastname', 'like', '%' . $this->search . '%')
+                        )
                 )
             )
             ->with(['contact:id,customer_number'])

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -65,6 +65,52 @@ test('payment reminder run lists due orders and preselects them', function (): v
         ->assertSet('groups', []);
 });
 
+test('searches due orders by the contact name', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+        'company' => 'Wunderlich Verlag GmbH',
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => false,
+        ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-201',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update([
+        'balance' => 250,
+        'payment_state' => 'open',
+        'payment_reminder_next_date' => now()->subDays(5)->toDateString(),
+    ]);
+
+    Livewire::test(PaymentReminderRun::class)
+        ->set('search', 'Wunderlich')
+        ->assertSet('groups', fn (array $groups) => count($groups) === 1)
+        ->set('search', 'no such company')
+        ->assertSet('groups', []);
+});
+
 test('sent orders disappear from the list without a manual reload', function (): void {
     Illuminate\Support\Facades\Queue::fake();
 


### PR DESCRIPTION
The dunning (Mahnlauf) search field only matched invoice number and customer number, so searching by a company/person name returned nothing.

## Changes

- Extend the search to also match the contact's address fields (`company`, `name`, `firstname`, `lastname`).
- Update the search placeholder to "Name, invoice or customer number".

## Tests

- New: searching a due order by its contact name returns the group; a non-matching term returns none.

## Summary by Sourcery

Extend payment reminder run search to support contact name fields alongside existing invoice and customer number matching.

New Features:
- Allow searching payment reminder runs by contact address fields (company, name, firstname, lastname).

Tests:
- Add a Livewire test verifying that searching by a contact name returns the expected due order group and that non-matching terms yield no results.