### PR TITLE
fix(addresses): drop the roles of a deleted address

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -280,16 +280,7 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
 
                 $mainAddress->update($addressUpdates);
 
-                // A role belongs to exactly one address, and the address that
-                // just handed it over has to give up its own claim on it.
-                // Keeping the flag left the role on two rows as soon as the
-                // deleted address was restored, and neither of them could be
-                // switched over any more, because a role is taken by turning it
-                // on somewhere else and both were already on.
-                resolve_static(Address::class, 'query')
-                    ->withTrashed()
-                    ->whereKey($address->getKey())
-                    ->update(array_fill_keys(array_keys($addressUpdates), false));
+                $address->updateQuietly(array_fill_keys(array_keys($addressUpdates), false));
             }
         });
     }

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -279,6 +279,17 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                     ->update($contactUpdates);
 
                 $mainAddress->update($addressUpdates);
+
+                // A role belongs to exactly one address, and the address that
+                // just handed it over has to give up its own claim on it.
+                // Keeping the flag left the role on two rows as soon as the
+                // deleted address was restored, and neither of them could be
+                // switched over any more, because a role is taken by turning it
+                // on somewhere else and both were already on.
+                resolve_static(Address::class, 'query')
+                    ->withTrashed()
+                    ->whereKey($address->getKey())
+                    ->update(array_fill_keys(array_keys($addressUpdates), false));
             }
         });
     }

--- a/tests/Feature/Models/AddressRolesTest.php
+++ b/tests/Feature/Models/AddressRolesTest.php
@@ -3,11 +3,6 @@
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
 
-// The roles of a contact are single assignment: an address does not give one up
-// by being switched off, it loses it when another address takes it over. A
-// deleted address hands its roles to the one that survives it, but it used to
-// keep claiming them on its own row, so restoring it left the contact with two
-// main addresses and no way back, because both toggles lock once they are on.
 test('a deleted address gives up the roles it hands over', function (): void {
     $contact = Contact::factory()->create();
     $main = Address::factory()->create([

--- a/tests/Feature/Models/AddressRolesTest.php
+++ b/tests/Feature/Models/AddressRolesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+
+// The roles of a contact are single assignment: an address does not give one up
+// by being switched off, it loses it when another address takes it over. A
+// deleted address hands its roles to the one that survives it, but it used to
+// keep claiming them on its own row, so restoring it left the contact with two
+// main addresses and no way back, because both toggles lock once they are on.
+test('a deleted address gives up the roles it hands over', function (): void {
+    $contact = Contact::factory()->create();
+    $main = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'is_delivery_address' => true,
+        'is_invoice_address' => false,
+    ]);
+    $second = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+        'is_delivery_address' => false,
+        'is_invoice_address' => true,
+    ]);
+
+    $main->delete();
+
+    expect(Address::withTrashed()->whereKey($main->getKey())->first())
+        ->is_main_address->toBeFalse()
+        ->is_delivery_address->toBeFalse()
+        ->and(Address::query()->whereKey($second->getKey())->first())
+        ->is_main_address->toBeTrue()
+        ->and($contact->fresh()->main_address_id)->toBe($second->getKey());
+});
+
+test('restoring a deleted address leaves the contact with a single main address', function (): void {
+    $contact = Contact::factory()->create();
+    $main = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'is_delivery_address' => true,
+        'is_invoice_address' => false,
+    ]);
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+        'is_delivery_address' => false,
+        'is_invoice_address' => true,
+    ]);
+
+    $main->delete();
+    Address::onlyTrashed()->whereKey($main->getKey())->first()->restore();
+
+    expect(Address::query()->where('contact_id', $contact->getKey())->where('is_main_address', true)->count())
+        ->toBe(1);
+});
+
+test('restoring a contact leaves it with a single main address', function (): void {
+    $contact = Contact::factory()->create();
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'is_delivery_address' => true,
+        'is_invoice_address' => false,
+    ]);
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+        'is_delivery_address' => false,
+        'is_invoice_address' => true,
+    ]);
+
+    $contact->delete();
+    Contact::onlyTrashed()->whereKey($contact->getKey())->first()->restore();
+
+    expect(Address::query()->where('contact_id', $contact->getKey())->where('is_main_address', true)->count())
+        ->toBe(1)
+        ->and(Address::query()->where('contact_id', $contact->getKey())->where('is_delivery_address', true)->count())
+        ->toBe(1);
+});


### PR DESCRIPTION
## Problem

A role of a contact (main, delivery, invoice) sits on exactly one address. An address never gives a role up by being switched off, the role moves when another address takes it over, which is why each role toggle is disabled once it is on.

`Address::deleted` already hands the roles of a deleted address to the address that survives it, and repoints the contact. The deleted row kept its own flags though. Restoring that address left the contact with two rows claiming the same role, and neither could be corrected afterwards: taking a role means turning it on somewhere else, and both were already on.

Deleting a whole contact hits the same path, because `CascadeSoftDeletes` deletes its addresses one by one through this hook. Restoring the contact then showed two main addresses, while the contact pointed at the one that had been promoted last.

## Change

The deleted address now gives up exactly the roles it handed over, so a restore always yields a single holder per role, and switching a role back works the normal way.

## Tests

`tests/Feature/Models/AddressRolesTest.php` covers the handover itself, restoring a single address, and restoring a whole contact. All three fail without the change. The Address and Contact tests of the Feature and Livewire suites pass.

## Summary by Sourcery

Ensure address roles are uniquely reassigned when an address or contact is soft-deleted and later restored.

Bug Fixes:
- Clear role flags on a deleted address after its roles are handed over so that no two addresses claim the same role after restore.

Tests:
- Add feature tests verifying role handover on address deletion and ensuring only a single main/delivery address exists after restoring an address or an entire contact.