### PR TITLE
Show the activity log of an order position

### DIFF
--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -529,6 +529,19 @@
                         />
                     @show
                     @stack('order-edit-position-modal-fields')
+                    @section('order-position-detail-modal.content.activities')
+                        <div
+                            id="order-position-activities"
+                            x-cloak
+                            x-show="$wire.orderPosition.id"
+                        >
+                            <x-card :header="__('Activities')" minimize="mount">
+                                <div class="px-2 py-5">
+                                    <livewire:order-position.activities />
+                                </div>
+                            </x-card>
+                        </div>
+                    @show
                 </div>
                 <x-errors />
             </div>

--- a/src/Livewire/Order/OrderPositions.php
+++ b/src/Livewire/Order/OrderPositions.php
@@ -363,6 +363,8 @@ class OrderPositions extends OrderPositionList
             $this->orderPosition->vat_rate_id ??= resolve_static(VatRate::class, 'default')?->getKey();
         }
 
+        $this->dispatch('load-order-position-activities', orderPositionId: $this->orderPosition->id);
+
         $this->js(<<<'JS'
             $tsui.open.modal('edit-order-position');
         JS);

--- a/src/Livewire/OrderPosition/Activities.php
+++ b/src/Livewire/OrderPosition/Activities.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FluxErp\Livewire\OrderPosition;
+
+use FluxErp\Livewire\Support\Activities as BaseActivities;
+use FluxErp\Models\OrderPosition;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\On;
+
+class Activities extends BaseActivities
+{
+    #[Locked]
+    public ?int $modelId = null;
+
+    protected string $modelType = OrderPosition::class;
+
+    #[On('load-order-position-activities')]
+    public function loadActivities(?int $orderPositionId): void
+    {
+        $this->reset('activities', 'page', 'total');
+
+        $this->modelId = $orderPositionId;
+
+        $this->loadPage(page: 1, perPage: $this->perPage);
+
+        $this->renderIsland(name: 'activities');
+    }
+}

--- a/tests/Browser/Orders/OrderPositionActivitiesTest.php
+++ b/tests/Browser/Orders/OrderPositionActivitiesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\VatRate;
+use FluxErp\Models\Warehouse;
+
+test('order position modal shows the activities of the edited position', function (): void {
+    Warehouse::factory()->create(['is_default' => true]);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $order = Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_locked' => false,
+    ]);
+
+    OrderPosition::factory()->create([
+        'order_id' => $order->getKey(),
+        'vat_rate_id' => VatRate::default()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_free_text' => false,
+        'is_alternative' => false,
+        'name' => 'Position With Activities',
+        'amount' => 1,
+        'unit_net_price' => 100,
+        'unit_gross_price' => 119,
+        'total_net_price' => 100,
+        'total_gross_price' => 119,
+    ]);
+
+    $page = visit(route('orders.id', ['id' => $order->getKey()]))
+        ->assertNoSmoke();
+
+    waitForDataTable($page);
+
+    $page->script(<<<'JS'
+        () => {
+            const button = document.querySelector('[wire\\:click*="editOrderPosition"]');
+            if (! button) throw new Error('Edit order position button not found');
+            button.click();
+        }
+    JS);
+
+    waitForCondition($page, <<<'JS'
+        () => document.querySelector('#order-position-activities')?.offsetParent !== null
+    JS);
+
+    $page->script(<<<'JS'
+        () => {
+            const button = document.querySelector(
+                '#order-position-activities [dusk="tallstackui_card_minimize"]',
+            );
+            if (! button) throw new Error('Activities card not found');
+            button.click();
+        }
+    JS);
+
+    $causer = json_encode($this->user->getLabel());
+
+    waitForCondition($page, <<<JS
+        () => document
+            .querySelector('#order-position-activities')
+            .textContent.includes({$causer})
+    JS);
+
+    $page->assertNoJavascriptErrors();
+});

--- a/tests/Livewire/OrderPosition/ActivitiesTest.php
+++ b/tests/Livewire/OrderPosition/ActivitiesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Livewire\OrderPosition\Activities;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderPosition;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\Models\Tenant;
+use FluxErp\Models\VatRate;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $tenant = Tenant::factory()->create([
+        'is_default' => true,
+    ]);
+    $currency = Currency::factory()->create([
+        'is_default' => true,
+    ]);
+    $contact = Contact::factory()
+        ->hasAttached(factory: $tenant, relationship: 'tenants')
+        ->create();
+    $priceList = PriceList::factory()->create([
+        'is_default' => true,
+    ]);
+
+    $paymentType = PaymentType::factory()
+        ->hasAttached(factory: $tenant, relationship: 'tenants')
+        ->create([
+            'is_default' => true,
+        ]);
+
+    $orderType = OrderType::factory()
+        ->hasAttached(factory: $tenant, relationship: 'tenants')
+        ->create([
+            'order_type_enum' => OrderTypeEnum::Order->value,
+        ]);
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->id,
+        'is_delivery_address' => true,
+        'is_invoice_address' => true,
+        'is_main_address' => true,
+    ]);
+
+    $order = Order::factory()->create([
+        'tenant_id' => $tenant->id,
+        'currency_id' => $currency->id,
+        'address_invoice_id' => $address->id,
+        'price_list_id' => $priceList->id,
+        'payment_type_id' => $paymentType->id,
+        'order_type_id' => $orderType->id,
+    ]);
+
+    $this->orderPosition = OrderPosition::factory()->create([
+        'tenant_id' => $tenant->id,
+        'order_id' => $order->id,
+        'vat_rate_id' => VatRate::factory()->create()->id,
+    ]);
+});
+
+test('renders successfully', function (): void {
+    Livewire::test(Activities::class)
+        ->assertOk();
+});
+
+test('loads activities on event', function (): void {
+    Livewire::test(Activities::class)
+        ->assertSet('modelId', null)
+        ->dispatch('load-order-position-activities', orderPositionId: $this->orderPosition->id)
+        ->assertSet('modelId', $this->orderPosition->id)
+        ->assertOk()
+        ->assertCount('activities', 1);
+});


### PR DESCRIPTION
Order positions already log activity via `LogsActivity`, but there was no UI to read it.

The order position modal now renders a collapsed `Activities` card. Opening a position dispatches `load-order-position-activities`, so the nested component reloads for the position currently being edited (the modal lives inside a `wire:ignore` block, so a `wire:model` binding would not propagate). The island is re-rendered explicitly because Livewire skips islands on updates after mount.

## Summary by Sourcery

Add an activities view to the order position modal and wire it to load the activity log for the currently edited position.

New Features:
- Expose an Activities card inside the order position detail modal showing the activity log of the selected position.

Enhancements:
- Introduce an OrderPosition Activities Livewire component that listens for a load-order-position-activities event and refreshes its data for the given position.

Tests:
- Add Livewire and browser tests to verify that order position activities load on the event and are visible in the order position modal.