### PR TITLE
Open the move address modal through tsui

### DIFF
--- a/resources/views/livewire/contact/addresses.blade.php
+++ b/resources/views/livewire/contact/addresses.blade.php
@@ -292,7 +292,9 @@
                                     <x-button
                                         color="secondary"
                                         light
-                                        x-on:click="$modalOpen('move-address')"
+                                        x-on:click="
+                                            $tsui.open.modal('move-address')
+                                        "
                                         :text="__('Move To Contact')"
                                     />
                                 </div>
@@ -352,7 +354,7 @@
                         color="secondary"
                         flat
                         :text="__('Cancel')"
-                        x-on:click="$modalClose('move-address')"
+                        x-on:click="$tsui.close.modal('move-address')"
                     />
                     <x-button
                         color="indigo"

--- a/tests/Unit/View/ModalMagicTest.php
+++ b/tests/Unit/View/ModalMagicTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+
+test('no view calls a modal magic that alpine does not provide', function (): void {
+    $offenders = [];
+
+    foreach (Finder::create()->files()->in(__DIR__ . '/../../../resources/views')->name('*.blade.php') as $file) {
+        if (preg_match('/\$modal(Open|Close)\s*\(/', $file->getContents())) {
+            $offenders[] = $file->getRelativePathname();
+        }
+    }
+
+    expect($offenders)->toBe([]);
+});


### PR DESCRIPTION
Moving an address to an existing contact was impossible: the button did nothing but draw a focus ring.

The trigger called `$modalOpen('move-address')`, an alpine magic that has not existed for a long time, so every click threw `Alpine Expression Error: $modalOpen is not defined` and the modal stayed closed. Moving an address to a *new* contact kept working, because that button calls a livewire method instead of opening a modal, which is exactly the split the customer reported.

It was the only occurrence in the whole repository. The close button of the same modal had the same problem with `$modalClose`, while the other 19 modals all use `$tsui`. Both now do as well.

A unit test walks every blade view and fails if one of the two magics reappears, naming the offending file.

## Summary by Sourcery

Fix address move modal to use the standard tsui modal API and guard against regressions.

Bug Fixes:
- Restore the ability to open and close the move-address modal by wiring its buttons to the tsui modal API instead of removed Alpine modal magics.

Tests:
- Add a unit test that scans Blade views and fails if deprecated $modalOpen or $modalClose Alpine magics are used.