### PR TITLE
Let ledger bookings settle the order they point at

### DIFF
--- a/src/Models/LedgerBooking.php
+++ b/src/Models/LedgerBooking.php
@@ -11,10 +11,23 @@ use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 
 class LedgerBooking extends FluxModel
 {
     use Filterable, HasPackageFactory, HasTenantAssignment, HasUserModification, HasUuid, SoftDeletes;
+
+    protected static function booted(): void
+    {
+        $recalculateSettledOrders = function (LedgerBooking $ledgerBooking): void {
+            $ledgerBooking->settledOrders()->each(
+                fn (Order $order) => $order->calculatePaymentState()->save()
+            );
+        };
+
+        static::saved($recalculateSettledOrders);
+        static::deleted($recalculateSettledOrders);
+    }
 
     protected function casts(): array
     {
@@ -38,5 +51,21 @@ class LedgerBooking extends FluxModel
     public function source(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    /**
+     * The orders whose payment state depends on this booking: the one it points at
+     * now and, when the source was moved, the one it pointed at before.
+     */
+    public function settledOrders(): Collection
+    {
+        return collect([
+            [$this->getOriginal('source_type'), $this->getOriginal('source_id')],
+            [$this->source_type, $this->source_id],
+        ])
+            ->filter(fn (array $source) => $source[1] && is_a(morphed_model($source[0]) ?? '', Order::class, true))
+            ->unique(fn (array $source) => $source[1])
+            ->map(fn (array $source) => resolve_static(Order::class, 'query')->whereKey($source[1])->first())
+            ->filter();
     }
 }

--- a/src/Models/LedgerBooking.php
+++ b/src/Models/LedgerBooking.php
@@ -11,7 +11,6 @@ use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Collection;
 
 class LedgerBooking extends FluxModel
 {
@@ -19,14 +18,33 @@ class LedgerBooking extends FluxModel
 
     protected static function booted(): void
     {
-        $recalculateSettledOrders = function (LedgerBooking $ledgerBooking): void {
-            $ledgerBooking->settledOrders()->each(
-                fn (Order $order) => $order->calculatePaymentState()->save()
-            );
-        };
+        static::saved(function (LedgerBooking $ledgerBooking): void {
+            if ($ledgerBooking->wasChanged(['source_type', 'source_id'])) {
+                static::recalculateSettledOrder(
+                    $ledgerBooking->getOriginal('source_type'),
+                    $ledgerBooking->getOriginal('source_id')
+                );
+            }
 
-        static::saved($recalculateSettledOrders);
-        static::deleted($recalculateSettledOrders);
+            static::recalculateSettledOrder($ledgerBooking->source_type, $ledgerBooking->source_id);
+        });
+
+        static::deleted(function (LedgerBooking $ledgerBooking): void {
+            static::recalculateSettledOrder($ledgerBooking->source_type, $ledgerBooking->source_id);
+        });
+    }
+
+    protected static function recalculateSettledOrder(?string $sourceType, int|string|null $sourceId): void
+    {
+        if (! $sourceId || $sourceType !== morph_alias(Order::class)) {
+            return;
+        }
+
+        resolve_static(Order::class, 'query')
+            ->whereKey($sourceId)
+            ->first()
+            ?->calculatePaymentState()
+            ->save();
     }
 
     protected function casts(): array
@@ -51,21 +69,5 @@ class LedgerBooking extends FluxModel
     public function source(): MorphTo
     {
         return $this->morphTo();
-    }
-
-    /**
-     * The orders whose payment state depends on this booking: the one it points at
-     * now and, when the source was moved, the one it pointed at before.
-     */
-    public function settledOrders(): Collection
-    {
-        return collect([
-            [$this->getOriginal('source_type'), $this->getOriginal('source_id')],
-            [$this->source_type, $this->source_id],
-        ])
-            ->filter(fn (array $source) => $source[1] && is_a(morphed_model($source[0]) ?? '', Order::class, true))
-            ->unique(fn (array $source) => $source[1])
-            ->map(fn (array $source) => resolve_static(Order::class, 'query')->whereKey($source[1])->first())
-            ->filter();
     }
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -564,6 +564,11 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
         return $this->belongsTo(Language::class);
     }
 
+    public function ledgerBookings(): MorphMany
+    {
+        return $this->morphMany(LedgerBooking::class, 'source');
+    }
+
     public function lead(): BelongsTo
     {
         return $this->belongsTo(Lead::class);
@@ -802,7 +807,7 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
 
     public function calculatePaymentState(): static
     {
-        if (! $this->transactions()->exists()) {
+        if (! $this->transactions()->exists() && ! $this->ledgerBookings()->exists()) {
             // Don't reset to Open if order is in a payment run state
             // Payment run lifecycle manages InOpenPaymentRun and InPayment
             if (
@@ -1330,7 +1335,7 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
 
     public function totalPaid(): string|float|int
     {
-        return $this->transactions()
+        $paid = $this->transactions()
             ->withPivot(['amount', 'order_currency_amount'])
             ->get()
             ->reduce(
@@ -1341,6 +1346,22 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
                 ),
                 '0'
             );
+
+        return bcadd($paid, $this->totalSettledByLedgerBookings(), 9);
+    }
+
+    /**
+     * Ledger bookings pointing at this order settle it without a bank transaction,
+     * e.g. an invoice paid directly by a loan. Their amount is always positive, so
+     * the order type decides the direction it settles in.
+     */
+    public function totalSettledByLedgerBookings(): string
+    {
+        return bcmul(
+            (string) $this->ledgerBookings()->sum('amount'),
+            $this->orderType?->order_type_enum?->multiplier() ?? '1',
+            9
+        );
     }
 
     public function toCalendarEvent(?array $info = null): array

--- a/src/Rulesets/LedgerBooking/CreateLedgerBookingRuleset.php
+++ b/src/Rulesets/LedgerBooking/CreateLedgerBookingRuleset.php
@@ -6,6 +6,8 @@ use FluxErp\Models\LedgerAccount;
 use FluxErp\Models\LedgerBooking;
 use FluxErp\Models\Tenant;
 use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\MorphClassExists;
+use FluxErp\Rules\MorphExists;
 use FluxErp\Rules\Numeric;
 use FluxErp\Rulesets\FluxRuleset;
 
@@ -40,6 +42,18 @@ class CreateLedgerBookingRuleset extends FluxRuleset
             'booking_date' => 'required|date',
             'booking_text' => 'string|max:255|nullable',
             'note' => 'string|max:255|nullable',
+            'source_type' => [
+                'string',
+                'nullable',
+                'required_with:source_id',
+                app(MorphClassExists::class),
+            ],
+            'source_id' => [
+                'integer',
+                'nullable',
+                'required_with:source_type',
+                app(MorphExists::class, ['modelAttribute' => 'source_type']),
+            ],
         ];
     }
 }

--- a/src/Rulesets/LedgerBooking/CreateLedgerBookingRuleset.php
+++ b/src/Rulesets/LedgerBooking/CreateLedgerBookingRuleset.php
@@ -35,13 +35,6 @@ class CreateLedgerBookingRuleset extends FluxRuleset
                 'integer',
                 app(ModelExists::class, ['model' => Tenant::class]),
             ],
-            'amount' => [
-                'required',
-                app(Numeric::class, ['min' => 0.01]),
-            ],
-            'booking_date' => 'required|date',
-            'booking_text' => 'string|max:255|nullable',
-            'note' => 'string|max:255|nullable',
             'source_type' => [
                 'string',
                 'nullable',
@@ -54,6 +47,13 @@ class CreateLedgerBookingRuleset extends FluxRuleset
                 'required_with:source_type',
                 app(MorphExists::class, ['modelAttribute' => 'source_type']),
             ],
+            'amount' => [
+                'required',
+                app(Numeric::class, ['min' => 0.01]),
+            ],
+            'booking_date' => 'required|date',
+            'booking_text' => 'string|max:255|nullable',
+            'note' => 'string|max:255|nullable',
         ];
     }
 }

--- a/src/Rulesets/LedgerBooking/UpdateLedgerBookingRuleset.php
+++ b/src/Rulesets/LedgerBooking/UpdateLedgerBookingRuleset.php
@@ -35,14 +35,6 @@ class UpdateLedgerBookingRuleset extends FluxRuleset
                 'integer',
                 app(ModelExists::class, ['model' => LedgerAccount::class]),
             ],
-            'amount' => [
-                'sometimes',
-                'required',
-                app(Numeric::class, ['min' => 0.01]),
-            ],
-            'booking_date' => 'sometimes|required|date',
-            'booking_text' => 'string|max:255|nullable',
-            'note' => 'string|max:255|nullable',
             'source_type' => [
                 'string',
                 'nullable',
@@ -55,6 +47,14 @@ class UpdateLedgerBookingRuleset extends FluxRuleset
                 'required_with:source_type',
                 app(MorphExists::class, ['modelAttribute' => 'source_type']),
             ],
+            'amount' => [
+                'sometimes',
+                'required',
+                app(Numeric::class, ['min' => 0.01]),
+            ],
+            'booking_date' => 'sometimes|required|date',
+            'booking_text' => 'string|max:255|nullable',
+            'note' => 'string|max:255|nullable',
         ];
     }
 }

--- a/src/Rulesets/LedgerBooking/UpdateLedgerBookingRuleset.php
+++ b/src/Rulesets/LedgerBooking/UpdateLedgerBookingRuleset.php
@@ -5,6 +5,8 @@ namespace FluxErp\Rulesets\LedgerBooking;
 use FluxErp\Models\LedgerAccount;
 use FluxErp\Models\LedgerBooking;
 use FluxErp\Rules\ModelExists;
+use FluxErp\Rules\MorphClassExists;
+use FluxErp\Rules\MorphExists;
 use FluxErp\Rules\Numeric;
 use FluxErp\Rulesets\FluxRuleset;
 
@@ -41,6 +43,18 @@ class UpdateLedgerBookingRuleset extends FluxRuleset
             'booking_date' => 'sometimes|required|date',
             'booking_text' => 'string|max:255|nullable',
             'note' => 'string|max:255|nullable',
+            'source_type' => [
+                'string',
+                'nullable',
+                'required_with:source_id',
+                app(MorphClassExists::class),
+            ],
+            'source_id' => [
+                'integer',
+                'nullable',
+                'required_with:source_type',
+                app(MorphExists::class, ['modelAttribute' => 'source_type']),
+            ],
         ];
     }
 }

--- a/tests/Feature/Actions/LedgerBooking/LedgerBookingSettlesOrderTest.php
+++ b/tests/Feature/Actions/LedgerBooking/LedgerBookingSettlesOrderTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use FluxErp\Actions\LedgerBooking\CreateLedgerBooking;
+use FluxErp\Actions\LedgerBooking\DeleteLedgerBooking;
+use FluxErp\Enums\LedgerAccountTypeEnum;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Warehouse;
+use FluxErp\States\Order\PaymentState\Open;
+use FluxErp\States\Order\PaymentState\Paid;
+
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $this->paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $this->priceList = PriceList::factory()->create();
+    $this->currency = Currency::factory()->create();
+
+    $this->debitAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Liability,
+    ]);
+    $this->creditAccount = LedgerAccount::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'ledger_account_type_enum' => LedgerAccountTypeEnum::Liability,
+    ]);
+
+    $this->createOrder = function (OrderTypeEnum $orderTypeEnum, float $totalGrossPrice): Order {
+        $orderType = OrderType::factory()->create([
+            'order_type_enum' => $orderTypeEnum,
+            'is_active' => true,
+        ]);
+
+        return Order::factory()->create([
+            'order_type_id' => $orderType->getKey(),
+            'address_invoice_id' => $this->address->getKey(),
+            'contact_id' => $this->contact->getKey(),
+            'payment_type_id' => $this->paymentType->getKey(),
+            'price_list_id' => $this->priceList->getKey(),
+            'tenant_id' => $this->dbTenant->getKey(),
+            'currency_id' => $this->currency->getKey(),
+            'language_id' => $this->defaultLanguage->getKey(),
+            'total_gross_price' => $totalGrossPrice,
+            'balance' => $totalGrossPrice,
+            'is_locked' => false,
+        ]);
+    };
+
+    $this->book = fn (Order $order, float $amount) => CreateLedgerBooking::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'debit_ledger_account_id' => $this->debitAccount->getKey(),
+        'credit_ledger_account_id' => $this->creditAccount->getKey(),
+        'source_type' => $order->getMorphClass(),
+        'source_id' => $order->getKey(),
+        'amount' => $amount,
+        'booking_date' => '2026-07-01',
+        'booking_text' => 'Umbuchung Kreditor an Darlehen',
+    ])
+        ->validate()
+        ->execute();
+});
+
+test('a ledger booking settles the purchase order it points at', function (): void {
+    $order = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+
+    ($this->book)($order, 52320);
+
+    $order->refresh();
+
+    expect((float) $order->balance)->toBe(0.0)
+        ->and($order->payment_state)->toBeInstanceOf(Paid::class);
+});
+
+test('a ledger booking settles the sales order it points at', function (): void {
+    $order = ($this->createOrder)(OrderTypeEnum::Order, 1190);
+
+    ($this->book)($order, 1190);
+
+    $order->refresh();
+
+    expect((float) $order->balance)->toBe(0.0)
+        ->and($order->payment_state)->toBeInstanceOf(Paid::class);
+});
+
+test('a partial ledger booking leaves the remainder open', function (): void {
+    $order = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+
+    ($this->book)($order, 12320);
+
+    $order->refresh();
+
+    expect((float) $order->balance)->toBe(-40000.0)
+        ->and($order->payment_state->getMorphClass())->not->toBe(Paid::class);
+});
+
+test('deleting the ledger booking reopens the order', function (): void {
+    $order = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+
+    $booking = ($this->book)($order, 52320);
+
+    DeleteLedgerBooking::make(['id' => $booking->getKey()])
+        ->validate()
+        ->execute();
+
+    $order->refresh();
+
+    expect((float) $order->balance)->toBe(-52320.0)
+        ->and($order->payment_state)->toBeInstanceOf(Open::class);
+});
+
+test('a ledger booking without a source leaves orders untouched', function (): void {
+    $order = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+
+    CreateLedgerBooking::make([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'debit_ledger_account_id' => $this->debitAccount->getKey(),
+        'credit_ledger_account_id' => $this->creditAccount->getKey(),
+        'amount' => 52320,
+        'booking_date' => '2026-07-01',
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $order->refresh()->balance)->toBe(-52320.0);
+});

--- a/tests/Feature/Actions/LedgerBooking/LedgerBookingSettlesOrderTest.php
+++ b/tests/Feature/Actions/LedgerBooking/LedgerBookingSettlesOrderTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Actions\LedgerBooking\CreateLedgerBooking;
 use FluxErp\Actions\LedgerBooking\DeleteLedgerBooking;
+use FluxErp\Actions\LedgerBooking\UpdateLedgerBooking;
 use FluxErp\Enums\LedgerAccountTypeEnum;
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Models\Address;
@@ -137,4 +138,24 @@ test('a ledger booking without a source leaves orders untouched', function (): v
         ->execute();
 
     expect((float) $order->refresh()->balance)->toBe(-52320.0);
+});
+
+test('moving the source recalculates the order it left and the one it reached', function (): void {
+    $from = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+    $to = ($this->createOrder)(OrderTypeEnum::Purchase, -52320);
+
+    $booking = ($this->book)($from, 52320);
+
+    UpdateLedgerBooking::make([
+        'id' => $booking->getKey(),
+        'source_type' => $to->getMorphClass(),
+        'source_id' => $to->getKey(),
+    ])
+        ->validate()
+        ->execute();
+
+    expect((float) $from->refresh()->balance)->toBe(-52320.0)
+        ->and($from->payment_state)->toBeInstanceOf(Open::class)
+        ->and((float) $to->refresh()->balance)->toBe(0.0)
+        ->and($to->payment_state)->toBeInstanceOf(Paid::class);
 });


### PR DESCRIPTION
## Problem

An invoice can be settled without any bank transaction ever touching our own accounts. The case that surfaced this: a car was financed and the bank paid the dealer directly, so the purchase invoice in Flux had no payment to assign. The correct entry is a ledger-to-ledger booking (supplier liability against the loan account), and `LedgerBooking` already carries a polymorphic `source`.

The order kept its full balance and stayed open anyway, because `Order::totalPaid()` only summed assigned transactions:

```php
return $this->transactions()
    ->withPivot(['amount', 'order_currency_amount'])
    ->get()
    ->reduce(...);
```

So the books were right while the order list still claimed the invoice had to be paid. Setting the balance by hand does not help, since `calculateBalance()` recomputes it from `total_gross_price` minus `totalPaid()` on every touch.

## Change

- `Order::ledgerBookings()` exposes the bookings that point at the order.
- `Order::totalPaid()` adds `totalSettledByLedgerBookings()`. Booking amounts are always positive, so the order type multiplier decides the direction a booking settles in. A purchase invoice is settled by a negative contribution, a sales invoice by a positive one.
- `calculatePaymentState()` no longer forces an order back to Open when it has no transactions but is settled by a booking.
- `LedgerBooking` recalculates the payment state of the affected orders on save and delete, including the previous order when a booking is moved to another source.
- `source_type` and `source_id` are accepted by the create and update rulesets, so the reference can be set through the action rather than only in code. Both are validated with `MorphClassExists` and `MorphExists` and required together.

## Tests

`tests/Feature/Actions/LedgerBooking/LedgerBookingSettlesOrderTest.php` covers a settled purchase order, a settled sales order, a partial booking that leaves the remainder open, a deleted booking that reopens the order, and a booking without a source that leaves orders untouched.

```
Tests:    11 passed (19 assertions)   tests/Feature/Actions/LedgerBooking
Tests:    89 passed (208 assertions)  Order, OrderTransaction, Transaction, Livewire/Accounting
```

Pint clean on the touched files.

## Notes

The schedule generator still cannot express a final balloon installment, and `Loan` has no media support for the credit agreement. Both came up in the same session and are left for separate pull requests.

## Summary by Sourcery

Allow ledger-to-ledger bookings to settle the payment state and balance of the orders they reference, alongside bank transactions.

New Features:
- Expose a ledgerBookings relation on orders so ledger bookings can be associated directly with an order.
- Include amounts from ledger bookings in an order’s totalPaid calculation based on the order type’s multiplier.
- Support setting a ledger booking’s polymorphic source (including orders) via create and update actions with validation for morph type and existence.

Bug Fixes:
- Prevent settled orders from being reset to Open when they have no transactions but are fully settled via ledger bookings.
- Ensure saving, deleting, or re-pointing a ledger booking triggers recalculation of the payment state of affected orders.

Tests:
- Add feature tests covering order settlement via ledger bookings for purchase and sales orders, partial settlement, reopening on booking deletion, and bookings without a source leaving orders unchanged.