### PR TITLE
fix(product): stop duplicating variant options on group select

### DIFF
--- a/src/Livewire/Product/VariantList.php
+++ b/src/Livewire/Product/VariantList.php
@@ -107,6 +107,7 @@ class VariantList extends ProductList
         ];
     }
 
+    #[Renderless]
     public function loadOptions(ProductOptionGroup $optionGroup): void
     {
         $this->productOptions = $optionGroup


### PR DESCRIPTION
## Problem

In the product variant editor (**Edit Variants** modal), picking an option group rendered its options **twice** on the right.

## Cause

`loadOptions` was a normal (rendering) action. Selecting a group triggered a full component re-render, and morphing the modal HTML while the Alpine `x-for` over `$wire.productOptions` had already rendered the option nodes duplicated them. The `productOptions` array itself is replaced (not appended), so it was purely a DOM-morph duplication.

## Fix

Mark `loadOptions` `#[Renderless]`. The property still syncs to the frontend, so the Alpine `x-for` re-renders the list once with no server-side morph.

## Tests

Existing VariantList tests stay green (loadOptions still populates `productOptions`).

## Summary by Sourcery

Bug Fixes:
- Prevent duplication of product option entries in the variant editor when selecting an option group by making the loadOptions action renderless.