### PR TITLE
Bump the npm dependencies dependabot proposed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
                 "@simplewebauthn/browser": "^13.3.0",
                 "@techstark/opencv-js": "^4.12.0-release.1",
                 "fullcalendar": "^7.0.2",
-                "temporal-polyfill": "^1.0.1"
+                "temporal-polyfill": "^1.0.3"
             },
             "devDependencies": {
-                "@alpinejs/collapse": "^3.15.12",
-                "@alpinejs/sort": "^3.15.12",
+                "@alpinejs/collapse": "^3.16.0",
+                "@alpinejs/sort": "^3.16.0",
                 "@floating-ui/dom": "^1.8.0",
                 "@fontsource/inter": "^5.0.18",
                 "@phosphor-icons/web": "^2.1.1",
@@ -30,7 +30,7 @@
                 "@tiptap/pm": "^3.29.2",
                 "@tiptap/starter-kit": "^3.29.2",
                 "@wireui/alpinejs-hold-directive": "^1.0.1",
-                "alpinejs": "^3.15.12",
+                "alpinejs": "^3.16.0",
                 "apexcharts": "^5.16.0",
                 "axios": "^1.19.0",
                 "dayjs": "^1.11.21",
@@ -42,10 +42,10 @@
                 "leaflet": "^1.9.4",
                 "leaflet.markercluster": "^1.5.3",
                 "playwright": "^1.62.1",
-                "prettier": "^3.9.5",
+                "prettier": "^3.9.6",
                 "prettier-plugin-blade": "^3.2.2",
                 "prettier-plugin-tailwindcss": "^0.8.1",
-                "pusher-js": "^8.4.0-rc2",
+                "pusher-js": "^8.6.0",
                 "qs": "^6.15.3",
                 "signature_pad": "^5.1.4",
                 "tailwindcss": "^4.3.2",
@@ -54,16 +54,16 @@
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.12.tgz",
-            "integrity": "sha512-BKNANLtNXuWYOSAnajSKLPjTsmHRNrv0ALFTbpmqt2/klHFooPhctSwkhFVPQb7rZ8BjEKHmNaBwnSbgtpk6xg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.0.tgz",
+            "integrity": "sha512-qXgeb99MhITdjd46SIDU0UuiArYGzpEyyr5t0XJlrqvBgURO/U16yxHN+x/L2AJnHGxfHfiBl4Fy77xPdJ08Ww==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.12.tgz",
-            "integrity": "sha512-DNIS7SQFg4H4o5faluRgqYEPi1Q7Hf+HMDgoCcIHXbXWH0g66WPEzz9OMk1zsUYib0KxMms4xXOqk+xh2tHZzg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.0.tgz",
+            "integrity": "sha512-DSeqbyxL/vEqLQvN1BpAKfSUwdxPUGTCMBa04Z5J9ISKXAyBsC61kb7rXn1DxUuusgD/4er7hjynpZQZV7LQ6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1352,9 +1352,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-            "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.0.tgz",
+            "integrity": "sha512-fRAp17Igmh2NHvgRGOY8n/x9o/g8rlseVn27awaq3wy7IsNYfu0lKnQGHn4WQx+NdjnpQFajhRiULah+R1Nsog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2380,9 +2380,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.9.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-            "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2665,9 +2665,9 @@
             }
         },
         "node_modules/pusher-js": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
-            "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.6.0.tgz",
+            "integrity": "sha512-wShJPfCS/kYkCBVzVW67wa9cnQIgHTszEK2XHNrFkOgGruuGw081aERAxfRjfdFU+WcIt8x6dvbwkTW4iZuQ8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2853,19 +2853,19 @@
             }
         },
         "node_modules/temporal-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-            "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.3.tgz",
+            "integrity": "sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==",
             "license": "MIT",
             "dependencies": {
-                "temporal-spec": "1.0.0",
+                "temporal-spec": "1.0.1",
                 "temporal-utils": "1.0.1"
             }
         },
         "node_modules/temporal-spec": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
-            "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+            "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
             "license": "Apache-2.0"
         },
         "node_modules/temporal-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2228,9 +2228,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,10 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "flux-core",
             "dependencies": {
                 "@simplewebauthn/browser": "^13.3.0",
                 "@techstark/opencv-js": "^4.12.0-release.1",
-                "fullcalendar": "^7.0.1",
+                "fullcalendar": "^7.0.2",
                 "temporal-polyfill": "^1.0.1"
             },
             "devDependencies": {
@@ -33,7 +32,7 @@
                 "@wireui/alpinejs-hold-directive": "^1.0.1",
                 "alpinejs": "^3.15.12",
                 "apexcharts": "^5.16.0",
-                "axios": "^1.18.1",
+                "axios": "^1.19.0",
                 "dayjs": "^1.11.21",
                 "filepond": "^4.31.3",
                 "filepond-plugin-image-preview": "^4.6.12",
@@ -45,13 +44,13 @@
                 "playwright": "^1.62.1",
                 "prettier": "^3.9.5",
                 "prettier-plugin-blade": "^3.2.2",
-                "prettier-plugin-tailwindcss": "^0.8.0",
+                "prettier-plugin-tailwindcss": "^0.8.1",
                 "pusher-js": "^8.4.0-rc2",
                 "qs": "^6.15.3",
-                "signature_pad": "^5.0.1",
+                "signature_pad": "^5.1.4",
                 "tailwindcss": "^4.3.2",
                 "uuid": "^14.0.1",
-                "vite": "^8.1.4"
+                "vite": "^8.2.1"
             }
         },
         "node_modules/@alpinejs/collapse": {
@@ -144,21 +143,21 @@
             }
         },
         "node_modules/@full-ui/headless-calendar": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@full-ui/headless-calendar/-/headless-calendar-7.0.1.tgz",
-            "integrity": "sha512-ridxaPRKiSzfeXkk8kta1wC9asYqPWXf4q0KbUW5hRvWQ1rkxeUbhBarcMEOFC7FvJHczPSAm0JzSrXv/ykuKw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@full-ui/headless-calendar/-/headless-calendar-7.0.2.tgz",
+            "integrity": "sha512-i6UlTNjBVuiBca5Sq6OoLxFqK6eaQ/v1XOLObjRkzXLuSuNn+qs9/dUvlzrbeesn7QbRH7+u7lyvlQyq8WvmGA==",
             "license": "MIT",
             "peerDependencies": {
                 "temporal-polyfill": "^1.0.1"
             }
         },
         "node_modules/@fullcalendar/core": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-7.0.1.tgz",
-            "integrity": "sha512-SRJT4lSRZZGVCz6ss48pFCNiIS7iutpQVID73GFQufH94MTYs+akCW9aKCjMwsnEWad5UV7Mcm4xndFQ4dDi0g==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-7.0.2.tgz",
+            "integrity": "sha512-EkhE1wkPttp5kKNmUNLsMwl8nUuQmLdj30SPKagOEWMJUE4AHETAu/F/SbYoRq+nksm2GWPe9cQs1kbQP2H9pA==",
             "license": "MIT",
             "peerDependencies": {
-                "@full-ui/headless-calendar": "7.0.1",
+                "@full-ui/headless-calendar": "7.0.2",
                 "temporal-polyfill": "^1.0.1"
             }
         },
@@ -232,9 +231,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.139.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -263,9 +262,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
             "cpu": [
                 "arm64"
             ],
@@ -280,9 +279,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
             "cpu": [
                 "arm64"
             ],
@@ -297,9 +296,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
             "cpu": [
                 "x64"
             ],
@@ -314,9 +313,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
             "cpu": [
                 "x64"
             ],
@@ -331,9 +330,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
             "cpu": [
                 "arm"
             ],
@@ -348,9 +347,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
             "cpu": [
                 "arm64"
             ],
@@ -365,9 +364,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -382,9 +381,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
             "cpu": [
                 "ppc64"
             ],
@@ -399,9 +398,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
             "cpu": [
                 "s390x"
             ],
@@ -416,9 +415,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
             "cpu": [
                 "x64"
             ],
@@ -433,9 +432,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
             "cpu": [
                 "x64"
             ],
@@ -450,9 +449,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
             "cpu": [
                 "arm64"
             ],
@@ -466,29 +465,10 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
             "cpu": [
                 "arm64"
             ],
@@ -503,9 +483,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
             "cpu": [
                 "x64"
             ],
@@ -1396,14 +1376,14 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+            "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -1677,13 +1657,13 @@
             }
         },
         "node_modules/fullcalendar": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-7.0.1.tgz",
-            "integrity": "sha512-e4HymMjH93UtKq9srPeN1cwmVsW5w6CmVNIb4qr4q1tMpl8RpMD9zaJAbbtlSjjMH0ELGP9yJwq9l34wDPUenA==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-7.0.2.tgz",
+            "integrity": "sha512-xqt/4CrnabOUVfu5PExyc6plbwH8QA1jAusRw6JOUfS+BmpA19W74lNLDty6EO0H+2cm/qVMza4TgQiJLHPAqQ==",
             "license": "MIT",
             "dependencies": {
-                "@full-ui/headless-calendar": "7.0.1",
-                "@fullcalendar/core": "7.0.1",
+                "@full-ui/headless-calendar": "7.0.2",
+                "@fullcalendar/core": "7.0.2",
                 "preact": "^10.29.0"
             },
             "peerDependencies": {
@@ -2444,9 +2424,9 @@
             }
         },
         "node_modules/prettier-plugin-tailwindcss": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
-            "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.1.tgz",
+            "integrity": "sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2712,13 +2692,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.139.0",
+                "@oxc-project/types": "=0.143.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -2728,21 +2708,20 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.5",
-                "@rolldown/binding-darwin-arm64": "1.1.5",
-                "@rolldown/binding-darwin-x64": "1.1.5",
-                "@rolldown/binding-freebsd-x64": "1.1.5",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-                "@rolldown/binding-linux-arm64-musl": "1.1.5",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-musl": "1.1.5",
-                "@rolldown/binding-openharmony-arm64": "1.1.5",
-                "@rolldown/binding-wasm32-wasi": "1.1.5",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+                "@rolldown/binding-android-arm64": "1.2.3",
+                "@rolldown/binding-darwin-arm64": "1.2.3",
+                "@rolldown/binding-darwin-x64": "1.2.3",
+                "@rolldown/binding-freebsd-x64": "1.2.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+                "@rolldown/binding-linux-arm64-musl": "1.2.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-musl": "1.2.3",
+                "@rolldown/binding-openharmony-arm64": "1.2.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+                "@rolldown/binding-win32-x64-msvc": "1.2.3"
             }
         },
         "node_modules/rope-sequence": {
@@ -2829,9 +2808,9 @@
             }
         },
         "node_modules/signature_pad": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-5.1.3.tgz",
-            "integrity": "sha512-zyxW5vuJVnQdGcU+kAj9FYl7WaAunY3kA5S7mPg0xJiujL9+sPAWfSQHS5tXaJXDUa4FuZeKhfdCDQ6K3wfkpQ==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-5.1.4.tgz",
+            "integrity": "sha512-q0wO5a+U+AWPVcVmiNXz7FY4Ad1QiE8wto/3Yn41WVqepoVVYMvkb1CTokaWPUUAHWDLLabH3/acODeWM9jCrg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2949,16 +2928,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
+                "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.17",
-                "rolldown": "~1.1.5",
+                "postcss": "^8.5.25",
+                "rolldown": "~1.2.1",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -2975,7 +2954,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -3063,6 +3042,267 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "sort-lang": "node scripts/sort-lang-json.mjs"
     },
     "devDependencies": {
-        "@alpinejs/collapse": "^3.15.12",
-        "@alpinejs/sort": "^3.15.12",
+        "@alpinejs/collapse": "^3.16.0",
+        "@alpinejs/sort": "^3.16.0",
         "@floating-ui/dom": "^1.8.0",
         "@fontsource/inter": "^5.0.18",
         "@phosphor-icons/web": "^2.1.1",
@@ -27,7 +27,7 @@
         "@tiptap/pm": "^3.29.2",
         "@tiptap/starter-kit": "^3.29.2",
         "@wireui/alpinejs-hold-directive": "^1.0.1",
-        "alpinejs": "^3.15.12",
+        "alpinejs": "^3.16.0",
         "apexcharts": "^5.16.0",
         "axios": "^1.19.0",
         "dayjs": "^1.11.21",
@@ -39,10 +39,10 @@
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "playwright": "^1.62.1",
-        "prettier": "^3.9.5",
+        "prettier": "^3.9.6",
         "prettier-plugin-blade": "^3.2.2",
         "prettier-plugin-tailwindcss": "^0.8.1",
-        "pusher-js": "^8.4.0-rc2",
+        "pusher-js": "^8.6.0",
         "qs": "^6.15.3",
         "signature_pad": "^5.1.4",
         "tailwindcss": "^4.3.2",
@@ -53,6 +53,6 @@
         "@simplewebauthn/browser": "^13.3.0",
         "@techstark/opencv-js": "^4.12.0-release.1",
         "fullcalendar": "^7.0.2",
-        "temporal-polyfill": "^1.0.1"
+        "temporal-polyfill": "^1.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@wireui/alpinejs-hold-directive": "^1.0.1",
         "alpinejs": "^3.15.12",
         "apexcharts": "^5.16.0",
-        "axios": "^1.18.1",
+        "axios": "^1.19.0",
         "dayjs": "^1.11.21",
         "filepond": "^4.31.3",
         "filepond-plugin-image-preview": "^4.6.12",
@@ -41,18 +41,18 @@
         "playwright": "^1.62.1",
         "prettier": "^3.9.5",
         "prettier-plugin-blade": "^3.2.2",
-        "prettier-plugin-tailwindcss": "^0.8.0",
+        "prettier-plugin-tailwindcss": "^0.8.1",
         "pusher-js": "^8.4.0-rc2",
         "qs": "^6.15.3",
-        "signature_pad": "^5.0.1",
+        "signature_pad": "^5.1.4",
         "tailwindcss": "^4.3.2",
         "uuid": "^14.0.1",
-        "vite": "^8.1.4"
+        "vite": "^8.2.1"
     },
     "dependencies": {
         "@simplewebauthn/browser": "^13.3.0",
         "@techstark/opencv-js": "^4.12.0-release.1",
-        "fullcalendar": "^7.0.1",
+        "fullcalendar": "^7.0.2",
         "temporal-polyfill": "^1.0.1"
     }
 }


### PR DESCRIPTION
Collects the five open dependabot bumps into one pull request so the runners build them once instead of five times, plus the packages that had a newer version inside their existing range.

| Package | From | To |
|---|---|---|
| vite | 8.1.5 | 8.2.1 |
| fullcalendar | 7.0.1 | 7.0.2 |
| axios | 1.18.1 | 1.19.0 |
| signature_pad | 5.1.3 | 5.1.4 |
| prettier-plugin-tailwindcss | 0.8.0 | 0.8.1 |
| alpinejs | 3.15.12 | 3.16.0 |
| @alpinejs/collapse | 3.15.12 | 3.16.0 |
| @alpinejs/sort | 3.15.12 | 3.16.0 |
| prettier | 3.9.5 | 3.9.6 |
| pusher-js | 8.4.0-rc2 | 8.6.0 |
| temporal-polyfill | 1.0.1 | 1.0.3 |

`npm ci`, `npm run build` and a prettier check pass locally. Replaces #1986, #1987, #1988, #1989 and #1990.

The two majors are deliberately left out and get their own pull request: `@techstark/opencv-js` 4 to 5 sits in the document scan and `apexcharts` 5 to 6 drives every chart widget, both need a look in the browser.