### PR TITLE
Leave the head of a table that fits on screen alone

### DIFF
--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -141,6 +141,16 @@ const measure = (table) => {
     const headRect = head.getBoundingClientRect();
     const bodyRect = body.getBoundingClientRect();
 
+    // A table that fits between the bar and the lower edge of the screen has
+    // nothing that could scroll underneath its labels. Letting them travel
+    // anyway would only lay the row over the few rows there are, and with a
+    // single one it covers the entire table.
+    if (bodyRect.bottom - headRect.top <= window.innerHeight - edge) {
+        labels.style.setProperty('--flux-head-travel', '0px');
+
+        return;
+    }
+
     // The row is shifted, the head around it is not: its top edge is where the
     // row would sit without the shift.
     const height = labels.offsetHeight;


### PR DESCRIPTION
A table shorter than the space below the top bar has nothing that could scroll underneath its column labels. The labels were let travel anyway, until their lower edge met the end of the table, and so they came to lie over the rows they belong to.

With a single row, an order with one position for instance, the labels covered the whole table and looked as if they had slipped into the middle of it.

The labels now stay where they are unless the table reaches past the lower edge of the screen.