### PR TITLE
Add a stack for extra fields in the order dates card

### DIFF
--- a/resources/views/livewire/order/order.blade.php
+++ b/resources/views/livewire/order/order.blade.php
@@ -1443,6 +1443,7 @@
                                             :without-time="true"
                                             :label="__('Payment Reminder Next Date')"
                                         />
+                                        @stack('order-detail-order-dates-fields')
                                     @show
                                 </div>
                             </x-card>


### PR DESCRIPTION
Packages that add an order level field (for example a shipping method) had no place in the order mask to render it. The blade section `content.right.order_dates` is where such a field belongs, next to invoice date, delivery dates, order date and commission, but a package cannot extend a section.

Adds `@stack('order-detail-order-dates-fields')` at the end of that card. No behaviour change on its own.

## Summary by Sourcery

Enhancements:
- Introduce a Blade stack in the order dates section so external packages can render extra order detail fields without modifying the core view.