### PR TITLE
Keep updating a schedule whose name is not a repeatable

### DIFF
--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -32,7 +32,10 @@ class UpdateSchedule extends FluxAction
             $repeatable = Repeatable::get($schedule->name);
 
             // Remove empty class parameters
-            $this->data['parameters'] = array_merge($repeatable['parameters'], $this->data['parameters'] ?? []);
+            $this->data['parameters'] = array_merge(
+                data_get($repeatable, 'parameters', []),
+                $this->data['parameters'] ?? []
+            );
             $this->data['parameters'] = array_filter($this->data['parameters']);
         }
 

--- a/tests/Feature/Actions/Schedule/ScheduleActionTest.php
+++ b/tests/Feature/Actions/Schedule/ScheduleActionTest.php
@@ -1,7 +1,33 @@
 <?php
 
 use FluxErp\Actions\Schedule\CreateSchedule;
+use FluxErp\Actions\Schedule\UpdateSchedule;
+use FluxErp\Invokable\ProcessSubscriptionOrder;
+use FluxErp\Models\Schedule;
 
 test('create schedule requires name and cron', function (): void {
     CreateSchedule::assertValidationErrors([], ['name', 'cron']);
+});
+
+test('a schedule with an unknown repeatable name can still be updated', function (): void {
+    $schedule = Schedule::query()->create([
+        'name' => 'Miete Buero Salzstrasse (Auftrag 941)',
+        'class' => ProcessSubscriptionOrder::class,
+        'type' => 'invokable',
+        'cron' => [
+            'methods' => ['basic' => 'monthlyOn', 'dayConstraint' => null, 'timeConstraint' => null],
+            'parameters' => ['basic' => [1, '06:00'], 'dayConstraint' => [], 'timeConstraint' => []],
+        ],
+        'parameters' => ['orderId' => 1],
+        'is_active' => true,
+    ]);
+
+    $updated = UpdateSchedule::make([
+        'id' => $schedule->getKey(),
+        'parameters' => ['orderId' => 2],
+    ])
+        ->validate()
+        ->execute();
+
+    expect(data_get($updated->parameters, 'orderId'))->toBe(2);
 });


### PR DESCRIPTION
Saving the contract card of a subscription order threw a 500 and swallowed the entered values. The save button chains `saveSchedule()` into `save()`, so when the schedule save died the order was never written and the calculated contract total was gone after the next render.

`UpdateSchedule` looks the repeatable up by the stored schedule name. `Repeatable::get()` returns null for a name that is not registered, and the null went straight into `array_merge()`. Schedules created with a readable name instead of the repeatable identifier, 13 of them on our own instance, could therefore never be updated. Flare counted 190 occurrences since April across 2 users, all on order pages.

The lookup result is now read through `data_get()` with an empty array as the fallback, so an unknown name simply contributes no class parameters.

Verified on the live instance before this PR: the save writes `contract_total_amount` again and the value survives a reload.

## Summary by Sourcery

Handle schedules whose names do not map to a registered repeatable so they can be updated without failing.

Bug Fixes:
- Prevent schedule updates from breaking when Repeatable::get() returns null by defaulting missing class parameters to an empty array.

Tests:
- Add a feature test ensuring schedules with an unknown repeatable name can be successfully updated and persist changed parameters.