### PR TITLE
Make categories media capable

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -10,6 +10,7 @@ use FluxErp\Traits\Model\HasPackageFactory;
 use FluxErp\Traits\Model\HasParentChildRelations;
 use FluxErp\Traits\Model\HasUserModification;
 use FluxErp\Traits\Model\HasUuid;
+use FluxErp\Traits\Model\InteractsWithMedia;
 use FluxErp\Traits\Model\LogsActivity;
 use FluxErp\Traits\Model\SortableTrait;
 use FluxErp\Traits\Scout\Searchable;
@@ -19,12 +20,19 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Spatie\EloquentSortable\Sortable;
+use Spatie\MediaLibrary\HasMedia;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
-class Category extends FluxModel implements InteractsWithDataTables, Sortable
+/**
+ * Categories carry images in every shop-facing project (a banner, a tile, a
+ * teaser). Media has to sit on this class and not on a bound subclass: the media
+ * library builds the owner from the morph map with `new $modelName`, so it always
+ * lands on the base model and would miss a trait a subclass added.
+ */
+class Category extends FluxModel implements HasMedia, InteractsWithDataTables, Sortable
 {
     use Filterable, HasAttributeTranslations, HasPackageFactory, HasParentChildRelations, HasUserModification, HasUuid,
-        LogsActivity, SortableTrait;
+        InteractsWithMedia, LogsActivity, SortableTrait;
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
     }

--- a/tests/Feature/Customization/ModelTest.php
+++ b/tests/Feature/Customization/ModelTest.php
@@ -1,10 +1,14 @@
 <?php
 
+use FluxErp\Models\Category;
 use FluxErp\Models\Comment;
 use FluxErp\Models\Language;
+use FluxErp\Models\Product;
 use FluxErp\Models\Ticket;
 use FluxErp\Models\User;
 use FluxErp\Traits\Model\HasParentMorphClass;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 test('model customization', function (): void {
     $class = new class() extends Language
@@ -65,4 +69,34 @@ test('model morph to eager relation', function (): void {
         ]);
 
     expect($comment->model)->toBeInstanceOf(get_class($class));
+});
+
+test('media can be added to a category through a bound subclass', function (): void {
+    // The media library builds the conversion owner with `new $modelName` off the
+    // morph map, so the base model has to be media capable. A subclass adding the
+    // trait is never seen there.
+    $class = new class() extends Category
+    {
+        use HasParentMorphClass;
+
+        protected $table = 'categories';
+
+        public function registerMediaCollections(): void
+        {
+            $this->addMediaCollection('banner')->singleFile();
+        }
+    };
+    $this->app->bind(Category::class, get_class($class));
+
+    Storage::fake('public');
+
+    $category = resolve_static(Category::class, 'query')->create([
+        'name' => 'Tea',
+        'model_type' => morph_alias(Product::class),
+    ]);
+
+    $category->addMedia(UploadedFile::fake()->image('banner.jpg'))
+        ->toMediaCollection('banner');
+
+    expect($category->getMedia('banner')->first()->file_name)->toBe('banner.jpg');
 });


### PR DESCRIPTION
Every shop-facing project puts an image on a category (a banner, a tile, a teaser) and had nowhere to keep it.

The trait has to sit on `FluxErp\\Models\\Category` rather than on a project's bound subclass: `ConversionCollection::addConversionsFromRelatedModel()` builds the conversion owner from the morph map with `new $modelName`, which always yields the base model, so a subclass adding the trait dies with `Call to undefined method FluxErp\\Models\\Category::registerAllMediaConversions()` the moment a file is attached.

The added test attaches a file to a category through a bound subclass and fails on exactly that without the change.

## Summary by Sourcery

Make categories directly support media attachments so media conversions work when using bound subclasses.

New Features:
- Allow Category models to act as media library owners by implementing the media interface and trait.

Tests:
- Add a feature test ensuring media can be attached to a category via a bound subclass using the parent morph class setup.