### PR TITLE
fix(fcm): deactivate tokens FCM reports as unregistered

### DIFF
--- a/src/Notifications/Channels/FcmChannel.php
+++ b/src/Notifications/Channels/FcmChannel.php
@@ -63,9 +63,14 @@ class FcmChannel
                     'error' => $e->getMessage(),
                 ]);
 
+                $message = strtolower($e->getMessage());
+
                 if (
-                    str_contains($e->getMessage(), 'not-found')
-                    || str_contains($e->getMessage(), 'invalid-registration-token')
+                    str_contains($message, 'not-found')
+                    || str_contains($message, 'invalid-registration-token')
+                    || str_contains($message, 'notregistered')
+                    || str_contains($message, 'not-registered')
+                    || str_contains($message, 'unregistered')
                 ) {
                     $deviceToken->update(['is_active' => false]);
                 }


### PR DESCRIPTION
## Problem
When a device no longer has the app installed, FCM rejects a send with `NotRegistered` / `UNREGISTERED` / `registration-token-not-registered`. `FcmChannel` only deactivated a token when the error contained `not-found` or `invalid-registration-token`, so these dead tokens stayed `is_active = true` and were retried on **every** future notification. The errors pile up and Firebase flags a high error rate (observed on the mega-meal SaaS: 26 dead tokens producing 312 send errors).

## Fix
Match the unregistered variants too, case-insensitive, before setting `is_active = false`.

Purely additive — it only deactivates on more dead-token signals, so no behavioural change for tokens that were already handled.

## Summary by Sourcery

Bug Fixes:
- Deactivate FCM device tokens when Firebase reports them as unregistered in various message formats, preventing repeated failed sends.