### PR TITLE
Add inheritance-aware policy resolution and MailAccountPolicy

### DIFF
--- a/src/Policies/MailAccountPolicy.php
+++ b/src/Policies/MailAccountPolicy.php
@@ -15,6 +15,6 @@ class MailAccountPolicy
     {
         return $mailAccount->relationLoaded('users')
             ? $mailAccount->users->contains($user)
-            : $mailAccount->users()->whereKey($user)->exists();
+            : $mailAccount->users()->whereKey($user->getKey())->exists();
     }
 }

--- a/src/Policies/MailAccountPolicy.php
+++ b/src/Policies/MailAccountPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FluxErp\Policies;
+
+use FluxErp\Models\MailAccount;
+use FluxErp\Models\User;
+
+/**
+ * Deliberately defines only the view ability: undefined abilities deny by
+ * Laravel's default; further abilities are added together with their consumers.
+ */
+class MailAccountPolicy
+{
+    public function view(User $user, MailAccount $mailAccount): bool
+    {
+        return $mailAccount->relationLoaded('users')
+            ? $mailAccount->users->contains($user)
+            : $mailAccount->users()->whereKey($user)->exists();
+    }
+}

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -2,12 +2,21 @@
 
 namespace FluxErp\Providers;
 
+use FluxErp\Models\MailAccount;
+use FluxErp\Policies\MailAccountPolicy;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
+    /**
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        MailAccount::class => MailAccountPolicy::class,
+    ];
+
     public function boot(): void
     {
         $this->registerPolicies();

--- a/tests/Feature/Policies/MailAccountPolicyTest.php
+++ b/tests/Feature/Policies/MailAccountPolicyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use FluxErp\Models\MailAccount;
+use FluxErp\Models\Role;
+use FluxErp\Models\User;
+use FluxErp\Tests\Fixtures\Models\InstanceMailAccount;
+
+test('an assigned user can view the mail account', function (): void {
+    $user = User::factory()->create();
+    $mailAccount = MailAccount::factory()->create();
+    $mailAccount->users()->attach($user);
+
+    expect($user->can('view', $mailAccount))->toBeTrue();
+});
+
+test('an unassigned user cannot view the mail account', function (): void {
+    $user = User::factory()->create();
+    $firstAccount = MailAccount::factory()->create();
+    $secondAccount = MailAccount::factory()->create();
+    $secondAccount->users()->attach($user);
+
+    expect($user->can('view', $firstAccount))->toBeFalse();
+});
+
+test('an assigned user can view a derived instance mail account', function (): void {
+    $user = User::factory()->create();
+    $mailAccount = InstanceMailAccount::query()
+        ->findOrFail(MailAccount::factory()->create()->getKey());
+    $mailAccount->users()->attach($user);
+
+    expect($user->can('view', $mailAccount))->toBeTrue();
+});
+
+test('a super admin can view any mail account', function (): void {
+    Role::findOrCreate('Super Admin');
+    $admin = User::factory()->create();
+    $admin->assignRole('Super Admin');
+    $mailAccount = MailAccount::factory()->create();
+
+    expect($admin->can('view', $mailAccount))->toBeTrue();
+});
+
+test('an undefined ability is denied even for an assigned user', function (): void {
+    $user = User::factory()->create();
+    $mailAccount = MailAccount::factory()->create();
+    $mailAccount->users()->attach($user);
+
+    expect($user->can('update', $mailAccount))->toBeFalse();
+});

--- a/tests/Fixtures/Models/InstanceMailAccount.php
+++ b/tests/Fixtures/Models/InstanceMailAccount.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Models;
+
+use FluxErp\Models\MailAccount;
+
+/**
+ * Stands in for an instance override (App\Models\MailAccount). A same-basename
+ * fixture is impossible under the FluxErp root: the policy guesser's
+ * namespace-prefix walk would resolve FluxErp\Policies\MailAccountPolicy and
+ * bypass the subclass fallback under test. Real instance classes keep the
+ * parent's basename outside the FluxErp prefix, so neither pin below is needed
+ * there — table and foreign key only compensate the diverging fixture basename.
+ */
+class InstanceMailAccount extends MailAccount
+{
+    protected $table = 'mail_accounts';
+
+    public function getForeignKey(): string
+    {
+        return 'mail_account_id';
+    }
+}

--- a/tests/Fixtures/Models/OverriddenMailAccount.php
+++ b/tests/Fixtures/Models/OverriddenMailAccount.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Models;
+
+use FluxErp\Models\MailAccount;
+
+class OverriddenMailAccount extends MailAccount
+{
+    protected $table = 'mail_accounts';
+}

--- a/tests/Fixtures/Models/RecordWithoutPolicy.php
+++ b/tests/Fixtures/Models/RecordWithoutPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RecordWithoutPolicy extends Model {}

--- a/tests/Fixtures/Policies/OverriddenMailAccountPolicy.php
+++ b/tests/Fixtures/Policies/OverriddenMailAccountPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Policies;
+
+use FluxErp\Models\MailAccount;
+use FluxErp\Models\User;
+
+class OverriddenMailAccountPolicy
+{
+    public function view(User $user, MailAccount $mailAccount): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Standalone/Policies/StandaloneRecordPolicy.php
+++ b/tests/Fixtures/Standalone/Policies/StandaloneRecordPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Standalone\Policies;
+
+use FluxErp\Models\User;
+
+class StandaloneRecordPolicy
+{
+    public function view(User $user): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Standalone/StandaloneRecord.php
+++ b/tests/Fixtures/Standalone/StandaloneRecord.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FluxErp\Tests\Fixtures\Standalone;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StandaloneRecord extends Model {}

--- a/tests/Unit/AuthServiceProviderTest.php
+++ b/tests/Unit/AuthServiceProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use FluxErp\Models\MailAccount;
+use FluxErp\Policies\MailAccountPolicy;
+use FluxErp\Tests\Fixtures\Models\InstanceMailAccount;
+use FluxErp\Tests\Fixtures\Models\OverriddenMailAccount;
+use FluxErp\Tests\Fixtures\Models\RecordWithoutPolicy;
+use FluxErp\Tests\Fixtures\Policies\OverriddenMailAccountPolicy;
+use FluxErp\Tests\Fixtures\Standalone\Policies\StandaloneRecordPolicy;
+use FluxErp\Tests\Fixtures\Standalone\StandaloneRecord;
+use Illuminate\Support\Facades\Gate;
+
+test('resolves a core policy for a core model', function (): void {
+    expect(Gate::getPolicyFor(MailAccount::class))->toBeInstanceOf(MailAccountPolicy::class);
+});
+
+test('resolves the parent policy for a derived instance model without an own policy', function (): void {
+    expect(Gate::getPolicyFor(InstanceMailAccount::class))->toBeInstanceOf(MailAccountPolicy::class);
+});
+
+test('prefers the conventionally-placed policy of a derived model over the parent policy', function (): void {
+    expect(Gate::getPolicyFor(OverriddenMailAccount::class))
+        ->toBeInstanceOf(OverriddenMailAccountPolicy::class);
+});
+
+test('an explicit registration on the parent class wins for derived models', function (): void {
+    Gate::policy(MailAccount::class, OverriddenMailAccountPolicy::class);
+
+    expect(Gate::getPolicyFor(InstanceMailAccount::class))
+        ->toBeInstanceOf(OverriddenMailAccountPolicy::class);
+});
+
+test('resolves no policy for a model without a policy class', function (): void {
+    expect(Gate::getPolicyFor(RecordWithoutPolicy::class))->toBeNull();
+});
+
+test('resolves no policy for a non-class string', function (): void {
+    expect(Gate::getPolicyFor('not-a-class'))->toBeNull();
+});
+
+test('default guessing still resolves policies outside the Models convention', function (): void {
+    expect(Gate::getPolicyFor(StandaloneRecord::class))->toBeInstanceOf(StandaloneRecordPolicy::class);
+});


### PR DESCRIPTION
- Registers `MailAccountPolicy` as the package's first record policy — view only (users assigned via `mail_account_user`, Super Admin via the existing `Gate::before`); further abilities land together with their consumers.
- Resolution is framework-native via `protected $policies`: the Gate's `is_subclass_of` fallback covers instance overrides (`App\Models\MailAccount`), conventional instance policies and explicit parent-class registrations keep precedence, and Laravel's default guessing stays untouched — all regression-tested.
- Behavior-neutral at runtime: nothing checks these abilities yet; the first consumer is the mention gating (#1770 follow-up).

## Summary by Sourcery

Introduce a MailAccount authorization policy and ensure Laravel Gate resolves it correctly for core and derived models while leaving non-mail models and undefined abilities unchanged.

New Features:
- Add MailAccountPolicy to control view access to mail accounts based on user assignment and super admin role.

Enhancements:
- Register MailAccountPolicy in AuthServiceProvider so it is discovered via Laravel's native policy resolution, including subclass and override scenarios.

Tests:
- Add feature tests covering mail account view permissions for assigned users, derived instance accounts, super admins, and denial of undefined abilities.
- Add unit tests verifying policy resolution behavior for core models, subclassed models, explicit parent-class overrides, models without policies, invalid class strings, and non-conventional policy locations.