### PR TITLE
Keep translated salutations out of the order address snapshots

### DIFF
--- a/database/migrations/2026_08_03_000002_normalize_salutation_in_order_address_snapshots.php
+++ b/database/migrations/2026_08_03_000002_normalize_salutation_in_order_address_snapshots.php
@@ -1,0 +1,90 @@
+<?php
+
+use FluxErp\Enums\SalutationEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        $labels = $this->labels();
+
+        if (! $labels) {
+            return;
+        }
+
+        DB::table('orders')
+            ->select(['id', 'address_invoice', 'address_delivery'])
+            ->orderBy('id')
+            ->chunk(500, function (Collection $orders) use ($labels): void {
+                foreach ($orders as $order) {
+                    $changes = [];
+
+                    foreach (['address_invoice', 'address_delivery'] as $column) {
+                        $address = json_decode($order->{$column} ?? '', true);
+                        $salutation = data_get($address, 'salutation');
+
+                        if (! is_array($address)
+                            || ! is_string($salutation)
+                            || ! array_key_exists($salutation, $labels)
+                        ) {
+                            continue;
+                        }
+
+                        $address['salutation'] = $labels[$salutation];
+                        $changes[$column] = json_encode($address);
+                    }
+
+                    if ($changes) {
+                        DB::table('orders')
+                            ->where('id', $order->id)
+                            ->update($changes);
+                    }
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        //
+    }
+
+    protected function labels(): array
+    {
+        $values = array_map(
+            fn (object $case): string => $case->value,
+            resolve_static(SalutationEnum::class, 'cases')
+        );
+
+        $labels = [];
+
+        foreach ($this->locales() as $locale) {
+            foreach ($values as $value) {
+                foreach ([Str::headline($value), $value] as $key) {
+                    $label = trans($key, [], $locale);
+
+                    if ($label !== $key && ! in_array($label, $values, true)) {
+                        $labels[$label] = $value;
+                    }
+                }
+            }
+        }
+
+        return $labels;
+    }
+
+    protected function locales(): array
+    {
+        return collect(glob(lang_path('*.json')))
+            ->merge(glob(__DIR__ . '/../../lang/*.json'))
+            ->map(fn (string $path): string => basename($path, '.json'))
+            ->push(config('app.locale'), config('app.fallback_locale'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+};

--- a/database/migrations/2026_08_03_000002_normalize_salutation_in_order_address_snapshots.php
+++ b/database/migrations/2026_08_03_000002_normalize_salutation_in_order_address_snapshots.php
@@ -18,6 +18,8 @@ return new class() extends Migration
 
         DB::table('orders')
             ->select(['id', 'address_invoice', 'address_delivery'])
+            ->whereNotNull('address_invoice')
+            ->orWhereNotNull('address_delivery')
             ->orderBy('id')
             ->chunk(500, function (Collection $orders) use ($labels): void {
                 foreach ($orders as $order) {
@@ -47,10 +49,7 @@ return new class() extends Migration
             });
     }
 
-    public function down(): void
-    {
-        //
-    }
+    public function down(): void {}
 
     protected function labels(): array
     {
@@ -59,21 +58,25 @@ return new class() extends Migration
             resolve_static(SalutationEnum::class, 'cases')
         );
 
-        $labels = [];
+        $locales = $this->locales();
+        $candidates = [];
 
-        foreach ($this->locales() as $locale) {
-            foreach ($values as $value) {
-                foreach ([Str::headline($value), $value] as $key) {
-                    $label = trans($key, [], $locale);
+        foreach ($values as $value) {
+            foreach ([Str::headline($value), $value] as $key) {
+                $candidates[$key][] = $value;
 
-                    if ($label !== $key && ! in_array($label, $values, true)) {
-                        $labels[$label] = $value;
-                    }
+                foreach ($locales as $locale) {
+                    $candidates[trans($key, [], $locale)][] = $value;
                 }
             }
         }
 
-        return $labels;
+        return collect($candidates)
+            ->except($values)
+            ->map(fn (array $mapped): array => array_unique($mapped))
+            ->filter(fn (array $mapped): bool => count($mapped) === 1)
+            ->map(fn (array $mapped): string => reset($mapped))
+            ->all();
     }
 
     protected function locales(): array

--- a/src/Rulesets/Order/CreateOrderRuleset.php
+++ b/src/Rulesets/Order/CreateOrderRuleset.php
@@ -36,6 +36,10 @@ class CreateOrderRuleset extends FluxRuleset
             resolve_static(BankConnectionRuleset::class, 'getRules'),
             Arr::prependKeysWith(
                 resolve_static(PostalAddressRuleset::class, 'getRules'),
+                'address_invoice.'
+            ),
+            Arr::prependKeysWith(
+                resolve_static(PostalAddressRuleset::class, 'getRules'),
                 'address_delivery.'
             ),
             resolve_static(AddressRuleset::class, 'getRules'),

--- a/src/Rulesets/Order/UpdateOrderRuleset.php
+++ b/src/Rulesets/Order/UpdateOrderRuleset.php
@@ -35,6 +35,10 @@ class UpdateOrderRuleset extends FluxRuleset
             resolve_static(BankConnectionRuleset::class, 'getRules'),
             Arr::prependKeysWith(
                 resolve_static(PostalAddressRuleset::class, 'getRules'),
+                'address_invoice.'
+            ),
+            Arr::prependKeysWith(
+                resolve_static(PostalAddressRuleset::class, 'getRules'),
                 'address_delivery.'
             ),
             resolve_static(AddressRuleset::class, 'getRules'),

--- a/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
+++ b/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use FluxErp\Actions\Order\UpdateOrder;
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Warehouse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $this->orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Purchase,
+        'is_active' => true,
+    ]);
+    $this->paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $this->priceList = PriceList::factory()->create();
+    $this->currency = Currency::factory()->create();
+
+    $this->order = Order::factory()->create([
+        'order_type_id' => $this->orderType->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => false,
+    ]);
+
+    app('translator')->addLines(['*.Company' => 'Firma'], app()->getLocale());
+
+    $this->migration = require __DIR__
+        . '/../../../database/migrations/2026_08_03_000002_normalize_salutation_in_order_address_snapshots.php';
+});
+
+test('the migration turns a translated label into the enum value', function (): void {
+    DB::table('orders')->where('id', $this->order->getKey())->update([
+        'address_invoice' => json_encode(['salutation' => 'Firma', 'company' => 'Musterfirma GmbH']),
+        'address_delivery' => json_encode(['salutation' => 'Firma']),
+    ]);
+
+    $this->migration->up();
+
+    $order = $this->order->refresh();
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('company')
+        ->and(data_get($order->address_delivery, 'salutation'))->toBe('company')
+        ->and(data_get($order->address_invoice, 'company'))->toBe('Musterfirma GmbH');
+});
+
+test('the migration leaves an enum value and an unknown salutation alone', function (): void {
+    DB::table('orders')->where('id', $this->order->getKey())->update([
+        'address_invoice' => json_encode(['salutation' => 'mr']),
+        'address_delivery' => json_encode(['salutation' => 'Kapitaen']),
+    ]);
+
+    $this->migration->up();
+
+    $order = $this->order->refresh();
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('mr')
+        ->and(data_get($order->address_delivery, 'salutation'))->toBe('Kapitaen');
+});
+
+test('the migration leaves a snapshot without a salutation untouched', function (): void {
+    DB::table('orders')->where('id', $this->order->getKey())->update([
+        'address_invoice' => json_encode(['company' => 'Musterfirma GmbH']),
+        'address_delivery' => null,
+    ]);
+
+    $this->migration->up();
+
+    $order = $this->order->refresh();
+
+    expect($order->address_invoice)->toBe(['company' => 'Musterfirma GmbH'])
+        ->and($order->address_delivery)->toBeNull();
+});
+
+test('updating an order rejects a translated salutation in the invoice snapshot', function (): void {
+    UpdateOrder::make([
+        'id' => $this->order->getKey(),
+        'address_invoice' => ['salutation' => 'Firma'],
+    ])->validate();
+})->throws(ValidationException::class);
+
+test('updating an order rejects a translated salutation in the delivery snapshot', function (): void {
+    UpdateOrder::make([
+        'id' => $this->order->getKey(),
+        'address_delivery' => ['salutation' => 'Firma'],
+    ])->validate();
+})->throws(ValidationException::class);
+
+test('updating an order accepts the enum value in both snapshots', function (): void {
+    UpdateOrder::make([
+        'id' => $this->order->getKey(),
+        'address_invoice' => ['salutation' => 'company'],
+        'address_delivery' => ['salutation' => 'company'],
+    ])->validate()->execute();
+
+    $order = $this->order->refresh();
+
+    expect(data_get($order->address_invoice, 'salutation'))->toBe('company')
+        ->and(data_get($order->address_delivery, 'salutation'))->toBe('company');
+});

--- a/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
+++ b/tests/Feature/Models/OrderAddressSnapshotSalutationTest.php
@@ -93,6 +93,28 @@ test('the migration leaves a snapshot without a salutation untouched', function 
         ->and($order->address_delivery)->toBeNull();
 });
 
+test('the migration maps a label that has no translation of its own', function (): void {
+    DB::table('orders')->where('id', $this->order->getKey())->update([
+        'address_invoice' => json_encode(['salutation' => 'No Salutation']),
+    ]);
+
+    $this->migration->up();
+
+    expect(data_get($this->order->refresh()->address_invoice, 'salutation'))->toBe('no_salutation');
+});
+
+test('the migration leaves a label alone that two cases share', function (): void {
+    app('translator')->addLines(['*.Mr' => 'Anrede', '*.Mrs' => 'Anrede'], app()->getLocale());
+
+    DB::table('orders')->where('id', $this->order->getKey())->update([
+        'address_invoice' => json_encode(['salutation' => 'Anrede']),
+    ]);
+
+    $this->migration->up();
+
+    expect(data_get($this->order->refresh()->address_invoice, 'salutation'))->toBe('Anrede');
+});
+
 test('updating an order rejects a translated salutation in the invoice snapshot', function (): void {
     UpdateOrder::make([
         'id' => $this->order->getKey(),


### PR DESCRIPTION
The invoice and the delivery address are stored as plain JSON on the order, and a caller was free to write the translated label into them. In a German instance that meant `Firma` where the enum expects `company`, and since the ruleset validates the salutation as an enum, every replication of such an order failed. A monthly subscription stopped producing its invoice that way.

Only the delivery address was ever validated field by field:

```php
Arr::prependKeysWith(
    resolve_static(PostalAddressRuleset::class, "getRules"),
    "address_delivery."
),
```

The invoice address had nothing but `array` and `nullable`, so the label went in unnoticed. Both are validated the same way now, and an order that carries a label is refused where it is written rather than where it is read.

The rows already carrying one are cleaned up once by a migration. It maps a label back to its case through the translations of every locale the installation has, the app lang directory, the package lang directory, `app.locale` and `fallback_locale`, so an instance in another language is repaired as well. It works on `DB` in chunks of 500 and writes only where something actually changes. Anything it cannot map stays as it is.

On our own live instance this concerns 199 rows in `address_invoice` and 195 in `address_delivery`, values `Firma`, `Herr` and `Frau`. The older ones come from the FileMaker import, the ones from 2025 and 2026 do not, while the address records themselves hold the enum value throughout.

One consequence worth knowing: a caller that sends a label now fails validation instead of storing it silently.

## Summary by Sourcery

Validate order invoice and delivery address snapshots with postal address rules and normalize existing salutation values from translated labels to enum values.

Bug Fixes:
- Prevent invalid translated salutations from being stored in order invoice and delivery address snapshots by enforcing postal address validation.
- Repair existing orders whose address snapshots contain translated salutation labels by mapping them back to the correct enum values.

Tests:
- Add feature tests covering salutation normalization in order address snapshots and validation of invoice and delivery address salutations.