### PR TITLE
Detect the scout trait through the flux wrapper on the api index

### DIFF
--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -17,7 +17,7 @@ class BaseController extends Controller
     public function index(Request $request, string $model): JsonResponse
     {
         $model = app($model);
-        if ($request->filled('search') && ! in_array(Searchable::class, class_uses($model))) {
+        if ($request->filled('search') && ! in_array(Searchable::class, class_uses_recursive($model))) {
             return ResponseHelper::createResponseFromBase(
                 statusCode: 400,
                 data: ['search' => 'Search not allowed on given model.']

--- a/tests/Feature/Api/BaseControllerSearchTest.php
+++ b/tests/Feature/Api/BaseControllerSearchTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use FluxErp\Models\Contact;
+use FluxErp\Models\Language;
+use FluxErp\Models\Permission;
+use Laravel\Sanctum\Sanctum;
+
+test('the index endpoint accepts a search on a searchable model', function (): void {
+    Contact::factory()->create();
+    $this->user->givePermissionTo(Permission::findOrCreate('api.contacts.get'));
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->getJson('/api/contacts?search=a')->assertOk();
+});
+
+test('the index endpoint refuses a search on a model without scout', function (): void {
+    Language::factory()->create();
+    $this->user->givePermissionTo(Permission::findOrCreate('api.languages.get'));
+    Sanctum::actingAs($this->user, ['user']);
+
+    $this->getJson('/api/languages?search=a')
+        ->assertStatus(400)
+        ->assertJsonPath('errors.search', 'Search not allowed on given model.');
+});


### PR DESCRIPTION
`GET /api/<resource>?search=…` answers with `400 Search not allowed on given model` for every model, in every installation.

## Cause

`BaseController::index` checked

```php
in_array(Searchable::class, class_uses($model))
```

with `Searchable` being `Laravel\Scout\Searchable`. No model uses that trait directly — all 26 searchable models use `FluxErp\Traits\Scout\Searchable`, which pulls the scout trait in itself. `class_uses` only looks one level deep, so the scout trait is never in the result and the guard rejects every search.

`SearchController:26` already does the same check with `class_uses_recursive`, which is why the async selects in the frontend work while the REST endpoint does not. This change only brings the two back in line.

Verified against a live instance: `/api/products?search=gorilla` returned the 400 while the same search worked in the UI.

## Note

The test suite could not be run locally: `composer.lock` on main still pins pest 4 while `composer.json` requires `^5.0.1`, so `composer install` refuses. Leaving that to CI rather than committing a lockfile update alongside a one word fix.

## Summary by Sourcery

Allow API index endpoints to correctly detect Scout-searchable models when handling search queries.

Bug Fixes:
- Fix API index search guard so Scout-searchable models are accepted instead of incorrectly returning 400 errors.

Tests:
- Add feature tests verifying that searchable models accept index searches while non-Scout models are rejected with a 400 response.