### PR TITLE
feat(order): create payment reminders straight from the order list

### DIFF
--- a/src/Livewire/Order/OrderList.php
+++ b/src/Livewire/Order/OrderList.php
@@ -406,8 +406,6 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
                 continue;
             }
 
-            // The action returns a fresh model, so the document hooks would query
-            // the order again for every single reminder.
             $reminder->setRelation('order', $order);
 
             $reminders->push($reminder);

--- a/src/Livewire/Order/OrderList.php
+++ b/src/Livewire/Order/OrderList.php
@@ -394,17 +394,23 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
         $reminders = collect();
         foreach ($orders as $order) {
             try {
-                $reminders->push(
-                    CreatePaymentReminder::make([
-                        'order_id' => $order->getKey(),
-                        'reminder_level' => (int) $order->payment_reminder_current_level + 1,
-                    ])
-                        ->validate()
-                        ->execute()
-                );
+                $reminder = CreatePaymentReminder::make([
+                    'order_id' => $order->getKey(),
+                    'reminder_level' => (int) $order->payment_reminder_current_level + 1,
+                ])
+                    ->validate()
+                    ->execute();
             } catch (ValidationException $e) {
                 exception_to_notifications($e, $this);
+
+                continue;
             }
+
+            // The action returns a fresh model, so the document hooks would query
+            // the order again for every single reminder.
+            $reminder->setRelation('order', $order);
+
+            $reminders->push($reminder);
         }
 
         $this->createDocumentFromItems($reminders);

--- a/src/Livewire/Order/OrderList.php
+++ b/src/Livewire/Order/OrderList.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\Order;
 use FluxErp\Actions\Order\CreateOrder;
 use FluxErp\Actions\Order\DeleteOrder;
 use FluxErp\Actions\Order\UpdateLockedOrder;
+use FluxErp\Actions\PaymentReminder\CreatePaymentReminder;
 use FluxErp\Contracts\OffersPrinting;
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Livewire\Forms\CollectiveOrderForm;
@@ -13,6 +14,7 @@ use FluxErp\Models\Contact;
 use FluxErp\Models\Language;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentReminder;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 use FluxErp\Models\Tenant;
@@ -21,9 +23,11 @@ use FluxErp\Support\Bus\BulkExecutor;
 use FluxErp\Traits\Livewire\CreatesDocuments;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 use Laravel\SerializableClosure\SerializableClosure;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use TeamNiftyGmbH\DataTable\Htmlables\DataTableButton;
@@ -31,9 +35,14 @@ use Throwable;
 
 class OrderList extends \FluxErp\Livewire\DataTables\OrderList
 {
-    use CreatesDocuments;
+    use CreatesDocuments {
+        openCreateDocumentsModal as protected openDocumentsModal;
+    }
 
     public ?string $cacheKey = 'order.order-list';
+
+    #[Locked]
+    public bool $createsPaymentReminders = false;
 
     public ?int $mapLimit = 100;
 
@@ -74,6 +83,12 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
                 ->text(__('Create Documents'))
                 ->color('indigo')
                 ->wireClick('openCreateDocumentsModal()'),
+            DataTableButton::make()
+                ->icon('bell-alert')
+                ->text(__('Create Payment Reminder'))
+                ->color('indigo')
+                ->when(fn () => resolve_static(CreatePaymentReminder::class, 'canPerformAction', [false]))
+                ->wireClick('openCreatePaymentRemindersModal()'),
             DataTableButton::make()
                 ->icon('banknotes')
                 ->text(__('Mark as paid'))
@@ -137,9 +152,37 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
     #[Renderless]
     public function createDocuments(): void
     {
+        if ($this->createsPaymentReminders) {
+            $this->createPaymentReminderDocuments();
+
+            return;
+        }
+
         $this->createDocumentFromItems($this->getSelectedModels());
         $this->loadData();
         $this->reset('selected');
+    }
+
+    public function openCreateDocumentsModal(): void
+    {
+        $this->createsPaymentReminders = false;
+
+        $this->openDocumentsModal();
+    }
+
+    public function openCreatePaymentRemindersModal(): void
+    {
+        try {
+            resolve_static(CreatePaymentReminder::class, 'canPerformAction', [true]);
+        } catch (UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $this->createsPaymentReminders = true;
+
+        $this->openDocumentsModal();
     }
 
     #[Renderless]
@@ -330,8 +373,60 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
         $this->dispatch('load-map');
     }
 
+    protected function createPaymentReminderDocuments(): void
+    {
+        $baseQuery = $this->getSelectedModelsQuery();
+
+        $orders = (clone $baseQuery)
+            ->whereHasMailablePaymentReminderAddress()
+            ->get();
+
+        $skippedCount = (clone $baseQuery)->count() - $orders->count();
+
+        if ($skippedCount > 0) {
+            $this->toast()
+                ->warning(
+                    __(':count order(s) skipped due to missing email address.', ['count' => $skippedCount])
+                )
+                ->send();
+        }
+
+        $reminders = collect();
+        foreach ($orders as $order) {
+            try {
+                $reminders->push(
+                    CreatePaymentReminder::make([
+                        'order_id' => $order->getKey(),
+                        'reminder_level' => (int) $order->payment_reminder_current_level + 1,
+                    ])
+                        ->validate()
+                        ->execute()
+                );
+            } catch (ValidationException $e) {
+                exception_to_notifications($e, $this);
+            }
+        }
+
+        $this->createDocumentFromItems($reminders);
+
+        $this->loadData();
+        $this->reset('selected');
+    }
+
     protected function getBladeParameters(OffersPrinting $item): array|SerializableClosure|null
     {
+        if ($item instanceof PaymentReminder) {
+            $reminderId = $item->getKey();
+
+            return new SerializableClosure(
+                fn (): array => [
+                    'paymentReminder' => resolve_static(PaymentReminder::class, 'query')
+                        ->whereKey($reminderId)
+                        ->first(),
+                ]
+            );
+        }
+
         return new SerializableClosure(
             fn () => [
                 'order' => resolve_static(Order::class, 'query')
@@ -343,11 +438,19 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
 
     protected function getDefaultTemplateId(OffersPrinting $item): ?int
     {
+        if ($item instanceof PaymentReminder) {
+            return $item->getPaymentReminderText()?->email_template_id;
+        }
+
         return $item->orderType?->email_template_id;
     }
 
     protected function getPrintLayouts(): array
     {
+        if ($this->createsPaymentReminders) {
+            return app(PaymentReminder::class)->resolvePrintViews();
+        }
+
         return resolve_static(Order::class, 'query')
             ->whereKey($this->getSelectedValues())
             ->with('orderType')
@@ -357,11 +460,21 @@ class OrderList extends \FluxErp\Livewire\DataTables\OrderList
 
     protected function getPreferredLanguageId(OffersPrinting $item): ?int
     {
+        if ($item instanceof PaymentReminder) {
+            return $item->order->language_id;
+        }
+
         return $item->language_id;
     }
 
     protected function getTo(OffersPrinting $item, array $documents): array
     {
+        if ($item instanceof PaymentReminder) {
+            return array_filter(
+                Arr::wrap($item->order->resolveMailablePaymentReminderAddress()?->email_primary)
+            );
+        }
+
         $printViews = $item->getPrintViews();
 
         $invoiceDocs = array_filter(

--- a/tests/Livewire/Order/OrderListTest.php
+++ b/tests/Livewire/Order/OrderListTest.php
@@ -8,6 +8,7 @@ use FluxErp\Models\Contact;
 use FluxErp\Models\Currency;
 use FluxErp\Models\Order;
 use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentReminder;
 use FluxErp\Models\PaymentType;
 use FluxErp\Models\PriceList;
 use FluxErp\States\Order\PaymentState\Open;
@@ -112,4 +113,98 @@ test('marking orders as paid does nothing without a selection', function (): voi
         ->assertHasNoErrors();
 
     Queue::assertNothingPushed();
+});
+
+test('creating payment reminders from the order list switches the modal to reminder layouts', function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => OrderType::factory()->create([
+            'order_type_enum' => OrderTypeEnum::Order,
+            'is_active' => true,
+        ])->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => PaymentType::factory()
+            ->hasAttached($this->dbTenant, relationship: 'tenants')
+            ->create()
+            ->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_locked' => true,
+        'invoice_number' => 'INV-2026-900',
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    $component = Livewire::test(OrderList::class)
+        ->set('selected', [$order->getKey()])
+        ->call('openCreatePaymentRemindersModal')
+        ->assertOk()
+        ->assertSet('createsPaymentReminders', true);
+
+    expect($component->get('printLayouts'))->not->toBeEmpty();
+
+    // Opening the regular document modal switches back to the order layouts.
+    $component->call('openCreateDocumentsModal')
+        ->assertSet('createsPaymentReminders', false);
+});
+
+test('creating payment reminders skips orders without a mailable address', function (): void {
+    $withEmail = Contact::factory()->create();
+    $addressWithEmail = Address::factory()->create([
+        'contact_id' => $withEmail->getKey(),
+        'email_primary' => 'reminder@example.com',
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+
+    $withoutEmail = Contact::factory()->create();
+    $addressWithoutEmail = Address::factory()->create([
+        'contact_id' => $withoutEmail->getKey(),
+        'email_primary' => null,
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+    $paymentType = PaymentType::factory()
+        ->hasAttached($this->dbTenant, relationship: 'tenants')
+        ->create();
+
+    $makeOrder = fn (Contact $contact, Address $address, string $invoiceNumber) => Order::factory()->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'is_locked' => true,
+        'invoice_number' => $invoiceNumber,
+        'payment_reminder_current_level' => 0,
+    ]);
+
+    $mailable = $makeOrder($withEmail, $addressWithEmail, 'INV-2026-901');
+    $unmailable = $makeOrder($withoutEmail, $addressWithoutEmail, 'INV-2026-902');
+
+    Livewire::test(OrderList::class)
+        ->set('selected', [$mailable->getKey(), $unmailable->getKey()])
+        ->call('openCreatePaymentRemindersModal')
+        ->call('createDocuments')
+        ->assertOk();
+
+    expect(PaymentReminder::query()->where('order_id', $mailable->getKey())->exists())->toBeTrue()
+        ->and(PaymentReminder::query()->where('order_id', $unmailable->getKey())->exists())->toBeFalse();
 });


### PR DESCRIPTION
Follow-up to #1845. The removed dunning page carried a bulk action the reminder run cannot replace: it created payment reminders for a freely filtered selection, while the run deliberately holds only what is due today. A customer noticed the gap.

The action moves to **Alle Aufträge**:

- **Zahlungserinnerung erstellen** appears next to **Dokumente erstellen**, gated by `CreatePaymentReminder::canPerformAction()`
- orders without a mailable reminder address are skipped, with a toast naming how many, exactly as the old page did
- the reminder level is taken from the order and raised by one, so a second run produces the next level

Both flows share one modal. `createsPaymentReminders` decides which print layouts are offered, and the item hooks branch on `$item instanceof PaymentReminder`, so mail template, subject, language, blade parameters and recipient resolve per document type. `openCreateDocumentsModal()` resets the flag, so the regular document flow cannot inherit the reminder state. The trait method is aliased to `openDocumentsModal()` because a trait method cannot be reached through `parent::`.

Tests cover the layout switch, the reset on the regular modal, and that an order whose contact has no email address gets no reminder while its neighbour does. 241 tests in `Livewire/Order` and `Livewire/Accounting` pass.

## Summary by Sourcery

Add a bulk action to create payment reminders directly from the order list, sharing the existing document creation flow while handling reminder-specific layouts, templates, and recipients.

New Features:
- Introduce a "Create Payment Reminder" bulk action on the order list to generate reminders for selected orders with mailable addresses.
- Support payment reminder document creation using appropriate print layouts, email templates, blade parameters, languages, and recipient resolution based on the reminder context.

Enhancements:
- Gate the payment reminder action with existing permission checks and ensure the regular document flow cannot accidentally inherit reminder state.
- Show a warning toast indicating how many selected orders were skipped due to missing mailable reminder addresses.

Tests:
- Add livewire tests verifying reminder layout selection in the modal, state reset when switching back to regular documents, and skipping orders without mailable addresses while processing eligible neighbours.