### PR TITLE
Cancel superseded test runs of the same pull request

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
Every push to a pull request starts a new test run while the previous one keeps going. The test workflow has five jobs on `[self-hosted, Linux]`, so an outdated run occupies up to five slots of the on-prem runners for results nobody will read. During a busy afternoon that is what turns into a queue.

`concurrency` groups the runs per branch and cancels the running one when a newer push arrives. `cancel-in-progress` is bound to the event, so only pull request runs are cancelled and pushes to `dev` always finish.

The other workflows are left alone on purpose: `translation-audit` and `release` are `workflow_dispatch` only, `build-ci-image` runs on a path filter and should not be interrupted halfway through an image build, and `code-standards` pushes a styling fix back, which is nothing to abort.

## Summary by Sourcery

CI:
- Add concurrency configuration to group PR test runs per branch and cancel in-progress runs only for pull_request events.