### PR TITLE
Reindex a contact when its main address changes

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -218,6 +218,17 @@ class Address extends FluxAuthenticatable implements Calendarable, HasLocalePref
                     ->where('contact_id', $address->contact_id)
                     ->update($addressesUpdates);
             }
+
+            if ($address->is_main_address
+                && ($address->wasRecentlyCreated
+                    || $address->wasChanged(['name', 'company', 'firstname', 'lastname', 'is_main_address'])
+                )
+            ) {
+                resolve_static(Contact::class, 'query')
+                    ->whereKey($address->contact_id)
+                    ->first()
+                    ?->searchable();
+            }
         });
 
         static::deleted(function (Address $address): void {

--- a/tests/Feature/Models/AddressReindexesContactTest.php
+++ b/tests/Feature/Models/AddressReindexesContactTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\NullEngine;
+
+beforeEach(function (): void {
+    // The collection engine reads the database instead of an index, so it can
+    // not tell whether a model was handed to the engine at all.
+    $this->engine = new class() extends NullEngine
+    {
+        public array $updated = [];
+
+        public function update($models): void
+        {
+            foreach ($models as $model) {
+                // Keyed by class, a contact and an address share the same ids.
+                $this->updated[] = $model::class . ':' . $model->getKey();
+            }
+        }
+    };
+
+    $engine = $this->engine;
+
+    app(EngineManager::class)->extend('spy', fn () => $engine);
+    config()->set('scout.driver', 'spy');
+});
+
+test('a new main address hands its contact to the search index', function (): void {
+    $contact = Contact::factory()->create();
+    $this->engine->updated = [];
+
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'lastname' => 'Penkova',
+    ]);
+
+    expect($this->engine->updated)->toContain(Contact::class . ':' . $contact->getKey());
+});
+
+test('a renamed main address hands its contact to the search index', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'lastname' => 'Penkova',
+    ]);
+    $this->engine->updated = [];
+
+    $address->update(['lastname' => 'Petrova']);
+
+    expect($this->engine->updated)->toContain(Contact::class . ':' . $contact->getKey());
+});
+
+test('a secondary address leaves its contact alone', function (): void {
+    $contact = Contact::factory()->create();
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+    $this->engine->updated = [];
+
+    Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => false,
+        'is_invoice_address' => false,
+        'is_delivery_address' => false,
+    ]);
+
+    expect($this->engine->updated)->not->toContain(Contact::class . ':' . $contact->getKey());
+});


### PR DESCRIPTION
## Problem

A contact created through the interface can not be found by name afterwards. The column filter finds it, the address search finds it, the global search finds it, only the contact search does not.

`Contact::toSearchableArray()` embeds `mainAddress`, so the name a user searches for lives in the contact document. The contact is created first and indexed right away, at which point it has no address yet. The address is created a moment later and links itself back with

```php
resolve_static(Contact::class, 'query')->whereKey($address->contact_id)->update($contactUpdates);
```

which is a query update, so no model event follows and Scout never hears about it. The document keeps `"main_address": null` forever and matches nothing a user would type.

The same applies when the main address is later renamed: the contact keeps the old name in the index.

Found while chasing an index that had drifted apart at a customer. Reimporting the index papers over it, the contacts created after the import drift right back out.

## Change

After the role updates, the contact is handed to the index again when its main address was just created, was renamed, or has taken over the main address role. Secondary addresses do not touch the contact.

## Tests

`AddressReindexesContactTest` swaps the engine for a spy, since the collection engine used in tests reads the database instead of an index and can not tell whether a model was handed over at all. The first two cases fail without the change.

## Summary by Sourcery

Fix contact search indexing drift by reindexing the associated contact whenever its main address is created or modified, and add tests to cover these scenarios.

Bug Fixes:
- Ensure contacts are reindexed in search when their main address is created or updated so they remain discoverable by name.

Tests:
- Add feature tests verifying that creating or renaming a main address triggers contact reindexing, while changes to secondary addresses do not.