### PR TITLE
Speak the language of the locale in the date and time pickers

### DIFF
--- a/resources/views/livewire/order/purchase-subscription.blade.php
+++ b/resources/views/livewire/order/purchase-subscription.blade.php
@@ -63,7 +63,6 @@
             >
                 <x-time
                     :label="__('Time')"
-                    format="24"
                     wire:model="schedule.cron.parameters.basic.0"
                     x-on:change="$wire.previewSchedule()"
                 />
@@ -90,7 +89,6 @@
                 />
                 <x-time
                     :label="__('Time')"
-                    format="24"
                     wire:model="schedule.cron.parameters.basic.1"
                     x-on:change="$wire.previewSchedule()"
                 />
@@ -113,7 +111,6 @@
                 />
                 <x-time
                     :label="__('Time')"
-                    format="24"
                     wire:model="schedule.cron.parameters.basic.1"
                     x-on:change="$wire.previewSchedule()"
                 />
@@ -141,7 +138,6 @@
                 </div>
                 <x-time
                     :label="__('Time')"
-                    format="24"
                     wire:model="schedule.cron.parameters.basic.2"
                     x-on:change="$wire.previewSchedule()"
                 />
@@ -189,7 +185,6 @@
                 />
                 <x-time
                     :label="__('Time')"
-                    format="24"
                     wire:model="schedule.cron.parameters.basic.2"
                     x-on:change="$wire.previewSchedule()"
                 />

--- a/resources/views/livewire/settings/scheduling.blade.php
+++ b/resources/views/livewire/settings/scheduling.blade.php
@@ -65,7 +65,6 @@
         >
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.basic.0"
             />
         </div>
@@ -132,7 +131,6 @@
             />
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.basic.1"
             />
         </div>
@@ -153,7 +151,6 @@
             />
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.basic.1"
             />
         </div>
@@ -178,7 +175,6 @@
             </div>
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.basic.2"
             />
         </div>
@@ -223,7 +219,6 @@
             />
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.basic.2"
             />
         </div>
@@ -264,7 +259,6 @@
         >
             <x-time
                 :label="__('Time')"
-                format="24"
                 wire:model="schedule.cron.parameters.timeConstraint.0"
             />
         </div>
@@ -278,12 +272,10 @@
         >
             <x-time
                 :label="__('Start')"
-                format="24"
                 wire:model="schedule.cron.parameters.timeConstraint.0"
             />
             <x-time
                 :label="__('End')"
-                format="24"
                 wire:model="schedule.cron.parameters.timeConstraint.1"
             />
         </div>

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -162,7 +162,11 @@ class EventServiceProvider extends ServiceProvider
 
             $format = $this->localeFormat('LT');
 
-            if ($format && ! str_contains($format, 'A')) {
+            if (! $format) {
+                return;
+            }
+
+            if (! str_contains(preg_replace('/\[[^\]]*\]/', '', $format), 'h')) {
                 $component->format = '24';
             }
         });

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Providers;
 
+use Carbon\Translator;
 use FluxErp\Listeners\Auth\LoginListener;
 use FluxErp\Listeners\Auth\LogoutListener;
 use FluxErp\Listeners\BroadcastEventSubscriber;
@@ -40,7 +41,8 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
-use TallStackUi\Components\Form\Date;
+use TallStackUi\Components\Form\Date\Component as Date;
+use TallStackUi\Components\Form\Time\Component as Time;
 use Throwable;
 
 class EventServiceProvider extends ServiceProvider
@@ -141,14 +143,35 @@ class EventServiceProvider extends ServiceProvider
             QueueMonitorManager::handle($event);
         });
 
-        $this->app->resolving(Date::class, function (Date $component) {
+        $this->app->resolving(Date::class, function (Date $component): void {
             $component->start = Carbon::getWeekStartsAt();
 
-            if ($format = data_get(Carbon::getTranslator()->getMessages(), 'de.formats.L')) {
-                $component->format = $format;
+            if ($component->format !== 'YYYY-MM-DD') {
+                return;
             }
 
-            return $component;
+            if ($format = $this->localeFormat('L')) {
+                $component->format = $format;
+            }
         });
+
+        $this->app->resolving(Time::class, function (Time $component): void {
+            if ($component->format !== '12') {
+                return;
+            }
+
+            $format = $this->localeFormat('LT');
+
+            if ($format && ! str_contains($format, 'A')) {
+                $component->format = '24';
+            }
+        });
+    }
+
+    protected function localeFormat(string $key): ?string
+    {
+        $locale = app()->getLocale();
+
+        return data_get(Translator::get($locale)->getMessages(), $locale . '.formats.' . $key);
     }
 }

--- a/tests/Feature/DatePickerFormatTest.php
+++ b/tests/Feature/DatePickerFormatTest.php
@@ -51,3 +51,19 @@ test('keeps a time format that was passed explicitly', function (): void {
 
     expect($html)->not->toContain('AM');
 });
+
+test('renders the time picker with meridiem when the locale writes it in lower case', function (): void {
+    app()->setLocale('si');
+
+    $html = Blade::render('<x-time />');
+
+    expect($html)->toContain('AM');
+});
+
+test('renders the time picker without meridiem when the locale only has one in a literal', function (): void {
+    app()->setLocale('lb');
+
+    $html = Blade::render('<x-time />');
+
+    expect($html)->not->toContain('AM');
+});

--- a/tests/Feature/DatePickerFormatTest.php
+++ b/tests/Feature/DatePickerFormatTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+test('renders the date picker in the format of the locale', function (): void {
+    app()->setLocale('de');
+
+    $html = Blade::render('<x-date />');
+
+    expect($html)->toContain('DD.MM.YYYY');
+    expect($html)->not->toContain('YYYY-MM-DD');
+});
+
+test('renders the date picker in the format of the english locale', function (): void {
+    app()->setLocale('en');
+
+    $html = Blade::render('<x-date />');
+
+    expect($html)->toContain('MM\/DD\/YYYY');
+});
+
+test('keeps a date format that was passed explicitly', function (): void {
+    app()->setLocale('de');
+
+    $html = Blade::render('<x-date format="MMMM YYYY" />');
+
+    expect($html)->toContain('MMMM YYYY');
+    expect($html)->not->toContain('DD.MM.YYYY');
+});
+
+test('renders the time picker without meridiem in german', function (): void {
+    app()->setLocale('de');
+
+    $html = Blade::render('<x-time />');
+
+    expect($html)->not->toContain('AM');
+});
+
+test('renders the time picker with meridiem in english', function (): void {
+    app()->setLocale('en');
+
+    $html = Blade::render('<x-time />');
+
+    expect($html)->toContain('AM');
+});
+
+test('keeps a time format that was passed explicitly', function (): void {
+    app()->setLocale('en');
+
+    $html = Blade::render('<x-time format="24" />');
+
+    expect($html)->not->toContain('AM');
+});


### PR DESCRIPTION
The pickers were localized once, from a callback that ran whenever the container built one of them. The move to TallStackUI v3 rewrote the import of that component to `TallStackUi\Components\Form\Date`, but in v3 that is a namespace and the class within it is called `Component`. Since `::class` only builds a string, nothing complained: the callback simply never ran again, and every picker fell back to the ISO format and to a week that begins on Sunday.

The lookup underneath was unreliable as well. Carbon only keeps the locales it has already loaded, so asking its translator for a format returned nothing whenever the locale had not been used yet. Asking `Carbon\Translator` for the locale loads it.

The time picker follows the same route now, so the thirteen views that each asked for a 24 hour clock no longer have to.

The format reaches the visible input only. The model keeps receiving the ISO date, so bindings, validation and stored values are untouched.

## Summary by Sourcery

Localize date and time picker components based on the current application locale while preserving explicitly configured formats and ISO model values.

New Features:
- Automatically derive date picker display format from the active locale’s Carbon translation settings.
- Automatically choose 12/24-hour time picker display mode based on the locale’s time format, including meridiem usage.

Enhancements:
- Refine date and time picker resolution callbacks to only override default formats and centralize locale format lookup logic.
- Rely on locale-driven defaults for time picker format, removing redundant explicit 24-hour format declarations in scheduling and subscription views.

Tests:
- Add feature tests to verify locale-specific date and time picker formats, including preservation of explicitly provided formats.