### PR TITLE
fix: refresh order address from the contact's current address

### DIFF
--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -270,7 +270,12 @@ class Order extends Component
 
         $address = resolve_static(Address::class, 'query')
             ->with('country:id,name')
-            ->whereKey($this->order->{$addressKey . '_id'})
+            ->whereKey(
+                resolve_static(Contact::class, 'query')
+                    ->whereKey($this->order->contact_id)
+                    ->value($type . '_address_id')
+                    ?? $this->order->{$addressKey . '_id'}
+            )
             ->first();
 
         if ($address) {
@@ -279,12 +284,14 @@ class Order extends Component
             try {
                 $updatedOrder = UpdateOrder::make([
                     'id' => $this->order->id,
+                    $addressKey . '_id' => $address->getKey(),
                     $addressKey => $addressArray,
                 ])
                     ->checkPermission()
                     ->validate()
                     ->execute();
 
+                $this->order->{$addressKey . '_id'} = $updatedOrder->{$addressKey . '_id'};
                 $this->order->{$addressKey} = $updatedOrder->{$addressKey};
             } catch (ValidationException|UnauthorizedException $e) {
                 exception_to_notifications($e, $this);

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -1527,6 +1527,50 @@ test('refresh delivery address updates address from address model', function ():
     expect($refreshedOrder->address_delivery['city'])->toEqual('Delivery City');
 });
 
+test('refresh invoice address switches to the contacts invoice address', function (): void {
+    $newInvoiceAddress = Address::factory()->create([
+        'contact_id' => $this->contact->id,
+        'company' => 'New Invoice Company',
+        'street' => 'Invoice Street 1',
+        'city' => 'Invoice City',
+        'is_invoice_address' => true,
+    ]);
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->call('refreshAddress', 'invoice')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('order.address_invoice_id', $newInvoiceAddress->id);
+
+    $refreshedOrder = $this->order->fresh();
+    expect($refreshedOrder->address_invoice_id)->toEqual($newInvoiceAddress->id);
+    expect($refreshedOrder->address_invoice['company'])->toEqual('New Invoice Company');
+    expect($refreshedOrder->address_invoice['street'])->toEqual('Invoice Street 1');
+    expect($refreshedOrder->address_invoice['city'])->toEqual('Invoice City');
+});
+
+test('refresh delivery address switches to the contacts delivery address', function (): void {
+    $newDeliveryAddress = Address::factory()->create([
+        'contact_id' => $this->contact->id,
+        'company' => 'New Delivery Company',
+        'street' => 'Delivery Street 1',
+        'city' => 'Delivery City',
+        'is_delivery_address' => true,
+    ]);
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->call('refreshAddress', 'delivery')
+        ->assertOk()
+        ->assertHasNoErrors()
+        ->assertSet('order.address_delivery_id', $newDeliveryAddress->id);
+
+    $refreshedOrder = $this->order->fresh();
+    expect($refreshedOrder->address_delivery_id)->toEqual($newDeliveryAddress->id);
+    expect($refreshedOrder->address_delivery['company'])->toEqual('New Delivery Company');
+    expect($refreshedOrder->address_delivery['street'])->toEqual('Delivery Street 1');
+    expect($refreshedOrder->address_delivery['city'])->toEqual('Delivery City');
+});
+
 test('refresh invoice address on locked order fails', function (): void {
     $this->order->update(['is_locked' => true]);
 


### PR DESCRIPTION
## Problem

The refresh button on an order's invoice and delivery address card re-read the address behind the id already stored on the order (`address_invoice_id` / `address_delivery_id`). When a new address is added to the contact and flagged as its invoice or delivery address, the order keeps pointing at the old address, so the refresh reloads the same address and the button appears to do nothing.

## Change

`Order::refreshAddress()` now resolves the address through the contact's `invoice_address_id` / `delivery_address_id` and persists that id on the order together with the address snapshot. If the contact has no address flagged for that type, it falls back to the address currently stored on the order, so the existing "the selected address was edited" behaviour is unchanged.

## Tests

Two new tests in `tests/Livewire/Order/OrderTest.php` cover switching to a newly flagged invoice and delivery address. The full `OrderTest` suite passes (44 tests).

## Summary by Sourcery

Update order address refresh to use the contact’s current invoice or delivery address and ensure the order’s address ID and snapshot stay in sync.

Bug Fixes:
- Ensure refreshing an order’s invoice or delivery address switches to the contact’s currently flagged invoice or delivery address instead of reloading the old one.

Tests:
- Add Livewire tests verifying that refreshing invoice and delivery addresses updates the order to the contact’s newly flagged addresses.