### PR TITLE
fix: keep lastDayOfMonth performance period from collapsing

### DIFF
--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -31,7 +31,15 @@ class Schedule extends FluxModel
         $start = Carbon::instance($start);
 
         if (data_get($cron, 'methods.basic') === FrequenciesEnum::LastDayOfMonth->value) {
-            return $start->endOfMonth();
+            $end = $start->copy()->endOfMonth();
+
+            // A period inherited from before this calculation existed can start on the last
+            // day of a month, which would collapse it to that single day. Billing the next
+            // month end instead keeps the period non-empty and puts the following one back
+            // on the first of a month.
+            return $end->isSameDay($start)
+                ? $start->copy()->addMonthNoOverflow()->endOfMonth()
+                : $end;
         }
 
         if ($cronExpression) {

--- a/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
+++ b/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
@@ -308,6 +308,79 @@ test('process subscription order uses real month-end for lastDayOfMonth schedule
         ->and($newOrder->system_delivery_date_end->format('Y-m-d'))->toBe('2026-02-28');
 });
 
+test('process subscription order heals a drifted anchor for lastDayOfMonth schedule', function (): void {
+    // Periods created before the lastDayOfMonth fix ended a day short of the real month
+    // end, so the next period starts on the last day of a month. endOfMonth() would then
+    // return the start date itself and collapse the period to a single day.
+    $this->subscriptionOrder->update([
+        'order_date' => Carbon\Carbon::create(2026, 6, 1),
+        'system_delivery_date' => Carbon\Carbon::create(2026, 6, 1),
+        'system_delivery_date_end' => null,
+    ]);
+
+    $driftedChild = Order::factory()->create([
+        'tenant_id' => $this->tenant->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'address_invoice_id' => $this->address->getKey(),
+        'order_type_id' => $this->targetOrderType->getKey(),
+        'currency_id' => $this->currency->getKey(),
+        'language_id' => $this->language->getKey(),
+        'price_list_id' => $this->priceList->getKey(),
+        'payment_type_id' => $this->paymentType->getKey(),
+        'created_from_id' => $this->subscriptionOrder->getKey(),
+        'parent_id' => null,
+        'system_delivery_date' => Carbon\Carbon::create(2026, 5, 31),
+        'system_delivery_date_end' => Carbon\Carbon::create(2026, 6, 29),
+    ]);
+
+    $schedule = Schedule::create([
+        'uuid' => Illuminate\Support\Str::uuid(),
+        'name' => 'ProcessSubscriptionOrder',
+        'class' => ProcessSubscriptionOrder::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'lastDayOfMonth',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => ['00:00'],
+                'dayConstraint' => [],
+                'timeConstraint' => [],
+            ],
+        ],
+        'cron_expression' => '0 0 30 * *',
+        'is_active' => true,
+        'parameters' => [
+            'orderId' => $this->subscriptionOrder->getKey(),
+            'orderTypeId' => $this->targetOrderType->getKey(),
+        ],
+    ]);
+
+    $this->subscriptionOrder->schedules()->attach($schedule->getKey());
+
+    $processor = new ProcessSubscriptionOrder();
+
+    $result = $processor(
+        orderId: $this->subscriptionOrder->getKey(),
+        orderTypeId: $this->targetOrderType->getKey()
+    );
+
+    expect($result)->toBeTrue();
+
+    $newOrder = Order::query()
+        ->where('created_from_id', $this->subscriptionOrder->getKey())
+        ->whereKeyNot($driftedChild->getKey())
+        ->first();
+
+    // The period must span to the next real month end instead of collapsing, which
+    // puts the following period back on the first of a month.
+    expect($newOrder)->not->toBeNull()
+        ->and($newOrder->system_delivery_date->format('Y-m-d'))->toBe('2026-06-30')
+        ->and($newOrder->system_delivery_date_end->format('Y-m-d'))->toBe('2026-07-31');
+});
+
 test('process subscription order sets correct performance period for quarterly schedule', function (): void {
     $orderDate = now()->startOfQuarter();
 


### PR DESCRIPTION
## Problem

Subscription orders on a `lastDayOfMonth` schedule can produce an invoice whose performance period is a single day, and which stays a month behind from then on.

`ProcessSubscriptionOrder` chains the next period start off the latest child order: `latestChild.system_delivery_date_end + 1 day`. Periods created before `Schedule::performancePeriodEnd()` existed were computed as `nextCronRun - 1 day`, which ends one day short of the real month end and loses another day every month. Once that drift reaches a full day, the next period starts on the last day of a month, and `$start->endOfMonth()` returns the start date itself:

| Run | Period written |
|---|---|
| 2026-03-31 | 2026-03-01 to 2026-03-30 |
| 2026-04-30 | 2026-03-31 to 2026-04-29 |
| 2026-05-31 | 2026-04-30 to 2026-05-30 |
| 2026-06-30 | 2026-05-31 to 2026-06-29 |
| 2026-07-31 | 2026-06-30 to 2026-06-30 |

Seen in production on 119 monthly invoices in a single run. Any installation with `lastDayOfMonth` subscriptions that ran before #1861 carries the same drifted anchors and hits this on its first month end afterwards.

## Fix

When the calculated end lands on the start date, bill through the next month end instead. The period stays non-empty and the following one starts on the first of a month again, so a drifted anchor heals itself after one cycle without a manual data correction.

The guard lives in `performancePeriodEnd()`, which both the actual run and the schedule preview already route through, so both stay in agreement.

## Tests

New regression test reproducing the drifted anchor: a child ending 2026-06-29 must yield 2026-06-30 to 2026-07-31, not a collapsed period. Fails before, passes after. Existing subscription and schedule tests stay green.

## Summary by Sourcery

Prevent last-day-of-month subscription performance periods from collapsing to a single day by adjusting how period end dates are derived for legacy drifted anchors.

Enhancements:
- Adjust lastDayOfMonth schedule performance period end calculation to extend to the next month end when the computed end would match the start date, allowing drifted anchors to self-correct.

Tests:
- Add a regression test ensuring ProcessSubscriptionOrder heals a drifted lastDayOfMonth anchor by generating a non-collapsed period that realigns subsequent periods to start on the first of the month.