### PR TITLE
Resolve address and media routes by primary key

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -198,15 +198,22 @@ Route::middleware('web')
                     });
                 Route::get(
                     '/address/{address}',
-                    fn (Address $address) => redirect()
-                        ->route(
-                            'contacts.id?',
-                            [
-                                'id' => $address->contact_id,
-                                'address' => $address->getKey(),
-                            ]
-                        )
+                    function (int $address) {
+                        $address = resolve_static(Address::class, 'query')
+                            ->whereKey($address)
+                            ->firstOrFail();
+
+                        return redirect()
+                            ->route(
+                                'contacts.id?',
+                                [
+                                    'id' => $address->contact_id,
+                                    'address' => $address->getKey(),
+                                ]
+                            );
+                    }
                 )
+                    ->whereNumber('address')
                     ->name('address.id');
 
                 Route::name('sales.')
@@ -365,9 +372,13 @@ Route::middleware('web')
 
             Route::post('/push-subscription', UpsertPushSubscription::class);
 
-            Route::get('/media/{media}/{filename}', function (Media $media) {
-                return $media;
-            })->name('media');
+            Route::get('/media/{media}/{filename}', function (int $media) {
+                return resolve_static(Media::class, 'query')
+                    ->whereKey($media)
+                    ->firstOrFail();
+            })
+                ->whereNumber('media')
+                ->name('media');
         });
 
         Route::middleware('auth:web')->group(function (): void {
@@ -390,7 +401,11 @@ Route::middleware('web')
             Route::get('/media-private/{media}/{filename}', PrivateMediaController::class)
                 ->name('media.private');
 
-            Route::get('/media/{media}', function (Media $media) {
+            Route::get('/media/{media}', function (int $media) {
+                $media = resolve_static(Media::class, 'query')
+                    ->whereKey($media)
+                    ->firstOrFail();
+
                 $disposition = ContentDisposition::make(
                     request()->boolean('download')
                         ? HeaderUtils::DISPOSITION_ATTACHMENT
@@ -417,6 +432,7 @@ Route::middleware('web')
                     ['Content-Disposition' => $disposition],
                 );
             })
+                ->whereNumber('media')
                 ->name('media.show');
         });
 

--- a/tests/Feature/Web/AddressRedirectRouteTest.php
+++ b/tests/Feature/Web/AddressRedirectRouteTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+
+beforeEach(function (): void {
+    $this->contact = Contact::factory()->create();
+    $this->address = Address::factory()->create([
+        'contact_id' => $this->contact->getKey(),
+        'is_main_address' => true,
+    ]);
+});
+
+test('the address route redirects to the contact', function (): void {
+    $this->actingAs($this->user, 'web')
+        ->get(route('address.id', ['address' => $this->address->getKey()]))
+        ->assertRedirect(
+            route('contacts.id?', [
+                'id' => $this->contact->getKey(),
+                'address' => $this->address->getKey(),
+            ])
+        );
+});
+
+test('the address route resolves by key even when the route key is customized', function (): void {
+    $class = new class() extends Address
+    {
+        protected $table = 'addresses';
+
+        public function getRouteKeyName(): string
+        {
+            return 'slug';
+        }
+    };
+    $this->app->bind(Address::class, get_class($class));
+
+    $this->actingAs($this->user, 'web')
+        ->get(route('address.id', ['address' => $this->address->getKey()]))
+        ->assertRedirect(
+            route('contacts.id?', [
+                'id' => $this->contact->getKey(),
+                'address' => $this->address->getKey(),
+            ])
+        );
+});
+
+test('an unknown address still gives a 404', function (): void {
+    $this->actingAs($this->user, 'web')
+        ->get(route('address.id', ['address' => 999999]))
+        ->assertNotFound();
+});


### PR DESCRIPTION
Clicking an address inside a contact answered with a 404 on every contact, while every other link on the page worked.

## Cause

Three routes use implicit route model binding, so laravel looks the record up through `getRouteKeyName()`. An installation that runs a public site next to flux in the same application can legitimately point that at a slug, and one of ours does exactly that: it binds its own Address model, which returns `slug`, into the container.

The url itself is built by flux with the id. `Address::detailRouteParams()` returns `'address' => $this->id`, and `/address/{address}` then tries to resolve that id through the slug column. Flux therefore hands out a link it can no longer read itself, and the result is a 404 that looks like a missing record.

## Change

`/address/{address}` and the two media routes resolve their record through `whereKey()` and only accept numeric parameters. The route key stays untouched and remains free for whatever the surrounding application needs it for.

A test binds an Address whose route key is a slug and asserts the redirect still works, next to one asserting an unknown id still gives a 404.

## Summary by Sourcery

Resolve address and media routes by primary key instead of implicit route model binding to avoid conflicts with customized route keys.

Bug Fixes:
- Fix address detail links returning 404 when the application overrides the Address route key to use a slug.
- Fix media download and public media routes failing when Media uses a non-numeric route key.

Enhancements:
- Restrict address and media routes to numeric parameters and look up records via primary key queries instead of implicit binding.

Tests:
- Add feature tests ensuring the address redirect route works with customized Address route keys and still returns 404 for unknown IDs.