### PR TITLE
feat(accounting): list outstanding items again after the reminder run rework

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1959,6 +1959,7 @@
     "Other": "Sonstige",
     "Other media": "Sonstige Dateien",
     "Outstanding": "Ausstehend",
+    "Outstanding Items": "Offene Posten",
     "Overall Lead Won Lost Ratio": "Gesamtes Lead Gewinn-Verlust-Verhältnis",
     "Overdue": "Überfällig",
     "Overdue Installments": "Überfällige Raten",

--- a/routes/frontend/web.php
+++ b/routes/frontend/web.php
@@ -15,6 +15,7 @@ use FluxErp\Livewire\Accounting\LedgerBookings;
 use FluxErp\Livewire\Accounting\Loan;
 use FluxErp\Livewire\Accounting\Loans;
 use FluxErp\Livewire\Accounting\MoneyTransfer;
+use FluxErp\Livewire\Accounting\OutstandingItems;
 use FluxErp\Livewire\Accounting\PaymentReminderRun;
 use FluxErp\Livewire\Accounting\PaymentRunPreview;
 use FluxErp\Livewire\Accounting\TransactionAssignments;
@@ -292,6 +293,7 @@ Route::middleware('web')
                         Route::get('/loans', Loans::class)->name('loans');
                         Route::get('/loans/{id}', Loan::class)->where('id', '[0-9]+')->name('loans.id')
                             ->metadata(['model' => 'loan']);
+                        Route::get('/outstanding-items', OutstandingItems::class)->name('outstanding-items');
                         Route::get('/payment-reminder-run', PaymentReminderRun::class)->name('payment-reminder-run');
                         Route::get('/purchase-invoices', PurchaseInvoiceList::class)->name('purchase-invoices');
                         Route::get('/transactions', TransactionList::class)->name('transactions');

--- a/src/Livewire/Accounting/OutstandingItems.php
+++ b/src/Livewire/Accounting/OutstandingItems.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FluxErp\Livewire\Accounting;
+
+use FluxErp\Livewire\Order\OrderList;
+use Illuminate\Database\Eloquent\Builder;
+
+class OutstandingItems extends OrderList
+{
+    public ?string $cacheKey = 'accounting.outstanding-items';
+
+    public array $enabledCols = [
+        'invoice_number',
+        'invoice_date',
+        'contact.customer_number',
+        'address_invoice.name',
+        'total_gross_price',
+        'balance',
+        'payment_reminder_current_level',
+    ];
+
+    protected function getBuilder(Builder $builder): Builder
+    {
+        return parent::getBuilder($builder)
+            ->unpaid()
+            ->revenue();
+    }
+}

--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -81,6 +81,7 @@ class MenuServiceProvider extends ServiceProvider
                 Menu::register(route: 'accounting.commissions');
                 Menu::register(route: 'accounting.ledger-bookings');
                 Menu::register(route: 'accounting.loans');
+                Menu::register(route: 'accounting.outstanding-items');
                 Menu::register(route: 'accounting.payment-reminder-run');
                 Menu::register(route: 'accounting.purchase-invoices');
                 Menu::register(route: 'accounting.transactions');

--- a/tests/Livewire/Accounting/OutstandingItemsTest.php
+++ b/tests/Livewire/Accounting/OutstandingItemsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Livewire\Accounting\OutstandingItems;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use Livewire\Livewire;
+
+function outstandingIds(): array
+{
+    $component = new OutstandingItems();
+    $method = new ReflectionMethod(OutstandingItems::class, 'getBuilder');
+    $method->setAccessible(true);
+
+    return $method->invoke($component, Order::query())->pluck('id')->all();
+}
+
+function createOutstandingOrder(object $test, array $orderAttributes = [], array $rawAttributes = []): Order
+{
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+
+    $paymentType = PaymentType::factory()
+        ->hasAttached($test->dbTenant, relationship: 'tenants')
+        ->create(['is_direct_debit' => false]);
+
+    $order = Order::factory()->create(array_merge([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'tenant_id' => $test->dbTenant->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $test->defaultLanguage->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-' . fake()->unique()->numberBetween(1000, 9999),
+    ], $orderAttributes));
+
+    Order::query()->whereKey($order->getKey())->update(array_merge([
+        'balance' => 250,
+        'payment_state' => 'open',
+    ], $rawAttributes));
+
+    return $order->refresh();
+}
+
+test('outstanding items renders', function (): void {
+    Livewire::test(OutstandingItems::class)
+        ->assertOk();
+});
+
+test('outstanding items lists an unpaid invoice', function (): void {
+    $order = createOutstandingOrder($this);
+
+    expect(outstandingIds())->toContain($order->getKey());
+});
+
+test('outstanding items hides orders without an invoice number', function (): void {
+    $order = createOutstandingOrder($this, ['invoice_number' => null]);
+
+    expect(outstandingIds())->not->toContain($order->getKey());
+});
+
+test('outstanding items hides settled invoices', function (): void {
+    $order = createOutstandingOrder($this, [], ['balance' => 0, 'payment_state' => 'paid']);
+
+    expect(outstandingIds())->not->toContain($order->getKey());
+});
+
+test('outstanding items hides purchase orders', function (): void {
+    $purchaseOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Purchase,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+
+    $order = createOutstandingOrder($this, ['order_type_id' => $purchaseOrderType->getKey()]);
+
+    expect(outstandingIds())->not->toContain($order->getKey());
+});
+
+test('outstanding items lists an invoice that is not due for a reminder yet', function (): void {
+    $order = createOutstandingOrder($this, [], [
+        'payment_reminder_next_date' => now()->addDays(30)->toDateString(),
+    ]);
+
+    expect(outstandingIds())->toContain($order->getKey());
+});


### PR DESCRIPTION
Reported by a customer after #1845: the **Mahnungen** page was not only the dunning entry point, it doubled as the list of every unpaid invoice. The reminder run cannot fill that role, it deliberately holds only what is due for a reminder today, so an invoice that is open but not yet due disappeared from view.

Adds **Buchhaltung > Offene Posten**, a page on top of `Order\OrderList` whose builder adds the two scopes the model already has:

```php
return parent::getBuilder($builder)
    ->unpaid()
    ->revenue();
```

`unpaid()` is invoice number present, payment state not paid, balance not zero. `revenue()` drops the purchase side. Together they are what the removed page queried.

Building on the order list means filters, column selection, saved filters, export and the existing actions come along, and the page carries its own cache key so column settings do not collide with the order list.

The dashboard widget already redirected here in spirit: #1845 pointed its **Show** and **Show overdue** options at the order list through a `SessionFilter`. This gives the same view a permanent, discoverable place in the menu.

Note for deployment: the route brings a new permission that has to be assigned, same as the reminder run itself.

## Summary by Sourcery

Add an accounting view that lists outstanding revenue invoices independently of the payment reminder run.

New Features:
- Introduce an Outstanding Items accounting page based on the order list to show all unpaid revenue invoices.
- Expose the Outstanding Items view via a new frontend route and register it in the accounting menu.

Tests:
- Add Livewire tests to verify that the Outstanding Items view includes only unpaid revenue invoices and excludes non-invoiced, settled, purchase, or not-yet-remindable orders.

Chores:
- Introduce a new permission associated with the Outstanding Items route that must be assigned on deployment.