### PR TITLE
Allow editing a single payment reminder mail before sending

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2789,6 +2789,7 @@
     "This is a test notification to verify that web push notifications are working correctly.": "Dies ist eine Testbenachrichtigung, um zu überprüfen, ob Web-Push-Benachrichtigungen korrekt funktionieren.",
     "This Month": "Dieser Monat",
     "This operation is not allowed.": "Diese Operation ist nicht erlaubt.",
+    "This order can no longer be reminded.": "Dieser Auftrag kann nicht mehr gemahnt werden.",
     "This page is only available inside the Nuxbe mobile app.": "Diese Seite ist nur in der Nuxbe App verfügbar.",
     "This password reset link will expire in :count minutes.": "Dieser Link zum Zurücksetzen des Passworts läuft in :count Minuten ab.",
     "This Quarter": "Dieses Quartal",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1044,6 +1044,7 @@
     "Edit Folders": "Ordner bearbeiten",
     "Edit Language": "Sprache bearbeiten",
     "Edit Mail Account": "E-Mail Konto bearbeiten",
+    "Edit mail and send": "Mail bearbeiten und senden",
     "Edit permissions": "Berechtigungen bearbeiten",
     "Edit Price List": "Preisliste bearbeiten",
     "Edit Printer": "Drucker bearbeiten",

--- a/resources/views/livewire/accounting/payment-reminder-run.blade.php
+++ b/resources/views/livewire/accounting/payment-reminder-run.blade.php
@@ -215,6 +215,15 @@
                                             loading="preview({{ $order['id'] }})"
                                             wire:click="preview({{ $order['id'] }})"
                                         />
+                                        <x-button
+                                            icon="pencil-square"
+                                            color="secondary"
+                                            size="sm"
+                                            flat
+                                            :title="__('Edit mail and send')"
+                                            loading="editMail({{ $order['id'] }})"
+                                            wire:click="editMail({{ $order['id'] }})"
+                                        />
                                     </div>
                                 @endforeach
                             </div>
@@ -237,4 +246,6 @@
             ></iframe>
         @endif
     </x-modal>
+
+    {{ $this->renderCreateDocumentsModal() }}
 </div>

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -4,23 +4,28 @@ namespace FluxErp\Livewire\Accounting;
 
 use Carbon\Carbon;
 use FluxErp\Actions\PaymentReminder\BundlePaymentReminders;
+use FluxErp\Actions\PaymentReminder\CreatePaymentReminder;
+use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentReminder;
 use FluxErp\Traits\Livewire\Actions;
+use FluxErp\Traits\Livewire\CreatesDocuments;
 use FluxErp\View\Printing\PaymentReminder\PaymentReminderView;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
+use Laravel\SerializableClosure\SerializableClosure;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
+use Livewire\Attributes\Renderless;
 use Livewire\Component;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Throwable;
 
 class PaymentReminderRun extends Component
 {
-    use Actions;
+    use Actions, CreatesDocuments;
 
     #[Locked]
     public array $groups = [];
@@ -51,6 +56,14 @@ class PaymentReminderRun extends Component
     public ?string $previewSrc = null;
 
     public bool $showPreview = false;
+
+    /**
+     * The invoice currently being mailed one by one. Editing the mail text before
+     * it goes out only works for a single reminder, never for the bulk run, so the
+     * mail dialog always operates on exactly this order.
+     */
+    #[Locked]
+    public ?int $documentOrderId = null;
 
     public function mount(): void
     {
@@ -200,6 +213,58 @@ class PaymentReminderRun extends Component
         }
     }
 
+    /**
+     * Opens the mail dialog for one invoice so the user can adjust the text before
+     * sending. Deliberately single invoice only: the bulk run sends one mail per
+     * invoice without user interaction, which leaves nothing to edit.
+     */
+    #[Renderless]
+    public function editMail(int $orderId): void
+    {
+        try {
+            resolve_static(CreatePaymentReminder::class, 'canPerformAction', [true]);
+        } catch (UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->documentOrderId = $orderId;
+
+        $this->openCreateDocumentsModal();
+    }
+
+    public function createDocuments(): void
+    {
+        $order = resolve_static(Order::class, 'query')
+            ->whereKey($this->documentOrderId)
+            ->wherePaymentReminderEligible()
+            ->first();
+
+        if (! $order) {
+            return;
+        }
+
+        try {
+            $reminder = CreatePaymentReminder::make([
+                'order_id' => $order->getKey(),
+                'reminder_level' => (int) $order->payment_reminder_current_level + 1,
+            ])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (ValidationException|UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->createDocumentFromItems($reminder);
+
+        $this->markAsSent([$order->getKey()]);
+        $this->loadData();
+    }
+
     public function sendGroup(string $key): void
     {
         $group = collect($this->groups)->firstWhere('key', $key);
@@ -245,6 +310,69 @@ class PaymentReminderRun extends Component
         $this->selectedOrders = $allSelected
             ? array_values(array_diff($this->selectedOrders, $groupIds))
             : array_values(array_unique(array_merge($this->selectedOrders, $groupIds)));
+    }
+
+    protected function getAttachments(OffersPrinting $item): array
+    {
+        $invoice = $item->order->invoice();
+
+        return $invoice
+            ? ['id' => $invoice->getKey(), 'name' => $invoice->file_name]
+            : [];
+    }
+
+    protected function getBladeParameters(OffersPrinting $item): array|SerializableClosure|null
+    {
+        $reminderId = $item->getKey();
+
+        return new SerializableClosure(
+            fn (): array => [
+                'paymentReminder' => resolve_static(PaymentReminder::class, 'query')
+                    ->whereKey($reminderId)
+                    ->first(),
+            ]
+        );
+    }
+
+    protected function getCommunicatableId(OffersPrinting $item): int
+    {
+        return $item->order_id;
+    }
+
+    protected function getCommunicatableType(OffersPrinting $item): string
+    {
+        return app(Order::class)->getMorphClass();
+    }
+
+    protected function getDefaultTemplateId(OffersPrinting $item): ?int
+    {
+        return $item->getPaymentReminderText()?->email_template_id;
+    }
+
+    protected function getPreferredLanguageId(OffersPrinting $item): ?int
+    {
+        return $item->order->language_id;
+    }
+
+    protected function getPrintLayouts(): array
+    {
+        return app(PaymentReminder::class)->resolvePrintViews();
+    }
+
+    protected function getSubject(OffersPrinting $item, array $documents): ?string
+    {
+        return $item->getPaymentReminderText()?->reminder_subject
+            ?? __('Reminder Level') . ' ' . $item->reminder_level;
+    }
+
+    /** The group recipient stays editable, so it wins over the resolved address. */
+    protected function getTo(OffersPrinting $item, array $documents): array
+    {
+        $groupKey = $item->order->contact_id . '-' . $item->reminder_level;
+        $email = data_get($this->recipientEmails, $groupKey)
+            ?: $item->order->resolveMailablePaymentReminderAddress()?->email_primary;
+
+        return array_filter([$email]);
     }
 
     protected function markAsSent(array $orderIds): void

--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -13,6 +13,7 @@ use FluxErp\Traits\Livewire\CreatesDocuments;
 use FluxErp\View\Printing\PaymentReminder\PaymentReminderView;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -242,6 +243,10 @@ class PaymentReminderRun extends Component
             ->first();
 
         if (! $order) {
+            $this->toast()
+                ->warning(__('This order can no longer be reminded.'))
+                ->send();
+
             return;
         }
 
@@ -317,7 +322,10 @@ class PaymentReminderRun extends Component
         $invoice = $item->order->invoice();
 
         return $invoice
-            ? ['id' => $invoice->getKey(), 'name' => $invoice->file_name]
+            ? [
+                'id' => $invoice->getKey(),
+                'name' => $invoice->file_name,
+            ]
             : [];
     }
 
@@ -341,7 +349,7 @@ class PaymentReminderRun extends Component
 
     protected function getCommunicatableType(OffersPrinting $item): string
     {
-        return app(Order::class)->getMorphClass();
+        return morph_alias(Order::class);
     }
 
     protected function getDefaultTemplateId(OffersPrinting $item): ?int
@@ -372,7 +380,7 @@ class PaymentReminderRun extends Component
         $email = data_get($this->recipientEmails, $groupKey)
             ?: $item->order->resolveMailablePaymentReminderAddress()?->email_primary;
 
-        return array_filter([$email]);
+        return array_filter(Arr::wrap($email));
     }
 
     protected function markAsSent(array $orderIds): void

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Livewire\Accounting\PaymentReminderRun;
+use FluxErp\Livewire\EditMail;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
@@ -280,4 +281,74 @@ test('the reminder mail defaults to the template of the reminder level', functio
                 && $messages[0]['default_template_id'] === $emailTemplate->getKey()
                 && $messages[0]['to'] === ['reminder@example.com'];
         });
+});
+
+test('the mail dialog shows the rendered reminder text instead of the placeholders', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => false,
+        ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-205',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update([
+        'balance' => 250,
+        'payment_state' => 'open',
+        'payment_reminder_next_date' => now()->subDays(5)->toDateString(),
+    ]);
+
+    // Mirrors how the editor stores a variable in a real reminder template.
+    $emailTemplate = EmailTemplate::factory()->create([
+        'html_body' => '<p>Rechnung <span data-type="blade-variable" '
+            . 'data-value="$paymentReminder-&gt;order-&gt;invoice_number">Rechnungsnummer</span></p>',
+    ]);
+    PaymentReminderText::factory()->create([
+        'reminder_level' => 1,
+        'email_template_id' => $emailTemplate->getKey(),
+    ]);
+
+    $sessionKey = null;
+
+    Livewire::actingAs($this->user)
+        ->test(PaymentReminderRun::class)
+        ->call('editMail', $order->getKey())
+        ->set('selectedPrintLayouts.email', ['payment-reminder'])
+        ->call('createDocuments')
+        ->assertDispatched('createFromSession', function (string $event, array $params) use (&$sessionKey): bool {
+            $sessionKey = $params['key'];
+
+            return true;
+        });
+
+    // The user has to see the finished text, not the raw placeholder markup.
+    Livewire::actingAs($this->user)
+        ->test(EditMail::class)
+        ->call('createFromSession', $sessionKey)
+        ->assertSet('mailMessage.html_body', fn (?string $body): bool => str_contains($body ?? '', 'INV-2026-205')
+            && ! str_contains($body ?? '', 'blade-variable')
+        );
 });

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -5,8 +5,11 @@ use FluxErp\Livewire\Accounting\PaymentReminderRun;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
+use FluxErp\Models\EmailTemplate;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentReminder;
+use FluxErp\Models\PaymentReminderText;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 use Livewire\Livewire;
@@ -159,4 +162,122 @@ test('sent orders disappear from the list without a manual reload', function ():
         ->call('sendSelected')
         ->assertSet('groups', fn (array $groups) => $groups === [])
         ->assertSet('selectedOrders', []);
+});
+
+test('a single invoice can be edited as a mail before it is sent', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => false,
+        ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-203',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update([
+        'balance' => 250,
+        'payment_state' => 'open',
+        'payment_reminder_next_date' => now()->subDays(5)->toDateString(),
+    ]);
+
+    $emailTemplate = EmailTemplate::factory()->create();
+    PaymentReminderText::factory()->create([
+        'reminder_level' => 1,
+        'email_template_id' => $emailTemplate->getKey(),
+    ]);
+
+    // The mail dialog is the whole point: the user edits the text before sending,
+    // which only works for a single invoice, never for the bulk run.
+    Livewire::actingAs($this->user)
+        ->test(PaymentReminderRun::class)
+        ->call('editMail', $order->getKey())
+        ->assertSet('documentOrderId', $order->getKey())
+        ->set('selectedPrintLayouts.email', ['payment-reminder'])
+        ->call('createDocuments')
+        ->assertHasNoErrors()
+        ->assertDispatched('createFromSession');
+
+    expect(PaymentReminder::query()->where('order_id', $order->getKey())->count())->toBe(1)
+        ->and(PaymentReminder::query()->where('order_id', $order->getKey())->value('reminder_level'))
+        ->toBe(1);
+});
+
+test('the reminder mail defaults to the template of the reminder level', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create([
+            'is_direct_debit' => false,
+        ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-204',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update([
+        'balance' => 250,
+        'payment_state' => 'open',
+        'payment_reminder_next_date' => now()->subDays(5)->toDateString(),
+    ]);
+
+    $emailTemplate = EmailTemplate::factory()->create();
+    PaymentReminderText::factory()->create([
+        'reminder_level' => 1,
+        'email_template_id' => $emailTemplate->getKey(),
+    ]);
+
+    Livewire::actingAs($this->user)
+        ->test(PaymentReminderRun::class)
+        ->call('editMail', $order->getKey())
+        ->set('selectedPrintLayouts.email', ['payment-reminder'])
+        ->call('createDocuments')
+        ->assertDispatched('createFromSession', function (string $event, array $params) use ($emailTemplate): bool {
+            $messages = session()->get($params['key']);
+
+            return count($messages) === 1
+                && $messages[0]['default_template_id'] === $emailTemplate->getKey()
+                && $messages[0]['to'] === ['reminder@example.com'];
+        });
 });


### PR DESCRIPTION
## Problem

The reminder run only offers the bulk send, which mails every selected invoice without user interaction. The screen it replaced was built on the mail dialog, so the user could adjust the reminder text per customer before it went out. That option was lost, and there is currently no way to send a reminder with an individually written text.

## Change

- `PaymentReminderRun` uses `CreatesDocuments`, the same path `OrderList` and `Order` already use for their mails.
- A per invoice action opens the create documents modal, creates the payment reminder for the next level and hands it to the mail dialog.
- The reminder text of the matching level supplies the default email template and the subject, the invoice PDF is attached next to the reminder document, and the editable group recipient wins over the resolved address.
- Only the invoice that was actually handed over is marked as sent, the bulk run is untouched and keeps using the queued batch.

Editing a mail before sending only makes sense for a single reminder, so the action is deliberately limited to one invoice.

## Tests

`PaymentReminderRunTest`:
- a single invoice can be edited as a mail before it is sent (dispatches `createFromSession`, creates exactly one reminder at the next level)
- the reminder mail defaults to the template of the reminder level (asserts `default_template_id` and recipient in the session payload)

## Summary by Sourcery

Allow sending individual payment reminder emails via the mail dialog for a single invoice while keeping the existing bulk reminder run unchanged.

New Features:
- Add per-invoice action to open the create-documents mail dialog for a single payment reminder with editable content before sending.

Enhancements:
- Integrate PaymentReminderRun with the shared CreatesDocuments flow to generate reminder documents, attach invoices, and prefill email metadata (subject, template, recipients, language).

Tests:
- Add Livewire tests ensuring a single invoice can be mailed via the edit flow and that the reminder email defaults to the correct template and recipient based on the reminder level.