### PR TITLE
Fix REST embedder response template for batched semantic search

### DIFF
--- a/src/Traits/Scout/Searchable.php
+++ b/src/Traits/Scout/Searchable.php
@@ -82,8 +82,11 @@ trait Searchable
                 'model' => $search->embedder_model,
                 'input' => ['{{text}}', '{{..}}'],
             ],
+            // The '{{..}}' repetition marker must appear in both request and response
+            // when batching; without it Meilisearch rejects the embedder with
+            // "response has a single embedding, but request has multiple texts to embed".
             'response' => [
-                'data' => [['embedding' => '{{embedding}}']],
+                'data' => [['embedding' => '{{embedding}}'], '{{..}}'],
             ],
         ];
     }

--- a/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
+++ b/tests/Unit/Traits/ScoutSearchableEmbedderTest.php
@@ -26,6 +26,27 @@ test('provides meilisearch embedders when semantic search enabled', function ():
     expect(data_get($embedder, 'request.model'))->toBe('text-embedding-3-small');
 });
 
+test('mirrors the batch repetition marker in request and response', function (): void {
+    config(['scout.driver' => 'meilisearch']);
+
+    SearchSettings::fake([
+        'semantic_search_enabled' => true,
+        'embedder_url' => 'https://litellm.test/v1/embeddings',
+        'embedder_api_key' => 'sk-test',
+        'embedder_model' => 'text-embedding-3-small',
+        'embedder_dimensions' => 1536,
+        'semantic_ratio' => 0.5,
+    ]);
+
+    $embedder = data_get(Country::scoutEmbedders(), 'default');
+
+    // Meilisearch requires the '{{..}}' marker in both request and response when
+    // batching; a request-only marker is rejected with "response has a single
+    // embedding, but request has multiple texts to embed".
+    expect(data_get($embedder, 'request.input'))->toBe(['{{text}}', '{{..}}'])
+        ->and(data_get($embedder, 'response.data'))->toBe([['embedding' => '{{embedding}}'], '{{..}}']);
+});
+
 test('provides no embedders when semantic search disabled', function (): void {
     config(['scout.driver' => 'meilisearch']);
 


### PR DESCRIPTION
## Problem

Enabling semantic search builds a Meilisearch REST embedder whose request batches multiple texts (`input: ["{{text}}", "{{..}}"]`) but whose response template describes only a single embedding (`data: [{embedding: "{{embedding}}"}]`).

Meilisearch requires the `{{..}}` repetition marker in **both** request and response when batching. Without it, applying the embedder fails with:

> Error while generating embeddings: user error: in `response`: `response` has a single embedding, but request has multiple texts to embed

So the embedder is never applied — the index keeps `embedders: {}` and semantic search is silently disabled, even though `SearchSettings::save()` correctly queues `flux-scout:sync-index-settings`.

## Fix

Add the `{{..}}` marker to the response template so request and response are consistent and Meilisearch accepts the definition:

```php
'response' => ['data' => [['embedding' => '{{embedding}}'], '{{..}}']],
```

Verified against the Meilisearch REST embedder docs ("When using `{{..}}`, it must be present in both the request and response configurations").

## Test

Adds a unit assertion pinning the batch-marker parity between request and response, so a request-only marker regresses the suite.

## Summary by Sourcery

Align the Meilisearch REST embedder definition with batched semantic search requirements by mirroring the batch repetition marker between request and response and covering it with a unit test.

Bug Fixes:
- Ensure Meilisearch REST embedder response template correctly mirrors the batch repetition marker used in the request so batched semantic search embeddings are accepted.

Tests:
- Add a unit test asserting that the Meilisearch REST embedder repeats the batch marker consistently in both request and response templates.