### PR TITLE
Normalize translated salutation labels in the order address snapshot

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -148,7 +148,17 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
             }
 
             foreach (['address_invoice', 'address_delivery'] as $addressSnapshot) {
-                $order->{$addressSnapshot} = static::normalizeSnapshotSalutation($order->{$addressSnapshot});
+                $address = $order->{$addressSnapshot};
+
+                if (! is_array($address)) {
+                    continue;
+                }
+
+                $normalized = static::normalizeSnapshotSalutation($address);
+
+                if ($normalized !== $address) {
+                    $order->{$addressSnapshot} = $normalized;
+                }
             }
 
             // reset to original
@@ -447,12 +457,8 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
         ];
     }
 
-    protected static function normalizeSnapshotSalutation(mixed $address): mixed
+    protected static function normalizeSnapshotSalutation(array $address): array
     {
-        if (! is_array($address)) {
-            return $address;
-        }
-
         $salutation = data_get($address, 'salutation');
 
         if (! $salutation || resolve_static(SalutationEnum::class, 'tryFrom', ['value' => $salutation])) {

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -447,10 +447,6 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
         ];
     }
 
-    /**
-     * A snapshot holding the translated label instead of the enum value fails
-     * validation on every replication of the order.
-     */
     protected static function normalizeSnapshotSalutation(mixed $address): mixed
     {
         if (! is_array($address)) {

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -16,6 +16,7 @@ use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Contracts\Targetable;
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Enums\PaymentRunTypeEnum;
+use FluxErp\Enums\SalutationEnum;
 use FluxErp\Events\Order\OrderApprovalRequestEvent;
 use FluxErp\Models\Pivots\AddressAddressTypeOrder;
 use FluxErp\Models\Pivots\OrderPaymentRun;
@@ -76,6 +77,7 @@ use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Number;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use RoundingMode;
 use Spatie\MediaLibrary\HasMedia;
@@ -143,6 +145,10 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
                 && ! $order->address_delivery
             ) {
                 $order->address_delivery = $order->addressDelivery()->with('country')->first();
+            }
+
+            foreach (['address_invoice', 'address_delivery'] as $addressSnapshot) {
+                $order->{$addressSnapshot} = static::normalizeSnapshotSalutation($order->{$addressSnapshot});
             }
 
             // reset to original
@@ -439,6 +445,32 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
                 ]
             ),
         ];
+    }
+
+    /**
+     * The address snapshots are plain JSON, so nothing stops a caller from storing the
+     * translated salutation label instead of the enum value. Replicating such an order
+     * later fails validation, because the ruleset only accepts the enum value. Map a
+     * known label back to its case and leave anything unknown untouched.
+     */
+    protected static function normalizeSnapshotSalutation(?array $address): ?array
+    {
+        $salutation = data_get($address, 'salutation');
+
+        if (! $salutation || resolve_static(SalutationEnum::class, 'tryFrom', ['value' => $salutation])) {
+            return $address;
+        }
+
+        $case = Arr::first(
+            resolve_static(SalutationEnum::class, 'cases'),
+            fn (object $case): bool => in_array(
+                $salutation,
+                [__(Str::headline($case->value)), __($case->value)],
+                true
+            )
+        );
+
+        return $case ? data_set($address, 'salutation', $case->value) : $address;
     }
 
     protected function casts(): array

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -448,13 +448,15 @@ class Order extends FluxModel implements Calendarable, HasMedia, InteractsWithDa
     }
 
     /**
-     * The address snapshots are plain JSON, so nothing stops a caller from storing the
-     * translated salutation label instead of the enum value. Replicating such an order
-     * later fails validation, because the ruleset only accepts the enum value. Map a
-     * known label back to its case and leave anything unknown untouched.
+     * A snapshot holding the translated label instead of the enum value fails
+     * validation on every replication of the order.
      */
-    protected static function normalizeSnapshotSalutation(?array $address): ?array
+    protected static function normalizeSnapshotSalutation(mixed $address): mixed
     {
+        if (! is_array($address)) {
+            return $address;
+        }
+
         $salutation = data_get($address, 'salutation');
 
         if (! $salutation || resolve_static(SalutationEnum::class, 'tryFrom', ['value' => $salutation])) {

--- a/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
+++ b/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Warehouse;
+
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $this->orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Purchase,
+        'is_active' => true,
+    ]);
+    $this->paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $this->priceList = PriceList::factory()->create();
+    $this->currency = Currency::factory()->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => false,
+    ]);
+
+    // Legacy rows carry the snapshot as stored, so bypass the model to seed them.
+    $this->seedSnapshot = function (array $address): Order {
+        Order::query()->whereKey($this->order->getKey())->update([
+            'address_invoice' => json_encode($address),
+            'address_delivery' => json_encode($address),
+        ]);
+
+        $order = $this->order->fresh();
+        $order->save();
+
+        return $order->refresh();
+    };
+
+    // JSON translation lines live under the "*" namespace and group.
+    app('translator')->addLines(['*.company' => 'Firma'], app()->getLocale());
+});
+
+test('a translated salutation label in the snapshot is normalized to the enum value', function (): void {
+    $order = ($this->seedSnapshot)(['salutation' => 'Firma', 'company' => 'Musterfirma GmbH']);
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('company')
+        ->and(data_get($order->address_delivery, 'salutation'))->toBe('company')
+        ->and(data_get($order->address_invoice, 'company'))->toBe('Musterfirma GmbH');
+});
+
+test('an enum value in the snapshot is left alone', function (): void {
+    $order = ($this->seedSnapshot)(['salutation' => 'mr']);
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('mr');
+});
+
+test('an unknown salutation in the snapshot is left alone', function (): void {
+    $order = ($this->seedSnapshot)(['salutation' => 'Kapitaen']);
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('Kapitaen');
+});
+
+test('a snapshot without a salutation stays untouched', function (): void {
+    $order = ($this->seedSnapshot)(['company' => 'Musterfirma GmbH']);
+
+    expect($order->address_invoice)->toBe(['company' => 'Musterfirma GmbH']);
+});
+
+test('assigning a label to an existing order normalizes it on save', function (): void {
+    $this->order->address_invoice = ['salutation' => 'Firma'];
+    $this->order->save();
+
+    expect(data_get($this->order->refresh()->address_invoice, 'salutation'))->toBe('company');
+});

--- a/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
+++ b/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
@@ -41,7 +41,6 @@ beforeEach(function (): void {
         'is_locked' => false,
     ]);
 
-    // Legacy rows carry the snapshot as stored, so bypass the model to seed them.
     $this->seedSnapshot = function (array $address): Order {
         Order::query()->whereKey($this->order->getKey())->update([
             'address_invoice' => json_encode($address),
@@ -54,7 +53,6 @@ beforeEach(function (): void {
         return $order->refresh();
     };
 
-    // JSON translation lines live under the "*" namespace and group.
     app('translator')->addLines(['*.company' => 'Firma'], app()->getLocale());
 });
 
@@ -89,4 +87,15 @@ test('assigning a label to an existing order normalizes it on save', function ()
     $this->order->save();
 
     expect(data_get($this->order->refresh()->address_invoice, 'salutation'))->toBe('company');
+});
+
+test('a snapshot that is not an array is left alone', function (): void {
+    Order::query()->whereKey($this->order->getKey())->update([
+        'address_invoice' => json_encode('Firma'),
+    ]);
+
+    $order = $this->order->fresh();
+    $order->save();
+
+    expect($order->refresh()->address_invoice)->toBe('Firma');
 });


### PR DESCRIPTION
## Problem

A monthly subscription order stopped producing its invoice. `ProcessSubscriptionOrder` failed every run with a validation error that only said:

```
Der ausgewählte Wert ist ungültig.   →   address_delivery.salutation
```

`orders.address_invoice` and `orders.address_delivery` are plain JSON snapshots cast to `array`. Nothing stops a caller from putting the translated label into them, and in a German instance the snapshot held `"Firma"` instead of `"company"`. `ReplicateOrder` builds its payload from `$originalOrder->toArray()` and the ruleset validates the snapshot with `EnumRule(SalutationEnum)`, so the label is rejected and every replication of that order fails.

It stays invisible until an order is replicated or saved through an action, which is why it surfaced on a subscription and not on the thousands of legacy orders carrying the same value.

## Change

`Order` normalizes the salutation inside both snapshots in its `saving` hook:

```php
foreach (['address_invoice', 'address_delivery'] as $addressSnapshot) {
    $order->{$addressSnapshot} = static::normalizeSnapshotSalutation($order->{$addressSnapshot});
}
```

`normalizeSnapshotSalutation()` returns the snapshot untouched when the salutation is empty or already a valid case. Otherwise it looks for a case whose label matches, checking both `__(Str::headline($case->value))` and `__($case->value)`, since JSON translation files key the plain value. Anything it cannot map stays as it is, so unknown input is never silently dropped.

Legacy rows heal on their next save, no migration required.

## Tests

`tests/Feature/Models/OrderAddressSnapshotSalutationTest.php`: a translated label is normalized in both snapshots while the rest of the address is preserved, an enum value is left alone, an unknown salutation is left alone, a snapshot without a salutation is untouched, and assigning a label to an existing order normalizes it on save.

```
Tests:    5 passed (7 assertions)    OrderAddressSnapshotSalutationTest
Tests:    43 passed (85 assertions)  tests/Feature/Actions/Order, tests/Feature/Models
```

Pint clean on the touched files.

## Summary by Sourcery

Normalize salutation values in order address snapshots to valid enum cases on save to prevent replication and validation failures caused by translated labels.

Enhancements:
- Add snapshot salutation normalization in the Order model saving hook for both invoice and delivery addresses, mapping known translated labels back to their corresponding SalutationEnum values while leaving unknown values unchanged.

Tests:
- Add feature tests ensuring address snapshot salutations are normalized from translated labels, left untouched when already valid or unknown, and updated correctly when assigned directly on existing orders.