### PR TITLE
Tell the user why an upload was rejected

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2768,6 +2768,8 @@
     "The debit and credit account must differ.": "Sollkonto und Habenkonto müssen sich unterscheiden.",
     "The default mail account must be one of the selected mail accounts.": "Das Standard-Mailkonto muss eines der ausgewählten Mailkonten sein.",
     "The employee is already assigned to this work time model": "Der Mitarbeiter ist bereits diesem Arbeitszeitmodell zugewiesen",
+    "The file :name is :size. The maximum upload size is :max.": "Die Datei :name ist :size groß. Die maximale Uploadgröße beträgt :max.",
+    "The file type of :name is not accepted. Allowed types: :types.": "Der Dateityp von :name wird nicht akzeptiert. Erlaubte Typen: :types.",
     "The given columns must be unique.": "Jede Spalte darf nur einmal angegeben werden.",
     "The given data was invalid.": "Die übermittelten Daten waren ungültig.",
     "The given order already has a parent.": "Der Auftrag ist bereits einem anderen Auftrag untergeordnet.",

--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -1,10 +1,6 @@
 import * as format from './nuxbe/format.js';
 import { parseNumber, openDetailModal } from './nuxbe/utils.js';
-import {
-    validateFiles,
-    formatFileSize,
-    escapeHtml,
-} from './nuxbe/uploads.js';
+import { validateFiles, formatFileSize, escapeHtml } from './nuxbe/uploads.js';
 import { lightbox, openLightbox } from './nuxbe/lightbox.js';
 import './nuxbe/lightbox/handlers/image.js';
 import './nuxbe/lightbox/handlers/pdf.js';

--- a/resources/js/nuxbe.js
+++ b/resources/js/nuxbe.js
@@ -1,5 +1,10 @@
 import * as format from './nuxbe/format.js';
 import { parseNumber, openDetailModal } from './nuxbe/utils.js';
+import {
+    validateFiles,
+    formatFileSize,
+    escapeHtml,
+} from './nuxbe/uploads.js';
 import { lightbox, openLightbox } from './nuxbe/lightbox.js';
 import './nuxbe/lightbox/handlers/image.js';
 import './nuxbe/lightbox/handlers/pdf.js';
@@ -64,6 +69,9 @@ const nuxbe = {
     format,
     parseNumber,
     openDetailModal,
+    validateFiles,
+    formatFileSize,
+    escapeHtml,
     promptValue,
     isAppMode,
     openLightbox,

--- a/resources/js/nuxbe/format.js
+++ b/resources/js/nuxbe/format.js
@@ -30,7 +30,7 @@ const badgeClasses = {
     rose: 'text-rose-600 bg-rose-100 dark:text-rose-400 dark:bg-slate-700',
 };
 
-function getLocale() {
+export function getLocale() {
     return document.documentElement.lang || 'de';
 }
 

--- a/resources/js/nuxbe/format.js
+++ b/resources/js/nuxbe/format.js
@@ -31,7 +31,7 @@ const badgeClasses = {
 };
 
 export function getLocale() {
-    return document.documentElement.lang || 'de';
+    return document.documentElement.lang || 'en';
 }
 
 function getCurrencyCode() {

--- a/resources/js/nuxbe/uploads.js
+++ b/resources/js/nuxbe/uploads.js
@@ -1,3 +1,5 @@
+import { getLocale } from './format.js';
+
 export function formatFileSize(bytes) {
     const units = ['B', 'KB', 'MB', 'GB'];
     let size = Number(bytes) || 0;
@@ -10,13 +12,10 @@ export function formatFileSize(bytes) {
 
     const decimals = size < 10 && unit > 0 ? 1 : 0;
 
-    const formatted = new Intl.NumberFormat(
-        document.documentElement.lang || 'de',
-        {
-            minimumFractionDigits: decimals,
-            maximumFractionDigits: decimals,
-        },
-    ).format(size);
+    const formatted = new Intl.NumberFormat(getLocale(), {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    }).format(size);
 
     return `${formatted} ${units[unit]}`;
 }
@@ -58,9 +57,13 @@ function matchesAccept(file, patterns) {
     }
 
     return patterns.some((pattern) => {
-        if (pattern.startsWith('.')) return name.endsWith(pattern);
-        if (pattern.endsWith('/*'))
+        if (pattern.startsWith('.')) {
+            return name.endsWith(pattern);
+        }
+
+        if (pattern.endsWith('/*')) {
             return type.startsWith(pattern.slice(0, -1));
+        }
 
         return type === pattern;
     });
@@ -80,7 +83,11 @@ export function validateFiles(files, { maxSize = 0, accept = '' } = {}) {
         }
 
         if (patterns.length && !matchesAccept(file, patterns)) {
-            return { file, reason: 'type', accept: patterns.join(', ') };
+            return {
+                file,
+                reason: 'type',
+                accept: patterns.join(', '),
+            };
         }
     }
 

--- a/resources/js/nuxbe/uploads.js
+++ b/resources/js/nuxbe/uploads.js
@@ -1,0 +1,88 @@
+export function formatFileSize(bytes) {
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let size = Number(bytes) || 0;
+    let unit = 0;
+
+    while (size >= 1024 && unit < units.length - 1) {
+        size /= 1024;
+        unit++;
+    }
+
+    const decimals = size < 10 && unit > 0 ? 1 : 0;
+
+    const formatted = new Intl.NumberFormat(
+        document.documentElement.lang || 'de',
+        {
+            minimumFractionDigits: decimals,
+            maximumFractionDigits: decimals,
+        },
+    ).format(size);
+
+    return `${formatted} ${units[unit]}`;
+}
+
+export function escapeHtml(value) {
+    return String(value ?? '').replace(
+        /[&<>"']/g,
+        (character) =>
+            ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#039;',
+            })[character],
+    );
+}
+
+function parseAccept(accept) {
+    return accept
+        .split(/[,;]/)
+        .map((pattern) => pattern.trim().toLowerCase())
+        .filter(Boolean);
+}
+
+function matchesAccept(file, patterns) {
+    const name = (file.name || '').toLowerCase();
+    const type = (file.type || '').toLowerCase();
+
+    if (!type) {
+        const extensions = patterns.filter((pattern) =>
+            pattern.startsWith('.'),
+        );
+
+        return (
+            extensions.length === 0 ||
+            extensions.some((pattern) => name.endsWith(pattern))
+        );
+    }
+
+    return patterns.some((pattern) => {
+        if (pattern.startsWith('.')) return name.endsWith(pattern);
+        if (pattern.endsWith('/*'))
+            return type.startsWith(pattern.slice(0, -1));
+
+        return type === pattern;
+    });
+}
+
+export function validateFiles(files, { maxSize = 0, accept = '' } = {}) {
+    const patterns = accept ? parseAccept(accept) : [];
+
+    for (const file of Array.from(files ?? [])) {
+        if (maxSize > 0 && file.size > maxSize) {
+            return {
+                file,
+                reason: 'size',
+                size: formatFileSize(file.size),
+                maxSize: formatFileSize(maxSize),
+            };
+        }
+
+        if (patterns.length && !matchesAccept(file, patterns)) {
+            return { file, reason: 'type', accept: patterns.join(', ') };
+        }
+    }
+
+    return null;
+}

--- a/resources/views/components/features/media/upload-form-object.blade.php
+++ b/resources/views/components/features/media/upload-form-object.blade.php
@@ -24,16 +24,38 @@
                     this.uploadFiles(event.dataTransfer.files, event)
                 }
             },
-            uploadError() {
+            uploadError(message = null) {
                 this.isUploading = false
                 this.progress = 0
                 $tsui
                     .interaction('dialog')
                     .error(
                         '{{ __('File upload failed') }}',
-                        '{{ __('Your file upload failed. Please try again.') }}',
+                        message ??
+                            '{{ __('Your file upload failed. Please try again.') }}',
                     )
                     .send()
+            },
+            rejectFiles(rejected) {
+                let name = $nuxbe.escapeHtml(rejected.file.name)
+
+                if (rejected.reason === 'size') {
+                    return this.uploadError(
+                        '{{ __('The file :name is :size. The maximum upload size is :max.') }}'
+                            .replace(':name', () => name)
+                            .replace(':size', () => rejected.size)
+                            .replace(':max', () => rejected.maxSize),
+                    )
+                }
+
+                this.uploadError(
+                    '{{ __('The file type of :name is not accepted. Allowed types: :types.') }}'
+                        .replace(':name', () => name)
+                        .replace(
+                            ':types',
+                            () => $nuxbe.escapeHtml(rejected.accept),
+                        ),
+                )
             },
             uploadSuccess(success, files) {
                 this.isUploading = false
@@ -43,6 +65,17 @@
                 this.progress = progress
             },
             uploadFiles(files, event) {
+                let rejected = $nuxbe.validateFiles(files, {
+                    maxSize: {{ \FluxErp\Helpers\Helper::getMaxUploadSizeInBytes() }},
+                    accept: '{{ $attributes->get('accept') }}',
+                })
+
+                if (rejected) {
+                    event.target.value = ''
+
+                    return this.rejectFiles(rejected)
+                }
+
                 this.isUploading = true
                 let $this = this
                 $wire.uploadMultiple(

--- a/resources/views/components/features/media/upload.blade.php
+++ b/resources/views/components/features/media/upload.blade.php
@@ -18,16 +18,38 @@
                     this.uploadFiles(event.dataTransfer.files, event)
                 }
             },
-            uploadError() {
+            uploadError(message = null) {
                 this.isUploading = false
                 this.progress = 0
                 $tsui
                     .interaction('dialog')
                     .error(
                         '{{ __('File upload failed') }}',
-                        '{{ __('Your file upload failed. Please try again.') }}',
+                        message ??
+                            '{{ __('Your file upload failed. Please try again.') }}',
                     )
                     .send()
+            },
+            rejectFiles(rejected) {
+                let name = $nuxbe.escapeHtml(rejected.file.name)
+
+                if (rejected.reason === 'size') {
+                    return this.uploadError(
+                        '{{ __('The file :name is :size. The maximum upload size is :max.') }}'
+                            .replace(':name', () => name)
+                            .replace(':size', () => rejected.size)
+                            .replace(':max', () => rejected.maxSize),
+                    )
+                }
+
+                this.uploadError(
+                    '{{ __('The file type of :name is not accepted. Allowed types: :types.') }}'
+                        .replace(':name', () => name)
+                        .replace(
+                            ':types',
+                            () => $nuxbe.escapeHtml(rejected.accept),
+                        ),
+                )
             },
             uploadSuccess(success, files) {
                 this.isUploading = false
@@ -38,6 +60,17 @@
                 this.progress = progress
             },
             uploadFiles(files, event) {
+                let rejected = $nuxbe.validateFiles(files, {
+                    maxSize: {{ \FluxErp\Helpers\Helper::getMaxUploadSizeInBytes() }},
+                    accept: '{{ $attributes->get('accept') }}',
+                })
+
+                if (rejected) {
+                    event.target.value = ''
+
+                    return this.rejectFiles(rejected)
+                }
+
                 this.isUploading = true
                 let $this = this
                 $wire.uploadMultiple(

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -107,27 +107,6 @@ class Helper
         }
     }
 
-    public static function getMaxUploadSizeInBytes(): int
-    {
-        $rules = config('livewire.temporary_file_upload.rules');
-        $rules = is_array($rules) ? $rules : explode('|', (string) ($rules ?: 'file|max:12288'));
-
-        $limits = [
-            static::parseIniSizeToBytes(ini_get('upload_max_filesize')),
-            static::parseIniSizeToBytes(ini_get('post_max_size')),
-        ];
-
-        foreach ($rules as $rule) {
-            if (is_string($rule) && str_starts_with($rule, 'max:')) {
-                $limits[] = ((int) Str::after($rule, 'max:')) * 1024;
-            }
-        }
-
-        $limits = array_filter($limits, fn (int $limit) => $limit > 0);
-
-        return $limits ? min($limits) : 12288 * 1024;
-    }
-
     public static function getHtmlInputFieldTypes(): array
     {
         return [
@@ -147,6 +126,27 @@ class Helper
             'checkbox',
             'select',
         ];
+    }
+
+    public static function getMaxUploadSizeInBytes(): int
+    {
+        $rules = config('livewire.temporary_file_upload.rules');
+        $rules = is_array($rules) ? $rules : explode('|', (string) ($rules ?: 'file|max:12288'));
+
+        $limits = [
+            static::parseIniSizeToBytes(ini_get('upload_max_filesize')),
+            static::parseIniSizeToBytes(ini_get('post_max_size')),
+        ];
+
+        foreach ($rules as $rule) {
+            if (is_string($rule) && str_starts_with($rule, 'max:')) {
+                $limits[] = ((int) Str::after($rule, 'max:')) * 1024;
+            }
+        }
+
+        $limits = array_filter($limits, fn (int $limit) => $limit > 0);
+
+        return $limits ? min($limits) : 12288 * 1024;
     }
 
     public static function getRepetitions(array|Model $repeatable, string $periodStart, string $periodEnd): array

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -9,6 +9,7 @@ use FluxErp\Actions\FluxAction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 class Helper
@@ -104,6 +105,27 @@ class Helper
 
             return class_exists($class) ? get_class(app($class)) : false;
         }
+    }
+
+    public static function getMaxUploadSizeInBytes(): int
+    {
+        $rules = config('livewire.temporary_file_upload.rules');
+        $rules = is_array($rules) ? $rules : explode('|', (string) ($rules ?: 'file|max:12288'));
+
+        $limits = [
+            static::parseIniSizeToBytes(ini_get('upload_max_filesize')),
+            static::parseIniSizeToBytes(ini_get('post_max_size')),
+        ];
+
+        foreach ($rules as $rule) {
+            if (is_string($rule) && str_starts_with($rule, 'max:')) {
+                $limits[] = ((int) Str::after($rule, 'max:')) * 1024;
+            }
+        }
+
+        $limits = array_filter($limits, fn (int $limit) => $limit > 0);
+
+        return $limits ? min($limits) : 12288 * 1024;
     }
 
     public static function getHtmlInputFieldTypes(): array
@@ -319,5 +341,20 @@ class Helper
                 }
             }
         }
+    }
+
+    protected static function parseIniSizeToBytes(string|false|null $size): int
+    {
+        if (! preg_match('/^(\d+)\s*([KMGT]?)B?$/i', trim((string) $size), $matches)) {
+            return 0;
+        }
+
+        return (int) $matches[1] * match (strtoupper($matches[2])) {
+            'K' => 1024,
+            'M' => 1024 ** 2,
+            'G' => 1024 ** 3,
+            'T' => 1024 ** 4,
+            default => 1,
+        };
     }
 }

--- a/tests/Browser/Features/Media/UploadValidationTest.php
+++ b/tests/Browser/Features/Media/UploadValidationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+beforeEach(function (): void {
+    $this->defaultLanguage->update(['language_code' => 'de']);
+});
+
+test('validateFiles names the file, its size and the limit', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => {
+                const file = new File(['x'.repeat(2048)], 'vertrag.pdf', {
+                    type: 'application/pdf',
+                });
+                const rejected = window.$nuxbe.validateFiles([file], { maxSize: 1024 });
+
+                return [rejected.reason, rejected.file.name, rejected.size, rejected.maxSize].join('|');
+            }
+        JS);
+
+    expect($result)->toBe('size|vertrag.pdf|2,0 KB|1,0 KB');
+});
+
+test('validateFiles rejects a type the input does not accept', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => {
+                const file = new File(['x'], 'schadcode.exe', {
+                    type: 'application/x-msdownload',
+                });
+                const rejected = window.$nuxbe.validateFiles([file], {
+                    maxSize: 1048576,
+                    accept: 'application/pdf, image/*',
+                });
+
+                return [rejected.reason, rejected.file.name].join('|');
+            }
+        JS);
+
+    expect($result)->toBe('type|schadcode.exe');
+});
+
+test('validateFiles passes a file that fits', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => {
+                const file = new File(['x'], 'beleg.pdf', { type: 'application/pdf' });
+
+                return window.$nuxbe.validateFiles([file], {
+                    maxSize: 1048576,
+                    accept: 'application/pdf',
+                }) === null;
+            }
+        JS);
+
+    expect($result)->toBeTrue();
+});
+
+test('an accept list separated by semicolons is understood', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => {
+                const file = new File(['x'], 'rechnung.pdf', { type: 'application/pdf' });
+
+                return window.$nuxbe.validateFiles([file], {
+                    maxSize: 1048576,
+                    accept: 'application/pdf;image/*',
+                }) === null;
+            }
+        JS);
+
+    expect($result)->toBeTrue();
+});
+
+test('a file without a mime type passes a mime only accept list', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => {
+                const file = new File(['x'], 'logo.svg', { type: '' });
+
+                return window.$nuxbe.validateFiles([file], {
+                    maxSize: 1048576,
+                    accept: 'image/jpeg, image/png, image/svg+xml',
+                }) === null;
+            }
+        JS);
+
+    expect($result)->toBeTrue();
+});
+
+test('a file name cannot inject markup into the message', function (): void {
+    $result = visit(route('dashboard'))
+        ->assertRoute('dashboard')
+        ->assertNoSmoke()
+        ->script(<<<'JS'
+            () => window.$nuxbe.escapeHtml('<img src=x onerror=alert(1)>.pdf')
+        JS);
+
+    expect($result)->toBe('&lt;img src=x onerror=alert(1)&gt;.pdf');
+});

--- a/tests/Unit/Helpers/MaxUploadSizeTest.php
+++ b/tests/Unit/Helpers/MaxUploadSizeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use FluxErp\Helpers\Helper;
+use Illuminate\Support\Number;
+
+test('the livewire rule caps the upload size', function (): void {
+    config(['livewire.temporary_file_upload.rules' => ['required', 'file', 'max:1024']]);
+
+    expect(Helper::getMaxUploadSizeInBytes())->toBe(1024 * 1024);
+});
+
+test('a rule given as a string is understood too', function (): void {
+    config(['livewire.temporary_file_upload.rules' => 'required|file|max:2048']);
+
+    expect(Helper::getMaxUploadSizeInBytes())->toBe(2048 * 1024);
+});
+
+test('without a rule the livewire default applies', function (): void {
+    config(['livewire.temporary_file_upload.rules' => null]);
+
+    expect(Helper::getMaxUploadSizeInBytes())->toBe(
+        min(
+            12288 * 1024,
+            (int) Number::fromFileSizeToBytes(ini_get('upload_max_filesize')),
+            (int) Number::fromFileSizeToBytes(ini_get('post_max_size')),
+        )
+    );
+});
+
+test('the php limits win when they are lower', function (): void {
+    config(['livewire.temporary_file_upload.rules' => ['file', 'max:1048576']]);
+
+    expect(Helper::getMaxUploadSizeInBytes())
+        ->toBeLessThanOrEqual((int) Number::fromFileSizeToBytes(ini_get('upload_max_filesize')));
+});
+
+test('ini values without a unit suffix are understood', function (): void {
+    expect(invade_helper('8388608'))->toBe(8388608)
+        ->and(invade_helper('8M'))->toBe(8 * 1024 * 1024)
+        ->and(invade_helper('1G'))->toBe(1024 ** 3)
+        ->and(invade_helper('512K'))->toBe(512 * 1024);
+});
+
+test('unlimited or unparseable ini values do not count as a limit', function (): void {
+    expect(invade_helper('0'))->toBe(0)
+        ->and(invade_helper('-1'))->toBe(0)
+        ->and(invade_helper(''))->toBe(0)
+        ->and(invade_helper('kaputt'))->toBe(0);
+});
+
+test('the fallback applies when no limit can be determined', function (): void {
+    config(['livewire.temporary_file_upload.rules' => ['file']]);
+
+    expect(Helper::getMaxUploadSizeInBytes())->toBeGreaterThan(0);
+});
+
+function invade_helper(string $value): int
+{
+    return (fn (string $size): int => static::parseIniSizeToBytes($size))
+        ->call(new Helper(), $value);
+}


### PR DESCRIPTION
Both upload components answered every failure with the same sentence: "Your file upload failed. Please try again." A tenant had no way to tell whether the file was too large, of the wrong type, or something else.

## Why the reason has to come from the browser

Three things were checked before writing this:

- Livewire calls the error callback with no arguments at all (`markUploadErrored` in `livewire.esm.js`), so the `error` parameter the components accepted was always `undefined`.
- The component error bag stays empty. Polled 40 times over 6 seconds in a live browser after a failed upload, it never filled.
- The 422 of the upload endpoint carries only `files.0 could not be uploaded`, which would not help anyone either.

The only place where a precise reason exists is the browser, before the upload starts, where name, size and type are known.

## What changes

`$nuxbe.validateFiles()` checks each file against the effective upload limit and the accept attribute of the input, and both components show what is actually wrong: the file name with its size and the limit, or the accepted types.

`Helper::getMaxUploadSizeInBytes()` derives that limit from the smallest of the livewire rule, `upload_max_filesize` and `post_max_size`. It parses those values itself instead of using the `fromFileSizeToBytes` macro, which throws on legal ini forms like a plain byte count, `0` or `-1`, and would have turned every page containing an upload into a 500 on such a host.

Two details worth naming: the file name is escaped, because the dialog renders its description through `x-html` and a name is fully user controlled. And the accept list is split on commas as well as semicolons, because the purchase invoice upload passes `application/pdf;image/*` and a comma only split would have rejected every file there.

## Tests

Browser tests cover size, type, the semicolon list, a file whose mime type the browser leaves empty, and the escaping. Unit tests cover the limit calculation including the ini forms that used to throw.

## Summary by Sourcery

Improve file upload UX by validating files client-side and surfacing specific rejection reasons to users.

New Features:
- Add client-side file validation for uploads based on maximum size and accepted types, returning detailed rejection metadata for the first invalid file.
- Display contextual error dialogs that name the rejected file, its size, and either the configured size limit or the allowed file types.
- Expose shared upload utilities (file-size formatter, HTML escaping, and validation) via the global $nuxbe object for reuse across upload components.

Bug Fixes:
- Prevent server errors caused by parsing edge-case PHP ini upload size values by introducing a resilient size parsing helper and using it to compute the effective upload limit.
- Ensure file names in upload error dialogs are safely escaped to avoid markup injection in HTML-rendered messages.
- Correct handling of accept lists separated by semicolons or containing wildcard and extension-based patterns so valid files are no longer incorrectly rejected.

Enhancements:
- Centralize computation of the effective maximum upload size by combining Livewire rules with PHP ini limits and using the minimum applicable value.
- Extend both media upload components to clear invalid file inputs and reuse shared client-side validation and error presentation logic.

Tests:
- Add browser tests covering client-side upload validation scenarios, including size and type rejections, semicolon-separated accept lists, empty MIME types, and HTML escaping of file names.
- Add unit tests for maximum upload size calculation and ini value parsing, including previously problematic forms like plain byte counts, zero, negative, and malformed values.