### PR TITLE
feat(loan): persist the loan key figures and give loans a detail page

### DIFF
--- a/database/migrations/2026_08_03_000001_add_remaining_and_total_interest_to_loans_table.php
+++ b/database/migrations/2026_08_03_000001_add_remaining_and_total_interest_to_loans_table.php
@@ -33,7 +33,7 @@ return new class() extends Migration
                 )
         SQL);
 
-        DB::statement('UPDATE loans SET progress = (amount - remaining) / amount WHERE amount > 0');
+        DB::statement('UPDATE loans SET progress = (amount - COALESCE(remaining, 0)) / amount WHERE amount > 0');
     }
 
     public function down(): void

--- a/database/migrations/2026_08_03_000001_add_remaining_and_total_interest_to_loans_table.php
+++ b/database/migrations/2026_08_03_000001_add_remaining_and_total_interest_to_loans_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('loans', function (Blueprint $table): void {
+            $table->decimal('remaining', 40, 10)->nullable()->after('installment_amount');
+            $table->decimal('total_interest', 40, 10)->nullable()->after('remaining');
+
+            $table->decimal('progress', 11, 10)->default(0)->after('total_interest');
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE loans
+            SET remaining = (
+                    SELECT COALESCE(SUM(principal_amount), 0)
+                    FROM loan_installments
+                    WHERE loan_installments.loan_id = loans.id
+                      AND loan_installments.is_paid = 0
+                      AND loan_installments.deleted_at IS NULL
+                ),
+                total_interest = (
+                    SELECT COALESCE(SUM(interest_amount), 0)
+                    FROM loan_installments
+                    WHERE loan_installments.loan_id = loans.id
+                      AND loan_installments.deleted_at IS NULL
+                )
+        SQL);
+
+        DB::statement('UPDATE loans SET progress = (amount - remaining) / amount WHERE amount > 0');
+    }
+
+    public function down(): void
+    {
+        Schema::table('loans', function (Blueprint $table): void {
+            $table->dropColumn(['remaining', 'total_interest', 'progress']);
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -2316,6 +2316,7 @@
     "Reminder Subject": "Erinnerungsbetreff",
     "Remove": "Entfernen",
     "Remove Color": "Farbe entfernen",
+    "Repayment Schedule": "Tilgungsplan",
     "Repayment Type": "Tilgungsart",
     "Repayment Type Enum": "Tilgungsart",
     "Repeat": "Wiederhole",

--- a/resources/views/components/loan/documents.blade.php
+++ b/resources/views/components/loan/documents.blade.php
@@ -1,0 +1,16 @@
+<x-card class="w-full">
+    <x-flux::features.media.upload-form-object
+        :label="__('Contract')"
+        wire:model="contract"
+        :multiple="false"
+        accept="application/pdf, image/jpeg, image/png"
+    />
+    <x-slot:footer>
+        <x-button
+            color="indigo"
+            loading="save"
+            :text="__('Save')"
+            x-on:click="$wire.save()"
+        />
+    </x-slot:footer>
+</x-card>

--- a/resources/views/components/loan/documents.blade.php
+++ b/resources/views/components/loan/documents.blade.php
@@ -8,9 +8,9 @@
     <x-slot:footer>
         <x-button
             color="indigo"
-            loading="save"
             :text="__('Save')"
-            x-on:click="$wire.save()"
+            loading="saveContract"
+            x-on:click="$wire.saveContract()"
         />
     </x-slot:footer>
 </x-card>

--- a/resources/views/components/loan/general.blade.php
+++ b/resources/views/components/loan/general.blade.php
@@ -1,0 +1,73 @@
+<x-card class="w-full">
+    <div
+        class="flex flex-col gap-1.5"
+        x-bind:class="!isEditing && 'pointer-events-none'"
+    >
+        <x-input wire:model="loan.name" :label="__('Name')" required />
+        <div class="grid grid-cols-1 gap-1.5 md:grid-cols-2">
+            <x-select.styled
+                :label="__('Contact')"
+                wire:model.number="loan.contact_id"
+                select="label:label|value:id"
+                required
+                :request="[
+                    'url' => route('search', \FluxErp\Models\Contact::class),
+                    'method' => 'POST',
+                ]"
+            />
+            <x-select.styled
+                :label="__('Ledger Account')"
+                wire:model.number="loan.ledger_account_id"
+                select="label:name|value:id|description:number"
+                required
+                unfiltered
+                :request="[
+                    'url' => route('search', \FluxErp\Models\LedgerAccount::class),
+                    'method' => 'POST',
+                ]"
+            />
+        </div>
+        <x-select.styled
+            :label="__('Order')"
+            wire:model.number="loan.order_id"
+            select="label:label|value:id"
+            :request="[
+                'url' => route('search', \FluxErp\Models\Order::class),
+                'method' => 'POST',
+            ]"
+        />
+        <x-input wire:model="loan.number" :label="__('Number')" />
+    </div>
+
+    <x-slot:footer>
+        <div class="pointer-events-none flex flex-col gap-1.5 opacity-60">
+            <div class="grid grid-cols-1 gap-1.5 md:grid-cols-2">
+                <x-number
+                    wire:model="loan.amount"
+                    :label="__('Amount')"
+                    step="0.01"
+                />
+                <x-number
+                    wire:model="loan.interest_rate"
+                    :label="__('Interest Rate')"
+                    suffix="%"
+                    step="0.001"
+                />
+            </div>
+            <div class="grid grid-cols-1 gap-1.5 md:grid-cols-3">
+                <x-select.styled
+                    wire:model="loan.repayment_type_enum"
+                    :label="__('Repayment Type')"
+                    select="label:label|value:value"
+                    :options="\FluxErp\Enums\RepaymentTypeEnum::valuesLocalized()"
+                />
+                <x-number
+                    wire:model="loan.number_of_installments"
+                    :label="__('Number Of Installments')"
+                    step="1"
+                />
+                <x-date wire:model="loan.starts_at" :label="__('Starts At')" />
+            </div>
+        </div>
+    </x-slot:footer>
+</x-card>

--- a/resources/views/components/loan/installments.blade.php
+++ b/resources/views/components/loan/installments.blade.php
@@ -1,0 +1,77 @@
+<x-card class="w-full">
+    <div
+        class="dark:divide-secondary-700 dark:border-secondary-700 mb-6 grid grid-cols-1 divide-y divide-gray-200 rounded-lg border border-gray-200 sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+    >
+        <div class="px-4 py-3">
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+                {{ __('Principal') }}
+            </div>
+            <div
+                class="mt-1 text-lg font-semibold text-gray-900 tabular-nums dark:text-gray-50"
+            >
+                {{ $this->totals['principal_amount'] }}
+            </div>
+            <div
+                class="mt-0.5 text-xs text-gray-500 tabular-nums dark:text-gray-400"
+            >
+                {{ __('Paid') }} {{ $this->totals['paid_principal_amount'] }}
+                <span class="opacity-60">
+                    ({{ $this->totals['paid_principal_share'] }})
+                </span>
+            </div>
+        </div>
+        <div class="px-4 py-3">
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+                {{ __('Interest') }}
+            </div>
+            <div
+                class="mt-1 text-lg font-semibold text-gray-900 tabular-nums dark:text-gray-50"
+            >
+                {{ $this->totals['interest_amount'] }}
+            </div>
+            <div
+                class="mt-0.5 text-xs text-gray-500 tabular-nums dark:text-gray-400"
+            >
+                {{ __('Paid') }} {{ $this->totals['paid_interest_amount'] }}
+                <span class="opacity-60">
+                    ({{ $this->totals['paid_interest_share'] }})
+                </span>
+            </div>
+        </div>
+        <div class="bg-gray-50/70 px-4 py-3 dark:bg-white/5">
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+                {{ __('Total') }}
+            </div>
+            <div
+                class="mt-1 text-lg font-semibold text-gray-900 tabular-nums dark:text-gray-50"
+            >
+                {{ $this->totals['total'] }}
+            </div>
+            <div
+                class="mt-0.5 text-xs text-gray-500 tabular-nums dark:text-gray-400"
+            >
+                {{ __('Paid') }} {{ $this->totals['paid_total'] }}
+                <span class="opacity-60">
+                    ({{ $this->totals['paid_total_share'] }})
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <x-table
+        :headers="$this->scheduleHeaders"
+        :rows="$this->installments"
+        striped
+    >
+        @interact('column_is_paid', $row)
+            <x-icon
+                :name="$row['is_paid'] ? 'check' : 'x-mark'"
+                @class([
+                    'h-5 w-5',
+                    'text-green-600' => $row['is_paid'],
+                    'text-gray-400' => ! $row['is_paid'],
+                ])
+            />
+        @endinteract
+    </x-table>
+</x-card>

--- a/resources/views/livewire/accounting/loan.blade.php
+++ b/resources/views/livewire/accounting/loan.blade.php
@@ -60,6 +60,7 @@
             @canAction(\FluxErp\Actions\Loan\DeleteLoan::class)
                 <x-button
                     color="red"
+                    loading="delete"
                     :text="__('Delete')"
                     x-cloak
                     x-show="!isEditing"

--- a/resources/views/livewire/accounting/loan.blade.php
+++ b/resources/views/livewire/accounting/loan.blade.php
@@ -1,0 +1,76 @@
+<div
+    x-data="{
+        isEditing: false,
+    }"
+>
+    <div
+        class="mx-auto md:flex md:items-center md:justify-between md:space-x-5"
+    >
+        <div class="flex items-center space-x-5">
+            @section('loan.title')
+                <div>
+                    <h1
+                        class="text-2xl font-bold text-gray-900 dark:text-gray-50"
+                    >
+                        <span x-text="$wire.loan.name"></span>
+                    </h1>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <span x-text="$wire.loan.number"></span>
+                    </p>
+                </div>
+            @show
+        </div>
+        <div
+            class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-y-0 sm:space-x-3 sm:space-x-reverse md:mt-0 md:flex-row md:space-x-3"
+        >
+            <x-button
+                color="indigo"
+                x-cloak
+                x-show="!isEditing"
+                class="w-full"
+                x-on:click="isEditing = true"
+                :text="__('Edit')"
+            />
+            <x-button
+                color="indigo"
+                loading="save"
+                x-cloak
+                x-show="isEditing"
+                class="w-full"
+                x-on:click="
+                    $wire.save().then((success) => {
+                        if (success) isEditing = false;
+                    })
+                "
+                :text="__('Save')"
+            />
+            <x-button
+                color="secondary"
+                light
+                flat
+                :text="__('Cancel')"
+                x-cloak
+                x-show="isEditing"
+                class="w-full"
+                x-on:click="
+                    isEditing = false;
+                    $wire.resetForm();
+                "
+            />
+            @canAction(\FluxErp\Actions\Loan\DeleteLoan::class)
+                <x-button
+                    color="red"
+                    :text="__('Delete')"
+                    x-cloak
+                    x-show="!isEditing"
+                    class="w-full"
+                    wire:click="delete()"
+                    wire:flux-confirm.type.error="{{ __('wire:confirm.delete', ['model' => __('Loan')]) }}"
+                />
+            @endcanAction
+            @stack('loan-detail-header-actions')
+        </div>
+    </div>
+    <x-flux::tabs wire:model.live="tab" :$tabs />
+    @stack('loan-detail-after-tabs')
+</div>

--- a/resources/views/livewire/accounting/loans.blade.php
+++ b/resources/views/livewire/accounting/loans.blade.php
@@ -1,4 +1,4 @@
-<x-modal id="edit-loan-modal" :title="__('Loan')" size="6xl">
+<x-modal id="edit-loan-modal" :title="__('Loan')" size="xl">
     <div class="flex flex-col gap-1.5">
         <x-input wire:model="loan.name" :label="__('Name')" required />
         <div class="grid grid-cols-1 gap-1.5 md:grid-cols-2">
@@ -34,87 +34,37 @@
             ]"
         />
         <x-input wire:model="loan.number" :label="__('Number')" />
-        <div
-            class="flex flex-col gap-1.5"
-            x-bind:class="$wire.loan.id && 'pointer-events-none opacity-60'"
-        >
-            <div class="grid grid-cols-1 gap-1.5 md:grid-cols-2">
-                <x-number
-                    wire:model="loan.amount"
-                    :label="__('Amount')"
-                    step="0.01"
-                    placeholder="0.00"
-                />
-                <x-number
-                    wire:model="loan.interest_rate"
-                    :label="__('Interest Rate')"
-                    suffix="%"
-                    min="0"
-                    step="0.001"
-                    placeholder="0.000"
-                />
-            </div>
-            <div class="grid grid-cols-1 gap-1.5 md:grid-cols-3">
-                <x-select.styled
-                    wire:model="loan.repayment_type_enum"
-                    :label="__('Repayment Type')"
-                    required
-                    select="label:label|value:value"
-                    :options="\FluxErp\Enums\RepaymentTypeEnum::valuesLocalized()"
-                />
-                <x-number
-                    wire:model="loan.number_of_installments"
-                    :label="__('Number Of Installments')"
-                    step="1"
-                />
-                <x-date wire:model="loan.starts_at" :label="__('Starts At')" />
-            </div>
+        <div class="grid grid-cols-1 gap-1.5 md:grid-cols-2">
+            <x-number
+                wire:model="loan.amount"
+                :label="__('Amount')"
+                step="0.01"
+                placeholder="0.00"
+            />
+            <x-number
+                wire:model="loan.interest_rate"
+                :label="__('Interest Rate')"
+                suffix="%"
+                min="0"
+                step="0.001"
+                placeholder="0.000"
+            />
         </div>
-
-        <x-flux::features.media.upload-form-object
-            :label="__('Contract')"
-            wire:model="contract"
-            :multiple="false"
-            accept="application/pdf, image/jpeg, image/png"
-        />
-
-        @if ($installments)
-            <div class="mt-4 max-h-96 overflow-y-auto">
-                <x-table>
-                    <x-slot:header>
-                        <table.row>
-                            <th class="text-left">{{ __('Sequence') }}</th>
-                            <th class="text-left">{{ __('Due Date') }}</th>
-                            <th class="text-right">{{ __('Principal') }}</th>
-                            <th class="text-right">{{ __('Interest') }}</th>
-                            <th class="text-right">{{ __('Remaining') }}</th>
-                            <th class="text-left">{{ __('Paid') }}</th>
-                        </table.row>
-                    </x-slot:header>
-                    @foreach ($installments as $installment)
-                        <x-table.row>
-                            <td>{{ $installment['sequence'] }}</td>
-                            <td>{{ $installment['due_date'] }}</td>
-                            <td class="text-right">
-                                {{ number_format((float) $installment['principal_amount'], 2) }}
-                            </td>
-                            <td class="text-right">
-                                {{ number_format((float) $installment['interest_amount'], 2) }}
-                            </td>
-                            <td class="text-right">
-                                {{ number_format((float) $installment['remaining'], 2) }}
-                            </td>
-                            <td>
-                                <x-icon
-                                    :name="$installment['is_paid'] ? 'check' : 'x-mark'"
-                                    class="h-5 w-5"
-                                />
-                            </td>
-                        </x-table.row>
-                    @endforeach
-                </x-table>
-            </div>
-        @endif
+        <div class="grid grid-cols-1 gap-1.5 md:grid-cols-3">
+            <x-select.styled
+                wire:model="loan.repayment_type_enum"
+                :label="__('Repayment Type')"
+                required
+                select="label:label|value:value"
+                :options="\FluxErp\Enums\RepaymentTypeEnum::valuesLocalized()"
+            />
+            <x-number
+                wire:model="loan.number_of_installments"
+                :label="__('Number Of Installments')"
+                step="1"
+            />
+            <x-date wire:model="loan.starts_at" :label="__('Starts At')" />
+        </div>
     </div>
     <x-slot:footer>
         <x-button
@@ -126,12 +76,9 @@
         />
         <x-button
             color="indigo"
+            loading="save"
             :text="__('Save')"
-            x-on:click="
-                $wire.save().then((success) => {
-                    if (success) $tsui.close.modal('edit-loan-modal');
-                })
-            "
+            wire:click="save()"
         />
     </x-slot:footer>
 </x-modal>

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -12,6 +12,7 @@ use FluxErp\Http\Middleware\TrackVisits;
 use FluxErp\Livewire\AbsenceRequest\AbsenceRequest;
 use FluxErp\Livewire\Accounting\DirectDebit;
 use FluxErp\Livewire\Accounting\LedgerBookings;
+use FluxErp\Livewire\Accounting\Loan;
 use FluxErp\Livewire\Accounting\Loans;
 use FluxErp\Livewire\Accounting\MoneyTransfer;
 use FluxErp\Livewire\Accounting\PaymentReminderRun;
@@ -275,6 +276,7 @@ Route::middleware('web')
                         Route::get('/commissions', CommissionList::class)->name('commissions');
                         Route::get('/ledger-bookings', LedgerBookings::class)->name('ledger-bookings');
                         Route::get('/loans', Loans::class)->name('loans');
+                        Route::get('/loans/{id}', Loan::class)->where('id', '[0-9]+')->name('loans.id');
                         Route::get('/payment-reminder-run', PaymentReminderRun::class)->name('payment-reminder-run');
                         Route::get('/purchase-invoices', PurchaseInvoiceList::class)->name('purchase-invoices');
                         Route::get('/transactions', TransactionList::class)->name('transactions');

--- a/src/Actions/Loan/CreateLoan.php
+++ b/src/Actions/Loan/CreateLoan.php
@@ -52,7 +52,10 @@ class CreateLoan extends FluxAction
                     : null),
             'ends_at' => $this->getData('ends_at') ?? $lastInstallment['due_date'] ?? null,
         ]);
-        $loan->save();
+        $loan->calculateRemaining()
+            ->calculateTotalInterest()
+            ->calculateProgress()
+            ->save();
 
         return $loan->refresh();
     }

--- a/src/Livewire/Accounting/Loan.php
+++ b/src/Livewire/Accounting/Loan.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Number;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -29,6 +30,10 @@ class Loan extends Component
 
     public MediaUploadForm $contract;
 
+    #[Locked]
+    public string $currencyIso = 'EUR';
+
+    #[Locked]
     public array $installments = [];
 
     public LoanForm $loan;
@@ -39,21 +44,22 @@ class Loan extends Component
 
     public string $tab = 'loan.general';
 
+    #[Locked]
     public array $totals = [];
-
-    protected ?string $currencyIso = null;
 
     public function mount(string $id): void
     {
-        $loan = resolve_static(LoanModel::class, 'query')
-            ->whereKey($id)
-            ->firstOrFail();
-
         try {
             $this->getTabButton($this->tab);
         } catch (Throwable) {
             throw new NotFoundHttpException('Tab not found');
         }
+
+        $this->currencyIso = resolve_static(Currency::class, 'query')
+            ->where('is_default', true)
+            ->value('iso') ?? 'EUR';
+
+        $loan = $this->loadLoan($id);
 
         $this->loan->fill($loan);
         $this->contract->fill($loan->getFirstMedia('contract') ?? []);
@@ -66,10 +72,9 @@ class Loan extends Component
         return view('flux::livewire.accounting.loan');
     }
 
+    #[Renderless]
     public function delete(): void
     {
-        $this->skipRender();
-
         try {
             DeleteLoan::make(['id' => $this->loan->id])
                 ->checkPermission()
@@ -81,20 +86,7 @@ class Loan extends Component
             return;
         }
 
-        $this->redirect(route('accounting.loans'));
-    }
-
-    #[Computed]
-    public function scheduleHeaders(): array
-    {
-        return [
-            ['index' => 'sequence', 'label' => __('Sequence')],
-            ['index' => 'due_date', 'label' => __('Due Date')],
-            ['index' => 'principal_amount', 'label' => __('Principal')],
-            ['index' => 'interest_amount', 'label' => __('Interest')],
-            ['index' => 'remaining', 'label' => __('Remaining')],
-            ['index' => 'is_paid', 'label' => __('Paid')],
-        ];
+        $this->redirect(route('accounting.loans'), navigate: true);
     }
 
     public function getTabs(): array
@@ -111,12 +103,8 @@ class Loan extends Component
 
     public function resetForm(): void
     {
-        $loan = resolve_static(LoanModel::class, 'query')
-            ->whereKey($this->loan->id)
-            ->firstOrFail();
-
         $this->loan->reset();
-        $this->loan->fill($loan);
+        $this->loan->fill($this->loadLoan($this->loan->id));
     }
 
     #[Renderless]
@@ -130,23 +118,46 @@ class Loan extends Component
             return false;
         }
 
-        $this->contract->model_type = morph_alias(LoanModel::class);
-        $this->contract->model_id = $this->loan->id;
-        $this->contract->collection_name = 'contract';
-
-        if ($this->contract->stagedFiles || $this->contract->id) {
-            try {
-                $this->contract->save();
-            } catch (ValidationException|UnauthorizedException $e) {
-                exception_to_notifications($e, $this);
-            }
-        }
-
         $this->toast()
             ->success(__(':model saved', ['model' => __('Loan')]))
             ->send();
 
         return true;
+    }
+
+    #[Renderless]
+    public function saveContract(): bool
+    {
+        $this->contract->model_type = morph_alias(LoanModel::class);
+        $this->contract->model_id = $this->loan->id;
+        $this->contract->collection_name = 'contract';
+
+        try {
+            $this->contract->save();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        $this->toast()
+            ->success(__(':model saved', ['model' => __('Contract')]))
+            ->send();
+
+        return true;
+    }
+
+    #[Computed]
+    public function scheduleHeaders(): array
+    {
+        return [
+            ['index' => 'sequence', 'label' => __('Sequence')],
+            ['index' => 'due_date', 'label' => __('Due Date')],
+            ['index' => 'principal_amount', 'label' => __('Principal')],
+            ['index' => 'interest_amount', 'label' => __('Interest')],
+            ['index' => 'remaining', 'label' => __('Remaining')],
+            ['index' => 'is_paid', 'label' => __('Paid')],
+        ];
     }
 
     /**
@@ -180,10 +191,16 @@ class Loan extends Component
      */
     protected function buildTotals(LoanModel $loan): array
     {
-        $principal = (string) $loan->installments()->sum('principal_amount');
-        $interest = (string) $loan->installments()->sum('interest_amount');
-        $paidPrincipal = (string) $loan->installments()->where('is_paid', true)->sum('principal_amount');
-        $paidInterest = (string) $loan->installments()->where('is_paid', true)->sum('interest_amount');
+        $principal = (string) $loan->installments()
+            ->sum('principal_amount');
+        $interest = (string) $loan->installments()
+            ->sum('interest_amount');
+        $paidPrincipal = (string) $loan->installments()
+            ->where('is_paid', true)
+            ->sum('principal_amount');
+        $paidInterest = (string) $loan->installments()
+            ->where('is_paid', true)
+            ->sum('interest_amount');
 
         return [
             'principal_amount' => $this->money($principal),
@@ -201,6 +218,18 @@ class Loan extends Component
         ];
     }
 
+    protected function loadLoan(int|string $id): LoanModel
+    {
+        return resolve_static(LoanModel::class, 'query')
+            ->whereKey($id)
+            ->firstOrFail();
+    }
+
+    protected function money(string|float|int|null $value): string
+    {
+        return Number::currency((float) $value, $this->currencyIso, app()->getLocale());
+    }
+
     protected function share(string $part, string $of): string
     {
         return Number::percentage(
@@ -208,17 +237,5 @@ class Loan extends Component
             1,
             locale: app()->getLocale()
         );
-    }
-
-    protected function currencyIso(): string
-    {
-        return $this->currencyIso ??= resolve_static(Currency::class, 'query')
-            ->where('is_default', true)
-            ->value('iso') ?? 'EUR';
-    }
-
-    protected function money(string|float|int|null $value): string
-    {
-        return Number::currency((float) $value, $this->currencyIso(), app()->getLocale());
     }
 }

--- a/src/Livewire/Accounting/Loan.php
+++ b/src/Livewire/Accounting/Loan.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace FluxErp\Livewire\Accounting;
+
+use FluxErp\Actions\Loan\DeleteLoan;
+use FluxErp\Htmlables\TabButton;
+use FluxErp\Livewire\Forms\LoanForm;
+use FluxErp\Livewire\Forms\MediaUploadForm;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Loan as LoanModel;
+use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\WithFileUploads;
+use FluxErp\Traits\Livewire\WithTabs;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Number;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Renderless;
+use Livewire\Component;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
+
+class Loan extends Component
+{
+    use Actions, WithFileUploads, WithTabs;
+
+    public MediaUploadForm $contract;
+
+    public array $installments = [];
+
+    public LoanForm $loan;
+
+    public array $queryString = [
+        'tab' => ['except' => 'loan.general'],
+    ];
+
+    public string $tab = 'loan.general';
+
+    public array $totals = [];
+
+    protected ?string $currencyIso = null;
+
+    public function mount(string $id): void
+    {
+        $loan = resolve_static(LoanModel::class, 'query')
+            ->whereKey($id)
+            ->firstOrFail();
+
+        try {
+            $this->getTabButton($this->tab);
+        } catch (Throwable) {
+            throw new NotFoundHttpException('Tab not found');
+        }
+
+        $this->loan->fill($loan);
+        $this->contract->fill($loan->getFirstMedia('contract') ?? []);
+        $this->installments = $this->buildSchedule($loan);
+        $this->totals = $this->buildTotals($loan);
+    }
+
+    public function render(): View|Factory|Application
+    {
+        return view('flux::livewire.accounting.loan');
+    }
+
+    public function delete(): void
+    {
+        $this->skipRender();
+
+        try {
+            DeleteLoan::make(['id' => $this->loan->id])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->redirect(route('accounting.loans'));
+    }
+
+    #[Computed]
+    public function scheduleHeaders(): array
+    {
+        return [
+            ['index' => 'sequence', 'label' => __('Sequence')],
+            ['index' => 'due_date', 'label' => __('Due Date')],
+            ['index' => 'principal_amount', 'label' => __('Principal')],
+            ['index' => 'interest_amount', 'label' => __('Interest')],
+            ['index' => 'remaining', 'label' => __('Remaining')],
+            ['index' => 'is_paid', 'label' => __('Paid')],
+        ];
+    }
+
+    public function getTabs(): array
+    {
+        return [
+            TabButton::make('loan.general')
+                ->text(__('General')),
+            TabButton::make('loan.installments')
+                ->text(__('Repayment Schedule')),
+            TabButton::make('loan.documents')
+                ->text(__('Documents')),
+        ];
+    }
+
+    public function resetForm(): void
+    {
+        $loan = resolve_static(LoanModel::class, 'query')
+            ->whereKey($this->loan->id)
+            ->firstOrFail();
+
+        $this->loan->reset();
+        $this->loan->fill($loan);
+    }
+
+    #[Renderless]
+    public function save(): bool
+    {
+        try {
+            $this->loan->save();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        $this->contract->model_type = morph_alias(LoanModel::class);
+        $this->contract->model_id = $this->loan->id;
+        $this->contract->collection_name = 'contract';
+
+        if ($this->contract->stagedFiles || $this->contract->id) {
+            try {
+                $this->contract->save();
+            } catch (ValidationException|UnauthorizedException $e) {
+                exception_to_notifications($e, $this);
+            }
+        }
+
+        $this->toast()
+            ->success(__(':model saved', ['model' => __('Loan')]))
+            ->send();
+
+        return true;
+    }
+
+    /**
+     * The stored installments plus a running remaining balance, formatted for
+     * display because the table renders the values as they are.
+     */
+    protected function buildSchedule(LoanModel $loan): array
+    {
+        $remaining = $loan->amount;
+        $schedule = [];
+
+        foreach ($loan->installments()->orderBy('sequence')->get() as $installment) {
+            $remaining = bcsub($remaining, $installment->principal_amount, 2);
+
+            $schedule[] = [
+                'sequence' => $installment->sequence,
+                'due_date' => $installment->due_date->locale(app()->getLocale())->isoFormat('L'),
+                'principal_amount' => $this->money($installment->principal_amount),
+                'interest_amount' => $this->money($installment->interest_amount),
+                'is_paid' => $installment->is_paid,
+                'remaining' => $this->money($remaining),
+            ];
+        }
+
+        return $schedule;
+    }
+
+    /**
+     * The sums above the schedule: what has to be repaid over the whole term
+     * and how much of it is settled already.
+     */
+    protected function buildTotals(LoanModel $loan): array
+    {
+        $principal = (string) $loan->installments()->sum('principal_amount');
+        $interest = (string) $loan->installments()->sum('interest_amount');
+        $paidPrincipal = (string) $loan->installments()->where('is_paid', true)->sum('principal_amount');
+        $paidInterest = (string) $loan->installments()->where('is_paid', true)->sum('interest_amount');
+
+        return [
+            'principal_amount' => $this->money($principal),
+            'interest_amount' => $this->money($interest),
+            'total' => $this->money(bcadd($principal, $interest, 2)),
+            'paid_principal_amount' => $this->money($paidPrincipal),
+            'paid_interest_amount' => $this->money($paidInterest),
+            'paid_total' => $this->money(bcadd($paidPrincipal, $paidInterest, 2)),
+            'paid_principal_share' => $this->share($paidPrincipal, $principal),
+            'paid_interest_share' => $this->share($paidInterest, $interest),
+            'paid_total_share' => $this->share(
+                bcadd($paidPrincipal, $paidInterest, 2),
+                bcadd($principal, $interest, 2)
+            ),
+        ];
+    }
+
+    protected function share(string $part, string $of): string
+    {
+        return Number::percentage(
+            bccomp($of, '0', 2) === 1 ? (float) bcmul(bcdiv($part, $of, 6), '100', 4) : 0,
+            1,
+            locale: app()->getLocale()
+        );
+    }
+
+    protected function currencyIso(): string
+    {
+        return $this->currencyIso ??= resolve_static(Currency::class, 'query')
+            ->where('is_default', true)
+            ->value('iso') ?? 'EUR';
+    }
+
+    protected function money(string|float|int|null $value): string
+    {
+        return Number::currency((float) $value, $this->currencyIso(), app()->getLocale());
+    }
+}

--- a/src/Livewire/Accounting/Loan.php
+++ b/src/Livewire/Accounting/Loan.php
@@ -101,6 +101,7 @@ class Loan extends Component
         ];
     }
 
+    #[Renderless]
     public function resetForm(): void
     {
         $loan = $this->loadLoan($this->loan->id);

--- a/src/Livewire/Accounting/Loan.php
+++ b/src/Livewire/Accounting/Loan.php
@@ -103,8 +103,10 @@ class Loan extends Component
 
     public function resetForm(): void
     {
+        $loan = $this->loadLoan($this->loan->id);
+
         $this->loan->reset();
-        $this->loan->fill($this->loadLoan($this->loan->id));
+        $this->loan->fill($loan);
     }
 
     #[Renderless]

--- a/src/Livewire/Accounting/Loans.php
+++ b/src/Livewire/Accounting/Loans.php
@@ -4,12 +4,9 @@ namespace FluxErp\Livewire\Accounting;
 
 use FluxErp\Actions\Loan\CreateLoan;
 use FluxErp\Actions\Loan\DeleteLoan;
-use FluxErp\Actions\Loan\UpdateLoan;
 use FluxErp\Livewire\DataTables\LoanList;
 use FluxErp\Livewire\Forms\LoanForm;
-use FluxErp\Livewire\Forms\MediaUploadForm;
 use FluxErp\Models\Loan;
-use FluxErp\Traits\Livewire\WithFileUploads;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
@@ -17,15 +14,9 @@ use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
 
 class Loans extends LoanList
 {
-    use WithFileUploads;
-
     public ?string $includeBefore = 'flux::livewire.accounting.loans';
 
     public LoanForm $loan;
-
-    public MediaUploadForm $contract;
-
-    public array $installments = [];
 
     protected function getTableActions(): array
     {
@@ -44,14 +35,6 @@ class Loans extends LoanList
     protected function getRowActions(): array
     {
         return [
-            DataTableButton::make()
-                ->text(__('Edit'))
-                ->icon('pencil')
-                ->color('indigo')
-                ->when(resolve_static(UpdateLoan::class, 'canPerformAction', [false]))
-                ->attributes([
-                    'wire:click' => 'edit(record.id)',
-                ]),
             DataTableButton::make()
                 ->text(__('Delete'))
                 ->icon('trash')
@@ -83,17 +66,9 @@ class Loans extends LoanList
     }
 
     #[Renderless]
-    public function edit(?Loan $loan = null): void
+    public function edit(): void
     {
         $this->loan->reset();
-        $this->contract->reset();
-        $this->installments = [];
-
-        if ($loan?->exists) {
-            $this->loan->fill($loan);
-            $this->contract->fill($loan->getFirstMedia('contract') ?? []);
-            $this->installments = $this->buildSchedule($loan);
-        }
 
         $this->modalOpen('edit-loan-modal');
     }
@@ -108,44 +83,8 @@ class Loans extends LoanList
             return false;
         }
 
-        $this->contract->model_type = morph_alias(Loan::class);
-        $this->contract->model_id = $this->loan->id;
-        $this->contract->collection_name = 'contract';
-
-        if ($this->contract->stagedFiles || $this->contract->id) {
-            try {
-                $this->contract->save();
-            } catch (ValidationException|UnauthorizedException $e) {
-                exception_to_notifications($e, $this);
-            }
-        }
-
-        $this->loadData();
+        $this->redirect(route('accounting.loans.id', ['id' => $this->loan->id]), navigate: true);
 
         return true;
-    }
-
-    /**
-     * The stored installments plus a running remaining balance for display.
-     */
-    protected function buildSchedule(Loan $loan): array
-    {
-        $remaining = $loan->amount;
-        $schedule = [];
-
-        foreach ($loan->installments()->orderBy('sequence')->get() as $installment) {
-            $remaining = bcsub($remaining, $installment->principal_amount, 2);
-
-            $schedule[] = [
-                'sequence' => $installment->sequence,
-                'due_date' => $installment->due_date->toDateString(),
-                'principal_amount' => $installment->principal_amount,
-                'interest_amount' => $installment->interest_amount,
-                'is_paid' => $installment->is_paid,
-                'remaining' => $remaining,
-            ];
-        }
-
-        return $schedule;
     }
 }

--- a/src/Livewire/DataTables/LoanList.php
+++ b/src/Livewire/DataTables/LoanList.php
@@ -25,18 +25,18 @@ class LoanList extends BaseDataTable
     public array $formatters = [
         'amount' => 'coloredMoney',
         'interest_rate' => 'percentage',
-        'progress' => 'progressPercentage',
         'remaining' => 'coloredMoney',
         'total_interest' => 'coloredMoney',
+        'progress' => 'progressPercentage',
         'starts_at' => 'date',
     ];
 
     public array $sortable = [
         'name',
         'amount',
-        'progress',
         'remaining',
         'total_interest',
+        'progress',
         'starts_at',
     ];
 

--- a/src/Livewire/DataTables/LoanList.php
+++ b/src/Livewire/DataTables/LoanList.php
@@ -9,15 +9,15 @@ class LoanList extends BaseDataTable
 {
     public array $columnLabels = [
         'contact.invoice_address.name' => 'Contact',
-        'remaining_principal' => 'Remaining',
     ];
 
     public array $enabledCols = [
         'name',
         'contact.invoice_address.name',
         'amount',
-        'remaining_principal',
+        'remaining',
         'total_interest',
+        'progress',
         'number_of_installments',
         'starts_at',
     ];
@@ -25,7 +25,8 @@ class LoanList extends BaseDataTable
     public array $formatters = [
         'amount' => 'coloredMoney',
         'interest_rate' => 'percentage',
-        'remaining_principal' => 'coloredMoney',
+        'progress' => 'progressPercentage',
+        'remaining' => 'coloredMoney',
         'total_interest' => 'coloredMoney',
         'starts_at' => 'date',
     ];
@@ -33,6 +34,9 @@ class LoanList extends BaseDataTable
     public array $sortable = [
         'name',
         'amount',
+        'progress',
+        'remaining',
+        'total_interest',
         'starts_at',
     ];
 
@@ -40,12 +44,6 @@ class LoanList extends BaseDataTable
 
     public function getBuilder(Builder $builder): Builder
     {
-        return $builder
-            ->with('contact.invoiceAddress:id,contact_id,name')
-            ->withSum(
-                ['installments as remaining_principal' => fn (Builder $query) => $query->where('is_paid', false)],
-                'principal_amount'
-            )
-            ->withSum('installments as total_interest', 'interest_amount');
+        return $builder->with('contact.invoiceAddress:id,contact_id,name');
     }
 }

--- a/src/Models/Loan.php
+++ b/src/Models/Loan.php
@@ -5,6 +5,7 @@ namespace FluxErp\Models;
 use FluxErp\Casts\Money;
 use FluxErp\Enums\RepaymentTypeEnum;
 use FluxErp\Traits\Model\Filterable;
+use FluxErp\Traits\Model\HasFrontendAttributes;
 use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasTenantAssignment;
 use FluxErp\Traits\Model\HasUserModification;
@@ -14,11 +15,14 @@ use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\MediaLibrary\HasMedia;
+use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
-class Loan extends FluxModel implements HasMedia
+class Loan extends FluxModel implements HasMedia, InteractsWithDataTables
 {
-    use Filterable, HasPackageFactory, HasTenantAssignment, HasUserModification, HasUuid, InteractsWithMedia,
-        SoftDeletes;
+    use Filterable, HasFrontendAttributes, HasPackageFactory, HasTenantAssignment, HasUserModification, HasUuid,
+        InteractsWithMedia, SoftDeletes;
+
+    protected ?string $detailRouteName = 'accounting.loans.id';
 
     protected function casts(): array
     {
@@ -52,6 +56,26 @@ class Loan extends FluxModel implements HasMedia
     public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class);
+    }
+
+    public function getAvatarUrl(): ?string
+    {
+        return null;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->number;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->detailRoute();
     }
 
     public function registerMediaCollections(): void

--- a/src/Models/Loan.php
+++ b/src/Models/Loan.php
@@ -11,7 +11,6 @@ use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\SoftDeletes;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\MediaLibrary\HasMedia;
@@ -27,6 +26,8 @@ class Loan extends FluxModel implements HasMedia
             'amount' => Money::class,
             'repayment_type_enum' => RepaymentTypeEnum::class,
             'installment_amount' => Money::class,
+            'remaining' => Money::class,
+            'total_interest' => Money::class,
             'starts_at' => 'date',
             'ends_at' => 'date',
         ];
@@ -60,17 +61,40 @@ class Loan extends FluxModel implements HasMedia
             ->singleFile();
     }
 
-    // Attributes
-    protected function remaining(): Attribute
+    // Public methods
+    /**
+     * The repaid share of the loan, between 0 and 1.
+     */
+    public function calculateProgress(): static
     {
-        return Attribute::get(
-            fn (): string => bcadd(
-                (string) $this->installments()
-                    ->where('is_paid', false)
-                    ->sum('principal_amount'),
-                '0',
-                2
-            )
+        $this->progress = bccomp((string) $this->amount, '0', 10) === 1
+            ? bcdiv(bcsub((string) $this->amount, (string) $this->remaining, 10), (string) $this->amount, 10)
+            : 0;
+
+        return $this;
+    }
+
+    public function calculateRemaining(): static
+    {
+        $this->remaining = bcround(
+            (string) $this->installments()->where('is_paid', false)->sum('principal_amount'),
+            2
         );
+
+        return $this;
+    }
+
+    /**
+     * The interest over the whole term. The schedule is locked once the loan
+     * exists, so this only moves when an installment is added or removed.
+     */
+    public function calculateTotalInterest(): static
+    {
+        $this->total_interest = bcround(
+            (string) $this->installments()->sum('interest_amount'),
+            2
+        );
+
+        return $this;
     }
 }

--- a/src/Models/Loan.php
+++ b/src/Models/Loan.php
@@ -58,6 +58,46 @@ class Loan extends FluxModel implements HasMedia, InteractsWithDataTables
         return $this->belongsTo(Order::class);
     }
 
+    // Public methods
+    /**
+     * The repaid share of the loan, between 0 and 1.
+     */
+    public function calculateProgress(): static
+    {
+        $this->progress = bccomp((string) $this->amount, '0', 10) === 1
+            ? bcdiv(bcsub((string) $this->amount, (string) $this->remaining, 10), (string) $this->amount, 10)
+            : 0;
+
+        return $this;
+    }
+
+    public function calculateRemaining(): static
+    {
+        $this->remaining = bcround(
+            (string) $this->installments()
+                ->where('is_paid', false)
+                ->sum('principal_amount'),
+            2
+        );
+
+        return $this;
+    }
+
+    /**
+     * The interest over the whole term. The schedule is locked once the loan
+     * exists, so this only moves when an installment is added or removed.
+     */
+    public function calculateTotalInterest(): static
+    {
+        $this->total_interest = bcround(
+            (string) $this->installments()
+                ->sum('interest_amount'),
+            2
+        );
+
+        return $this;
+    }
+
     public function getAvatarUrl(): ?string
     {
         return null;
@@ -83,42 +123,5 @@ class Loan extends FluxModel implements HasMedia, InteractsWithDataTables
         $this->addMediaCollection('contract')
             ->acceptsMimeTypes(['application/pdf', 'image/jpeg', 'image/png'])
             ->singleFile();
-    }
-
-    // Public methods
-    /**
-     * The repaid share of the loan, between 0 and 1.
-     */
-    public function calculateProgress(): static
-    {
-        $this->progress = bccomp((string) $this->amount, '0', 10) === 1
-            ? bcdiv(bcsub((string) $this->amount, (string) $this->remaining, 10), (string) $this->amount, 10)
-            : 0;
-
-        return $this;
-    }
-
-    public function calculateRemaining(): static
-    {
-        $this->remaining = bcround(
-            (string) $this->installments()->where('is_paid', false)->sum('principal_amount'),
-            2
-        );
-
-        return $this;
-    }
-
-    /**
-     * The interest over the whole term. The schedule is locked once the loan
-     * exists, so this only moves when an installment is added or removed.
-     */
-    public function calculateTotalInterest(): static
-    {
-        $this->total_interest = bcround(
-            (string) $this->installments()->sum('interest_amount'),
-            2
-        );
-
-        return $this;
     }
 }

--- a/src/Models/LoanInstallment.php
+++ b/src/Models/LoanInstallment.php
@@ -14,6 +14,25 @@ class LoanInstallment extends FluxModel
 {
     use Filterable, HasPackageFactory, HasUserModification, HasUuid, SoftDeletes;
 
+    protected static function booted(): void
+    {
+        static::saved(function (LoanInstallment $loanInstallment): void {
+            $loanInstallment->loan
+                ?->calculateRemaining()
+                ->calculateTotalInterest()
+                ->calculateProgress()
+                ->save();
+        });
+
+        static::deleted(function (LoanInstallment $loanInstallment): void {
+            $loanInstallment->loan
+                ?->calculateRemaining()
+                ->calculateTotalInterest()
+                ->calculateProgress()
+                ->save();
+        });
+    }
+
     protected function casts(): array
     {
         return [

--- a/src/Models/LoanInstallment.php
+++ b/src/Models/LoanInstallment.php
@@ -14,22 +14,31 @@ class LoanInstallment extends FluxModel
 {
     use Filterable, HasPackageFactory, HasUserModification, HasUuid, SoftDeletes;
 
+    /**
+     * The columns the loan key figures are calculated from. Moving an
+     * installment in time or in the order leaves them untouched.
+     */
+    protected const RECALCULATES_LOAN = [
+        'loan_id',
+        'principal_amount',
+        'interest_amount',
+        'is_paid',
+    ];
+
     protected static function booted(): void
     {
         static::saved(function (LoanInstallment $loanInstallment): void {
-            $loanInstallment->loan
-                ?->calculateRemaining()
-                ->calculateTotalInterest()
-                ->calculateProgress()
-                ->save();
+            if (! $loanInstallment->wasRecentlyCreated
+                && ! $loanInstallment->wasChanged(static::RECALCULATES_LOAN)
+            ) {
+                return;
+            }
+
+            $loanInstallment->recalculateLoan();
         });
 
         static::deleted(function (LoanInstallment $loanInstallment): void {
-            $loanInstallment->loan
-                ?->calculateRemaining()
-                ->calculateTotalInterest()
-                ->calculateProgress()
-                ->save();
+            $loanInstallment->recalculateLoan();
         });
     }
 
@@ -47,5 +56,15 @@ class LoanInstallment extends FluxModel
     public function loan(): BelongsTo
     {
         return $this->belongsTo(Loan::class);
+    }
+
+    // Public methods
+    public function recalculateLoan(): void
+    {
+        $this->loan
+            ?->calculateRemaining()
+            ->calculateTotalInterest()
+            ->calculateProgress()
+            ->save();
     }
 }

--- a/tests/Feature/Actions/Loan/LoanActionTest.php
+++ b/tests/Feature/Actions/Loan/LoanActionTest.php
@@ -30,11 +30,24 @@ function baseLoanData(array $overrides = []): array
     ], $overrides);
 }
 
+test('create loan persists the remaining principal and the total interest', function (): void {
+    $loan = CreateLoan::make(baseLoanData())->validate()->execute();
+
+    $this->assertDatabaseHas('loans', [
+        'id' => $loan->getKey(),
+        'remaining' => 12000,
+    ]);
+
+    expect($loan->refresh()->total_interest)
+        ->toEqual($loan->installments()->sum('interest_amount'))
+        ->and((float) $loan->total_interest)->toBeGreaterThan(0);
+});
+
 test('create loan generates the full repayment schedule', function (): void {
     $loan = CreateLoan::make(baseLoanData())->validate()->execute();
 
     expect($loan->installments()->count())->toBe(12);
-    expect($loan->remaining)->toBe('12000.00');
+    expect($loan->remaining)->toEqual(12000);
     expect($loan->ends_at->toDateString())->toBe('2027-01-01');
 
     $this->assertDatabaseCount('loan_installments', 12);
@@ -54,11 +67,14 @@ test('create loan rejects a foreign tenant contact', function (): void {
 test('remaining drops after an installment is settled', function (): void {
     $loan = CreateLoan::make(baseLoanData(['interest_rate' => 0]))->validate()->execute();
 
-    expect($loan->remaining)->toBe('12000.00');
+    expect($loan->remaining)->toEqual(12000)
+        ->and((float) $loan->progress)->toEqual(0.0);
 
     $loan->installments()->orderBy('sequence')->first()->update(['is_paid' => true]);
 
-    expect($loan->refresh()->remaining)->toBe('11000.00');
+    // one of twelve installments repaid
+    expect($loan->refresh()->remaining)->toEqual(11000)
+        ->and(round((float) $loan->progress, 4))->toEqual(0.0833);
 });
 
 test('update loan', function (): void {
@@ -107,4 +123,18 @@ test('delete loan soft deletes', function (): void {
     DeleteLoan::make(['id' => $loan->getKey()])->validate()->execute();
 
     $this->assertSoftDeleted('loans', ['id' => $loan->getKey()]);
+});
+
+test('deleting an installment updates every derived column', function (): void {
+    $loan = CreateLoan::make(baseLoanData(['number_of_installments' => 2, 'interest_rate' => 0.12]))
+        ->validate()
+        ->execute();
+
+    $lastInstallment = $loan->installments()->orderByDesc('sequence')->first();
+    $expectedInterest = bcsub((string) $loan->total_interest, (string) $lastInstallment->interest_amount, 2);
+
+    $lastInstallment->delete();
+
+    expect($loan->refresh()->total_interest)->toEqual($expectedInterest)
+        ->and($loan->remaining)->toEqual($loan->installments()->sum('principal_amount'));
 });

--- a/tests/Livewire/Accounting/LoanTest.php
+++ b/tests/Livewire/Accounting/LoanTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use FluxErp\Livewire\Accounting\Loan;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\Loan as LoanModel;
+use Illuminate\Http\UploadedFile;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    // the amounts are asserted with two decimals, so the currency must not be a
+    // random one from the factory
+    Currency::query()->update(['is_default' => false]);
+    ($euro = Currency::query()->firstWhere('iso', 'EUR'))
+        ? $euro->update(['is_default' => true])
+        : Currency::factory()->create(['iso' => 'EUR', 'name' => 'Euro', 'is_default' => true]);
+
+    $this->contact = Contact::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+    $this->ledgerAccount = LedgerAccount::factory()->create(['tenant_id' => $this->dbTenant->getKey()]);
+    $this->loan = LoanModel::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => $this->contact->getKey(),
+        'ledger_account_id' => $this->ledgerAccount->getKey(),
+        'name' => 'Machine financing',
+        'amount' => 12000,
+        'interest_rate' => 0.02299,
+        'number_of_installments' => 2,
+    ]);
+    $this->loan->installments()->create([
+        'sequence' => 1,
+        'due_date' => '2026-02-01',
+        'principal_amount' => 6000,
+        'interest_amount' => 60,
+    ]);
+    $this->loan->installments()->create([
+        'sequence' => 2,
+        'due_date' => '2026-03-01',
+        'principal_amount' => 6000,
+        'interest_amount' => 30,
+    ]);
+});
+
+test('renders successfully', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->assertOk()
+        ->assertSet('loan.id', $this->loan->getKey())
+        ->assertCount('installments', 2)
+        // stored as a factor, shown as a percentage
+        ->assertSet('loan.interest_rate', 2.299);
+});
+
+test('every tab renders', function (string $tab): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('tab', $tab)
+        ->assertOk()
+        ->assertNoRedirect();
+})->with(['loan.general', 'loan.installments', 'loan.documents']);
+
+test('the schedule tab formats amounts and dates for the locale', function (): void {
+    app()->setLocale('de');
+
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('tab', 'loan.installments')
+        ->assertOk()
+        ->assertSee('01.02.2026')
+        ->assertSee('6.000,00')
+        ->assertSet('totals.principal_amount', fn (string $value) => str_contains($value, '12.000,00'))
+        ->assertSet('totals.interest_amount', fn (string $value) => str_contains($value, '90,00'))
+        ->assertSet('totals.total', fn (string $value) => str_contains($value, '12.090,00'));
+});
+
+test('the totals show how much of the loan is settled', function (): void {
+    app()->setLocale('de');
+
+    $this->loan->installments()->orderBy('sequence')->first()->update(['is_paid' => true]);
+
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->assertOk()
+        ->assertSet('totals.paid_principal_amount', fn (string $value) => str_contains($value, '6.000,00'))
+        ->assertSet('totals.paid_interest_amount', fn (string $value) => str_contains($value, '60,00'))
+        ->assertSet('totals.paid_total', fn (string $value) => str_contains($value, '6.060,00'))
+        ->assertSet('totals.paid_principal_share', fn (string $value) => str_contains($value, '50'))
+        ->assertSet('totals.paid_total_share', fn (string $value) => str_contains($value, '50,1'));
+});
+
+test('an unknown loan is not found', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey() + 1]);
+})->throws(Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+test('can save the loan', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('loan.name', 'Renamed loan')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('loans', [
+        'id' => $this->loan->getKey(),
+        'name' => 'Renamed loan',
+    ]);
+});
+
+test('can attach a contract', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('contract.file', [UploadedFile::fake()->image('contract.jpg')])
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($this->loan->refresh()->getMedia('contract'))->toHaveCount(1);
+});
+
+test('can delete the loan', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->call('delete')
+        ->assertOk()
+        ->assertRedirect(route('accounting.loans'));
+
+    $this->assertSoftDeleted('loans', ['id' => $this->loan->getKey()]);
+});

--- a/tests/Livewire/Accounting/LoanTest.php
+++ b/tests/Livewire/Accounting/LoanTest.php
@@ -6,6 +6,7 @@ use FluxErp\Models\Currency;
 use FluxErp\Models\LedgerAccount;
 use FluxErp\Models\Loan as LoanModel;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -106,11 +107,38 @@ test('can save the loan', function (): void {
 test('can attach a contract', function (): void {
     Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
         ->set('contract.file', [UploadedFile::fake()->image('contract.jpg')])
-        ->call('save')
+        ->call('saveContract')
         ->assertOk()
         ->assertHasNoErrors();
 
     expect($this->loan->refresh()->getMedia('contract'))->toHaveCount(1);
+});
+
+test('saving the loan leaves the contract untouched', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('loan.name', 'Renamed loan')
+        ->call('save')
+        ->assertOk()
+        ->assertHasNoErrors();
+
+    expect($this->loan->refresh()->getMedia('contract'))->toHaveCount(0);
+});
+
+test('moving an installment in time does not touch the loan', function (): void {
+    $installment = $this->loan->installments()->orderBy('sequence')->first();
+
+    // a recalculation would write the loan and move its timestamp
+    DB::table('loans')->where('id', $this->loan->getKey())->update(['updated_at' => '2020-01-01 00:00:00']);
+
+    $installment->update(['due_date' => '2026-04-01', 'sequence' => 7]);
+
+    expect(DB::table('loans')->where('id', $this->loan->getKey())->value('updated_at'))
+        ->toBe('2020-01-01 00:00:00');
+
+    $installment->update(['is_paid' => true]);
+
+    expect(DB::table('loans')->where('id', $this->loan->getKey())->value('updated_at'))
+        ->not->toBe('2020-01-01 00:00:00');
 });
 
 test('can delete the loan', function (): void {

--- a/tests/Livewire/Accounting/LoanTest.php
+++ b/tests/Livewire/Accounting/LoanTest.php
@@ -141,6 +141,15 @@ test('moving an installment in time does not touch the loan', function (): void 
         ->not->toBe('2020-01-01 00:00:00');
 });
 
+test('resetting the form restores the stored values', function (): void {
+    Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
+        ->set('loan.name', 'Discarded')
+        ->call('resetForm')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('loan.name', 'Machine financing');
+});
+
 test('can delete the loan', function (): void {
     Livewire::test(Loan::class, ['id' => $this->loan->getKey()])
         ->call('delete')

--- a/tests/Livewire/Accounting/LoansTest.php
+++ b/tests/Livewire/Accounting/LoansTest.php
@@ -5,7 +5,6 @@ use FluxErp\Livewire\Accounting\Loans;
 use FluxErp\Models\Contact;
 use FluxErp\Models\LedgerAccount;
 use FluxErp\Models\Loan;
-use Illuminate\Http\UploadedFile;
 use Livewire\Livewire;
 
 beforeEach(function (): void {
@@ -26,7 +25,6 @@ test('edit with null resets form and opens modal', function (): void {
         ->assertOk()
         ->assertHasNoErrors()
         ->assertSet('loan.id', null)
-        ->assertSet('installments', [])
         ->assertOpensModal('edit-loan-modal');
 });
 
@@ -43,7 +41,10 @@ test('can create a loan with its schedule', function (): void {
         ->set('loan.starts_at', '2026-01-01')
         ->call('save')
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertRedirect(
+            route('accounting.loans.id', ['id' => Loan::query()->value('id')])
+        );
 
     $this->assertDatabaseHas('loans', [
         'name' => 'Machine financing',
@@ -71,48 +72,6 @@ test('a tiny interest rate does not reach bcmath in scientific notation', functi
         'name' => 'Almost free money',
         'interest_rate' => 0.0000001,
     ]);
-});
-
-test('edit shows the interest rate as a percentage', function (): void {
-    $loan = Loan::factory()->create([
-        'tenant_id' => $this->dbTenant->getKey(),
-        'contact_id' => $this->contact->getKey(),
-        'ledger_account_id' => $this->ledgerAccount->getKey(),
-        'interest_rate' => 0.02299,
-    ]);
-
-    Livewire::test(Loans::class)
-        ->call('edit', $loan->getKey())
-        ->assertOk()
-        ->assertSet('loan.interest_rate', 2.299);
-});
-
-test('edit populates the schedule for an existing loan', function (): void {
-    $loan = Loan::factory()->create([
-        'tenant_id' => $this->dbTenant->getKey(),
-        'contact_id' => $this->contact->getKey(),
-        'ledger_account_id' => $this->ledgerAccount->getKey(),
-        'amount' => 12000,
-        'number_of_installments' => 2,
-    ]);
-    $loan->installments()->create([
-        'sequence' => 1,
-        'due_date' => '2026-02-01',
-        'principal_amount' => 6000,
-        'interest_amount' => 0,
-    ]);
-    $loan->installments()->create([
-        'sequence' => 2,
-        'due_date' => '2026-03-01',
-        'principal_amount' => 6000,
-        'interest_amount' => 0,
-    ]);
-
-    Livewire::test(Loans::class)
-        ->call('edit', $loan->getKey())
-        ->assertOk()
-        ->assertSet('loan.id', $loan->getKey())
-        ->assertCount('installments', 2);
 });
 
 test('the list sums the total interest over the whole term', function (): void {
@@ -149,26 +108,6 @@ test('the list sums the total interest over the whole term', function (): void {
     expect(data_get($data, 'data.0.total_interest.raw'))->toEqual(90)
         ->and(data_get($data, 'data.0.total_interest.display'))->toContain('text-green-600')
         ->and(data_get($data, 'data.0.remaining.raw'))->toEqual(6000);
-});
-
-test('can attach a contract to a loan', function (): void {
-    $loan = Loan::factory()->create([
-        'tenant_id' => $this->dbTenant->getKey(),
-        'contact_id' => $this->contact->getKey(),
-        'ledger_account_id' => $this->ledgerAccount->getKey(),
-    ]);
-
-    Livewire::test(Loans::class)
-        ->call('edit', $loan->getKey())
-        ->set('contract.file', [UploadedFile::fake()->image('contract.jpg')])
-        ->call('save')
-        ->assertOk()
-        ->assertHasNoErrors();
-
-    $media = $loan->refresh()->getMedia('contract');
-
-    expect($media)->toHaveCount(1)
-        ->and($media->first()->file_name)->toBe('contract.jpg');
 });
 
 test('can delete a loan', function (): void {

--- a/tests/Livewire/Accounting/LoansTest.php
+++ b/tests/Livewire/Accounting/LoansTest.php
@@ -137,6 +137,9 @@ test('the list sums the total interest over the whole term', function (): void {
         'is_paid' => true,
     ]);
 
+    // the schedule was created without the action, so the loan has to catch up once
+    $loan->calculateTotalInterest()->save();
+
     $data = Livewire::test(Loans::class)
         ->call('loadData')
         ->assertOk()
@@ -145,7 +148,7 @@ test('the list sums the total interest over the whole term', function (): void {
 
     expect(data_get($data, 'data.0.total_interest.raw'))->toEqual(90)
         ->and(data_get($data, 'data.0.total_interest.display'))->toContain('text-green-600')
-        ->and(data_get($data, 'data.0.remaining_principal.raw'))->toEqual(6000);
+        ->and(data_get($data, 'data.0.remaining.raw'))->toEqual(6000);
 });
 
 test('can attach a contract to a loan', function (): void {


### PR DESCRIPTION
Groundwork for linking loan installments to real payments. Two steps, one commit each.

## Key figures as columns

The remaining principal was an accessor and the total interest an aggregate in the list, so neither could be sorted, filtered or summed in a data table. Both are columns on `loans` now, together with `progress`, the repaid share, calculated the way `projects.progress` is.

`Loan::calculateRemaining()`, `calculateTotalInterest()` and `calculateProgress()` follow the `Order::calculateBalance()` pattern and are triggered from `CreateLoan` and from the `saved` and `deleted` hooks of `LoanInstallment`. The migration backfills existing loans.

## Detail page

The modal had to hold master data, the repayment schedule and the contract at once. Loans now have their own page at `accounting/loans/{id}` with three tabs, mirroring `Livewire\Project\Project`:

- **General** with the master data, the schedule relevant fields visible but locked
- **Repayment Schedule** with the installments, amounts and dates formatted for the current locale, plus a summary of principal, interest and total, each with the share that is already settled
- **Documents** with the contract

`Loan` implements `InteractsWithDataTables` and carries a `detailRouteName`, so the list rows link to the page. The edit row action is gone, delete stays and is gated by the action permission. Creating a loan keeps the modal, because amount, interest rate, repayment type, number of installments and start date are locked once the schedule exists, and redirects to the new page afterwards.

## Next

Assigning bank transactions to installments builds on this page, in a separate pull request.

## Summary by Sourcery

Persist loan key figures and introduce a dedicated loan detail view with tabs for general data, repayment schedule, and documents.

New Features:
- Add a loan detail page with tabbed sections for general information, repayment schedule, and documents.
- Introduce localized, formatted repayment schedule summaries including principal, interest, totals, and paid shares.
- Allow attaching and managing loan contract documents from the loan detail page.

Enhancements:
- Persist remaining principal, total interest, and progress on loans and expose them as sortable, formatted data table columns.
- Wire loans into the generic DataTable detail routing, including basic frontend attributes and labels.
- Redirect loan creation from the modal to the new detail page and streamline the list actions to focus on delete.

Tests:
- Add coverage for loan detail Livewire component behavior, including tabs, schedule formatting, totals, saving, contracts, and deletion.
- Extend action and Livewire tests to assert persisted key figures, progress updates, redirects, and installment-driven recalculations.