### PR TITLE
Let packages mount a component into the layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -106,6 +106,9 @@
         @persist('record-merging')
             <livewire:record-merging lazy />
         @endpersist
+        @persist('layout-global-components')
+            @stack('layout-global-components')
+        @endpersist
     @endauth
 
     <x-flux::layout>


### PR DESCRIPTION
`edit-mail` and `record-merging` are wired into the layout by hand because they have to be reachable from any page. A package cannot do the same: it can repeat itself in every view it owns, which still leaves every other page silent, or send the user somewhere else.

Persisted, so it survives `wire:navigate`. Empty until somebody pushes.

First consumer is flux-finapi, where a bank raises a confirmation request the user did not ask for and cannot predict, and the dialog has to open wherever they happen to be.


## Summary by Sourcery

Enhancements:
- Introduce a persisted Blade stack in the main app layout for package-defined components that need to render globally across navigation.
