### PR TITLE
Give every page a browser title from its route

### DIFF
--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -192,7 +192,8 @@ Route::middleware('web')
                 Route::name('contacts.')->prefix('contacts')
                     ->group(function (): void {
                         Route::get('/contacts', ContactList::class)->name('contacts');
-                        Route::get('/contacts/{id?}', Contact::class)->where('id', '[0-9]+')->name('id?');
+                        Route::get('/contacts/{id?}', Contact::class)->where('id', '[0-9]+')->name('id?')
+                            ->metadata(['model' => 'contact']);
                         Route::get('/addresses', AddressList::class)->name('addresses');
                         Route::get('/communications', CommunicationList::class)->name('communications');
                     });
@@ -213,7 +214,8 @@ Route::middleware('web')
                     ->prefix('sales')
                     ->group(function (): void {
                         Route::get('/leads', LeadList::class)->name('leads');
-                        Route::get('/leads/{id}', Lead::class)->name('lead.id');
+                        Route::get('/leads/{id}', Lead::class)->name('lead.id')
+                            ->metadata(['model' => 'lead']);
                     });
 
                 Route::name('orders.')
@@ -223,22 +225,28 @@ Route::middleware('web')
                         Route::get('/list/{orderType}', OrderListByOrderType::class)->name('order-type');
                         Route::get('/order-positions/list', OrderPositionList::class)->name('order-positions');
                         Route::get('/create-child-order', CreateChildOrder::class)->name('create-child-order');
-                        Route::get('/{id}', Order::class)->where('id', '[0-9]+')->name('id');
+                        Route::get('/{id}', Order::class)->where('id', '[0-9]+')->name('id')
+                            ->metadata(['model' => 'order']);
                     });
 
                 Route::get('/tasks', TaskList::class)->name('tasks');
-                Route::get('/tasks/{id}', Task::class)->name('tasks.id');
+                Route::get('/tasks/{id}', Task::class)->name('tasks.id')
+                    ->metadata(['model' => 'task']);
                 Route::get('/tickets', TicketList::class)->name('tickets');
-                Route::get('/tickets/{id}', Ticket::class)->name('tickets.id');
+                Route::get('/tickets/{id}', Ticket::class)->name('tickets.id')
+                    ->metadata(['model' => 'ticket']);
                 Route::get('/projects', ProjectList::class)->name('projects');
-                Route::get('/projects/{id}', Project::class)->name('projects.id');
+                Route::get('/projects/{id}', Project::class)->name('projects.id')
+                    ->metadata(['model' => 'project']);
 
                 Route::name('products.')->prefix('products')
                     ->group(function (): void {
                         Route::get('/list', ProductList::class)->name('products');
                         Route::get('/serial-numbers', SerialNumberList::class)->name('serial-numbers');
-                        Route::get('/serial-numbers/{id?}', SerialNumber::class)->name('serial-numbers.id?');
-                        Route::get('/{id}', Product::class)->where('id', '[0-9]+')->name('id');
+                        Route::get('/serial-numbers/{id?}', SerialNumber::class)->name('serial-numbers.id?')
+                            ->metadata(['model' => 'serial_number']);
+                        Route::get('/{id}', Product::class)->where('id', '[0-9]+')->name('id')
+                            ->metadata(['model' => 'product']);
                     });
 
                 Route::name('human-resources.')->prefix('human-resources')
@@ -246,7 +254,8 @@ Route::middleware('web')
                         Route::get('/absence-requests', AbsenceRequests::class)
                             ->name('absence-requests');
                         Route::get('/absence-requests/{id}', AbsenceRequest::class)
-                            ->name('absence-requests.show');
+                            ->name('absence-requests.show')
+                            ->metadata(['model' => 'absence_request']);
 
                         Route::get('/attendance-overview', AttendanceOverview::class)
                             ->name('attendance-overview');
@@ -256,17 +265,21 @@ Route::middleware('web')
                         Route::get('/employee-days', EmployeeDays::class)
                             ->name('employee-days');
                         Route::get('/employee-days/{id}', EmployeeDay::class)
-                            ->name('employee-days.show');
+                            ->name('employee-days.show')
+                            ->metadata(['model' => 'employee_day']);
 
                         Route::get('/employees', Employees::class)->name('employees');
-                        Route::get('/employees/{id}', Employee::class)->name('employees.id');
+                        Route::get('/employees/{id}', Employee::class)->name('employees.id')
+                            ->metadata(['model' => 'employee']);
 
                         Route::get('/my-employee-profile', MyEmployeeProfile::class)
                             ->name('my-employee-profile');
                         Route::get('/my-employee-profile/employee-day/{id}', MyEmployeeDay::class)
-                            ->name('my-employee-profile.my-employee-day');
+                            ->name('my-employee-profile.my-employee-day')
+                            ->metadata(['model' => 'employee_day']);
                         Route::get('/my-employee-profile/absence-request/{id}', MyAbsenceRequest::class)
-                            ->name('my-employee-profile.my-absence-request');
+                            ->name('my-employee-profile.my-absence-request')
+                            ->metadata(['model' => 'absence_request']);
 
                         Route::get('/work-times', WorkTimes::class)->name('work-times');
                     });
@@ -276,7 +289,8 @@ Route::middleware('web')
                         Route::get('/commissions', CommissionList::class)->name('commissions');
                         Route::get('/ledger-bookings', LedgerBookings::class)->name('ledger-bookings');
                         Route::get('/loans', Loans::class)->name('loans');
-                        Route::get('/loans/{id}', Loan::class)->where('id', '[0-9]+')->name('loans.id');
+                        Route::get('/loans/{id}', Loan::class)->where('id', '[0-9]+')->name('loans.id')
+                            ->metadata(['model' => 'loan']);
                         Route::get('/payment-reminder-run', PaymentReminderRun::class)->name('payment-reminder-run');
                         Route::get('/purchase-invoices', PurchaseInvoiceList::class)->name('purchase-invoices');
                         Route::get('/transactions', TransactionList::class)->name('transactions');
@@ -351,7 +365,8 @@ Route::middleware('web')
                         Route::get('/vacation-carryover-rules', VacationCarryoverRules::class)->name('vacation-carryover-rules');
                         Route::get('/vat-rates', VatRates::class)->name('vat-rates');
                         Route::get('/warehouses', Warehouses::class)->name('warehouses');
-                        Route::get('/work-time-model/{id}', WorkTimeModel::class)->name('work-time-model');
+                        Route::get('/work-time-model/{id}', WorkTimeModel::class)->name('work-time-model')
+                            ->metadata(['model' => 'work_time_model']);
                         Route::get('/work-time-models', WorkTimeModels::class)->name('work-time-models');
                         Route::get('/work-time-types', WorkTimeTypes::class)->name('work-time-types');
                     });

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -222,7 +222,8 @@ Route::middleware('web')
                     ->prefix('orders')
                     ->group(function (): void {
                         Route::get('/list', OrderList::class)->name('orders');
-                        Route::get('/list/{orderType}', OrderListByOrderType::class)->name('order-type');
+                        Route::get('/list/{orderType}', OrderListByOrderType::class)->name('order-type')
+                            ->metadata(['title' => 'Orders', 'model' => 'order_type']);
                         Route::get('/order-positions/list', OrderPositionList::class)->name('order-positions');
                         Route::get('/create-child-order', CreateChildOrder::class)->name('create-child-order');
                         Route::get('/{id}', Order::class)->where('id', '[0-9]+')->name('id')

--- a/src/Models/OrderType.php
+++ b/src/Models/OrderType.php
@@ -64,6 +64,12 @@ class OrderType extends FluxModel implements Sortable
             ->using(OrderTypeTenant::class);
     }
 
+    // Public methods
+    public function getLabel(): ?string
+    {
+        return $this->name;
+    }
+
     // Protected methods
     protected function translatableAttributes(): array
     {

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -159,8 +159,8 @@ class ViewServiceProvider extends ServiceProvider
         Blade::component(App::class, 'flux::layouts.app');
         Blade::component(Printing::class, 'flux::layouts.print');
         config([
-            'livewire.layout' => 'flux::layouts.app',
-            'livewire.component_layout' => 'flux::layouts.app',
+            'livewire.layout' => App::class,
+            'livewire.component_layout' => App::class,
         ]);
 
         // Register Printing views as blade components

--- a/src/View/Layouts/App.php
+++ b/src/View/Layouts/App.php
@@ -4,25 +4,73 @@ namespace FluxErp\View\Layouts;
 
 use Closure;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 class App extends Component
 {
-    /**
-     * Create a new component instance.
-     *
-     * @return void
-     */
-    public function __construct()
+    public function __construct(public ?string $title = null)
     {
-        //
+        $this->title ??= $this->titleForRoute(Request::route());
     }
 
-    /**
-     * Get the view / contents that represent the component.
-     */
     public function render(): View|Closure|string
     {
         return view('flux::layouts.app');
+    }
+
+    protected function titleForRoute(?Route $route): string
+    {
+        $appName = config('app.name', 'Flux ERP');
+
+        if (! $route) {
+            return $appName;
+        }
+
+        return collect([
+            $this->section($route),
+            $this->recordLabel($route),
+            $appName,
+        ])
+            ->filter()
+            ->implode(' / ');
+    }
+
+    protected function section(Route $route): ?string
+    {
+        $section = $route->getMetadata('title');
+
+        if (! $section && $model = $this->modelForRoute($route)) {
+            $section = class_basename($model);
+        }
+
+        $section ??= Str::afterLast(rtrim($route->getName() ?? '', '.'), '.');
+
+        return $section ? __(Str::headline($section)) : null;
+    }
+
+    protected function recordLabel(Route $route): ?string
+    {
+        $model = $this->modelForRoute($route);
+
+        if (! $model || ! $key = $route->parameter('id')) {
+            return null;
+        }
+
+        $record = resolve_static($model, 'query')->whereKey($key)->first();
+
+        return $record && method_exists($record, 'getLabel') ? $record->getLabel() : null;
+    }
+
+    protected function modelForRoute(Route $route): ?string
+    {
+        $model = $route->getMetadata('model');
+
+        return $model
+            ? Relation::getMorphedModel($model) ?? $model
+            : null;
     }
 }

--- a/src/View/Layouts/App.php
+++ b/src/View/Layouts/App.php
@@ -3,74 +3,20 @@
 namespace FluxErp\View\Layouts;
 
 use Closure;
+use FluxErp\View\PageTitle;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 class App extends Component
 {
     public function __construct(public ?string $title = null)
     {
-        $this->title ??= $this->titleForRoute(Request::route());
+        $this->title ??= resolve_static(PageTitle::class, 'forRoute', [Request::route()]);
     }
 
     public function render(): View|Closure|string
     {
         return view('flux::layouts.app');
-    }
-
-    protected function titleForRoute(?Route $route): string
-    {
-        $appName = config('app.name', 'Flux ERP');
-
-        if (! $route) {
-            return $appName;
-        }
-
-        return collect([
-            $this->section($route),
-            $this->recordLabel($route),
-            $appName,
-        ])
-            ->filter()
-            ->implode(' / ');
-    }
-
-    protected function section(Route $route): ?string
-    {
-        $section = $route->getMetadata('title');
-
-        if (! $section && $model = $this->modelForRoute($route)) {
-            $section = class_basename($model);
-        }
-
-        $section ??= Str::afterLast(rtrim($route->getName() ?? '', '.'), '.');
-
-        return $section ? __(Str::headline($section)) : null;
-    }
-
-    protected function recordLabel(Route $route): ?string
-    {
-        $model = $this->modelForRoute($route);
-
-        if (! $model || ! $key = $route->parameter('id')) {
-            return null;
-        }
-
-        $record = resolve_static($model, 'query')->whereKey($key)->first();
-
-        return $record && method_exists($record, 'getLabel') ? $record->getLabel() : null;
-    }
-
-    protected function modelForRoute(Route $route): ?string
-    {
-        $model = $route->getMetadata('model');
-
-        return $model
-            ? Relation::getMorphedModel($model) ?? $model
-            : null;
     }
 }

--- a/src/View/PageTitle.php
+++ b/src/View/PageTitle.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace FluxErp\View;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+
+class PageTitle
+{
+    public static function forRoute(?Route $route): string
+    {
+        $appName = config('app.name', 'Flux ERP');
+
+        if (! $route) {
+            return $appName;
+        }
+
+        $model = static::model($route);
+        $section = $route->getMetadata('title')
+            ?: ($model
+                ? class_basename($model)
+                : Str::afterLast(rtrim($route->getName() ?? '', '.'), '.'));
+
+        return collect([
+            $section ? __(Str::headline($section)) : null,
+            static::record($route, $model),
+            $appName,
+        ])
+            ->filter()
+            ->implode(' / ');
+    }
+
+    protected static function model(Route $route): ?string
+    {
+        $model = $route->getMetadata('model');
+
+        return $model
+            ? Relation::getMorphedModel($model) ?? $model
+            : null;
+    }
+
+    protected static function record(Route $route, ?string $model): ?string
+    {
+        if (! $model || ! $key = $route->parameter('id')) {
+            return null;
+        }
+
+        $record = resolve_static($model, 'query')->whereKey($key)->first();
+
+        return $record && method_exists($record, 'getLabel') ? $record->getLabel() : null;
+    }
+}

--- a/src/View/PageTitle.php
+++ b/src/View/PageTitle.php
@@ -2,7 +2,7 @@
 
 namespace FluxErp\View;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
 
@@ -16,38 +16,36 @@ class PageTitle
             return $appName;
         }
 
-        $model = static::model($route);
-        $section = $route->getMetadata('title')
-            ?: ($model
-                ? class_basename($model)
-                : Str::afterLast(rtrim($route->getName() ?? '', '.'), '.'));
+        $alias = $route->getMetadata('model');
 
         return collect([
-            $section ? __(Str::headline($section)) : null,
-            static::record($route, $model),
+            static::section($route, $alias),
+            static::recordLabel($route, $alias),
             $appName,
         ])
             ->filter()
             ->implode(' / ');
     }
 
-    protected static function model(Route $route): ?string
+    protected static function section(Route $route, ?string $alias): ?string
     {
-        $model = $route->getMetadata('model');
+        $section = $route->getMetadata('title')
+            ?: class_basename($alias ? morphed_model($alias) ?? '' : '')
+            ?: Str::afterLast(rtrim($route->getName() ?? '', '.'), '.');
 
-        return $model
-            ? Relation::getMorphedModel($model) ?? $model
-            : null;
+        return $section ? __(Str::headline($section)) : null;
     }
 
-    protected static function record(Route $route, ?string $model): ?string
+    protected static function recordLabel(Route $route, ?string $alias): ?string
     {
-        if (! $model || ! $key = $route->parameter('id')) {
-            return null;
-        }
+        $parameter = collect($route->parameters())->first();
 
-        $record = resolve_static($model, 'query')->whereKey($key)->first();
+        $record = $parameter instanceof Model
+            ? $parameter
+            : ($alias && $parameter ? morph_to($alias, (int) $parameter) : null);
 
-        return $record && method_exists($record, 'getLabel') ? $record->getLabel() : null;
+        return $record && method_exists($record, 'getLabel')
+            ? $record->getLabel()
+            : null;
     }
 }

--- a/src/View/PageTitle.php
+++ b/src/View/PageTitle.php
@@ -17,12 +17,14 @@ class PageTitle
         }
 
         $alias = $route->getMetadata('model');
+        $section = static::section($route, $alias);
+        $record = static::recordLabel($route, $alias);
 
-        return collect([
-            static::section($route, $alias),
-            static::recordLabel($route, $alias),
-            $appName,
-        ])
+        if ($section && $record && str_starts_with($record, $section)) {
+            $section = null;
+        }
+
+        return collect([$section, $record, $appName])
             ->filter()
             ->implode(' / ');
     }
@@ -38,7 +40,9 @@ class PageTitle
 
     protected static function recordLabel(Route $route, ?string $alias): ?string
     {
-        $parameter = collect($route->parameters())->first();
+        $parameter = $route->hasParameters()
+            ? collect($route->parameters())->first()
+            : null;
 
         $record = $parameter instanceof Model
             ? $parameter

--- a/tests/Feature/Web/PageTitleTest.php
+++ b/tests/Feature/Web/PageTitleTest.php
@@ -11,6 +11,7 @@ use FluxErp\Models\PaymentType;
 use FluxErp\Models\Permission;
 use FluxErp\Models\PriceList;
 use FluxErp\View\Layouts\App;
+use FluxErp\View\PageTitle;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -62,6 +63,18 @@ test('a detail page carries the record it shows', function (): void {
         ->toBe(__('Order') . ' / ' . e($this->order->getLabel()) . ' / ' . config('app.name'));
 });
 
+test('a record that repeats its section drops the section', function (): void {
+    $this->order->orderType->update(['name' => __('Order') . ' XY']);
+    $this->user->givePermissionTo(Permission::findOrCreate('orders.{id}.get', 'web'));
+
+    $response = $this->actingAs($this->user, 'web')
+        ->get('/orders/' . $this->order->id)
+        ->assertOk();
+
+    expect(renderedTitle($response))
+        ->toBe(e($this->order->fresh()->getLabel()) . ' / ' . config('app.name'));
+});
+
 test('a title passed in wins over the route', function (): void {
     Route::get('/page-title-explicit', fn () => '')
         ->name('orders.id')
@@ -76,4 +89,12 @@ test('a page without a route falls back to the application name', function (): v
     Request::setRouteResolver(fn () => null);
 
     expect((new App())->title)->toBe(config('app.name'));
+});
+
+test('a route that was never bound to a request still yields a title', function (): void {
+    $route = Route::get('/page-title-unbound/{id}', fn () => '')
+        ->name('page-title-unbound')
+        ->metadata(['title' => 'Order', 'model' => 'order']);
+
+    expect(PageTitle::forRoute($route))->toBe(__('Order') . ' / ' . config('app.name'));
 });

--- a/tests/Feature/Web/PageTitleTest.php
+++ b/tests/Feature/Web/PageTitleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Language;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\Permission;
+use FluxErp\Models\PriceList;
+use FluxErp\View\Layouts\App;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
+
+function renderedTitle($response): ?string
+{
+    preg_match('/<title>(.*?)<\/title>/s', $response->getContent(), $matches);
+
+    return isset($matches[1]) ? trim($matches[1]) : null;
+}
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->id]);
+
+    $this->order = Order::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'language_id' => Language::factory()->create()->id,
+        'order_type_id' => OrderType::factory()->create([
+            'order_type_enum' => OrderTypeEnum::Order,
+        ])->id,
+        'payment_type_id' => PaymentType::factory()
+            ->hasAttached(factory: $this->dbTenant, relationship: 'tenants')
+            ->create(['is_default' => false])
+            ->id,
+        'price_list_id' => PriceList::factory()->create()->id,
+        'currency_id' => Currency::factory()->create(['is_default' => true])->id,
+        'address_invoice_id' => $address->id,
+        'address_delivery_id' => $address->id,
+        'is_locked' => false,
+    ]);
+});
+
+test('a list page is titled after its route', function (): void {
+    $this->user->givePermissionTo(Permission::findOrCreate('orders.list.get', 'web'));
+
+    $response = $this->actingAs($this->user, 'web')->get('/orders/list')->assertOk();
+
+    expect(renderedTitle($response))->toBe(__('Orders') . ' / ' . config('app.name'));
+});
+
+test('a detail page carries the record it shows', function (): void {
+    $this->user->givePermissionTo(Permission::findOrCreate('orders.{id}.get', 'web'));
+
+    $response = $this->actingAs($this->user, 'web')
+        ->get('/orders/' . $this->order->id)
+        ->assertOk();
+
+    expect(renderedTitle($response))
+        ->toBe(__('Order') . ' / ' . e($this->order->getLabel()) . ' / ' . config('app.name'));
+});
+
+test('a title passed in wins over the route', function (): void {
+    Route::get('/page-title-explicit', fn () => '')
+        ->name('orders.id')
+        ->metadata(['model' => 'order']);
+
+    Request::setRouteResolver(fn () => Route::getRoutes()->getByName('orders.id'));
+
+    expect((new App('Handpicked'))->title)->toBe('Handpicked');
+});
+
+test('a page without a route falls back to the application name', function (): void {
+    Request::setRouteResolver(fn () => null);
+
+    expect((new App())->title)->toBe(config('app.name'));
+});


### PR DESCRIPTION
Every page sends the same document title, the application name, so a user with several tabs open cannot tell them apart. That is the one situation a title exists for.

## Why the layout class never ran

`resources/views/layouts/app.blade.php` already renders `{{ $title ?? config('app.name') }}` and `FluxErp\View\Layouts\App` is registered as its component, but nothing ever filled `$title`, and for Livewire pages the class was not even instantiated:

```php
// Livewire\Features\SupportPageComponents\PageComponentConfig
if (is_subclass_of($view, \Illuminate\View\Component::class)) {
    $layout = app()->makeWith($view, $params);
} else {
    $layout = new AnonymousComponent($view, $params);
}
```

`livewire.layout` held the view name `flux::layouts.app`, so every page component took the `AnonymousComponent` branch. Pointing the config at `App::class` makes Livewire instantiate the layout; it resolves its own view from `render()`, so the three `<x-flux::layouts.app>` blades keep working unchanged.

## How a route names its page

The title is built in three descending steps, which is why 124 frontend routes needed almost no declaration:

1. `metadata(['title' => ...])`, when a route names itself
2. the model a route resolves to
3. the last segment of the route name

Step three is the convention `MenuManager` already uses to label a menu entry registered without one, so list pages are covered for free.

Only detail routes were touched, and they name their model by morph alias:

```php
Route::get('/{id}', Order::class)->where('id', '[0-9]+')->name('id')
    ->metadata(['model' => 'order']);
```

By alias rather than class because this route file already imports the page component under the same short name, so every model would otherwise need `use FluxErp\Models\Order as OrderModel`. A fully qualified class name is accepted too, for applications with models outside the morph map.

Result:

```
/orders/list   Orders / Flux ERP
/orders/42     Order / Invoice - RE-2026-0042 - Acme Ltd / Flux ERP
```

The section comes first because a browser tab shows only its leading characters; the application name in front of all of them would defeat the purpose.

## Compatibility

A page that declares `#[Title]` is unaffected. Livewire hands that value to the layout as the constructor argument, so it wins over the route and no suffix is appended.

`app.blade.php` is unchanged. `SignaturePublicLink` swaps the layout at runtime and is not affected.

Applications get titles for their own routes by adding the same metadata; nothing is required of them for the core pages.

## Tests

Four feature tests: a list page titled from its route name, a detail page carrying its record label, an explicitly passed title winning over the route, and a layout rendered without a route falling back to the application name.

## Summary by Sourcery

Derive context-aware browser page titles from frontend routes and Livewire layout, so each tab shows a meaningful section and record label instead of only the application name.

New Features:
- Generate page titles in the App layout component based on route metadata, inferred model type, and record label, with fallback to the application name.
- Allow frontend routes to declare display models via metadata for detail pages, enabling titles like "Order / <record label> / Flux ERP".

Enhancements:
- Configure Livewire to use the App layout component class instead of the Blade view so layout logic (including title resolution) is executed for all pages.

Tests:
- Add feature tests covering list pages titled from route names, detail pages including their record labels, explicit titles overriding route-derived ones, and pages without routes falling back to the application name.