### PR TITLE
feat(loans): book a repayment against the loan ledger account

### DIFF
--- a/src/Models/Pivots/LoanInstallmentTransaction.php
+++ b/src/Models/Pivots/LoanInstallmentTransaction.php
@@ -2,6 +2,9 @@
 
 namespace FluxErp\Models\Pivots;
 
+use FluxErp\Actions\LedgerBooking\CreateLedgerBooking;
+use FluxErp\Actions\LedgerBooking\DeleteLedgerBooking;
+use FluxErp\Actions\LedgerBooking\UpdateLedgerBooking;
 use FluxErp\Models\LedgerBooking;
 use FluxErp\Models\LoanInstallment;
 use FluxErp\Models\Transaction;
@@ -26,7 +29,7 @@ class LoanInstallmentTransaction extends FluxPivot
 
         static::deleted(function (LoanInstallmentTransaction $loanInstallmentTransaction): void {
             $loanInstallmentTransaction->recalculate();
-            $loanInstallmentTransaction->ledgerBooking()->delete();
+            $loanInstallmentTransaction->deleteLedgerBooking();
         });
     }
 
@@ -82,6 +85,7 @@ class LoanInstallmentTransaction extends FluxPivot
 
     public function syncLedgerBooking(): void
     {
+        $ledgerBooking = $this->ledgerBooking()->first();
         $loan = $this->loanInstallment()->first()?->loan;
         $transaction = $this->transaction()->first();
         $bankLedgerAccountId = $transaction?->bankConnection?->ledger_account_id;
@@ -93,21 +97,51 @@ class LoanInstallmentTransaction extends FluxPivot
             || $loan->ledger_account_id === $bankLedgerAccountId
             || bccomp($amount, '0', 2) === 0
         ) {
-            $this->ledgerBooking()->delete();
+            $this->deleteLedgerBooking($ledgerBooking);
 
             return;
         }
 
         $isRepayment = bccomp($amount, '0', 2) === -1;
 
-        $this->ledgerBooking()->updateOrCreate([], [
-            'tenant_id' => $loan->tenant_id,
+        $data = [
             'debit_ledger_account_id' => $isRepayment ? $loan->ledger_account_id : $bankLedgerAccountId,
             'credit_ledger_account_id' => $isRepayment ? $bankLedgerAccountId : $loan->ledger_account_id,
             'amount' => ltrim($amount, '-'),
-            'booking_date' => $transaction->booking_date,
+            'booking_date' => $transaction->booking_date?->toDateString(),
             'booking_text' => $loan->name,
             'note' => $this->note,
-        ]);
+        ];
+
+        if ($ledgerBooking) {
+            UpdateLedgerBooking::make(array_merge($data, ['id' => $ledgerBooking->getKey()]))
+                ->validate()
+                ->execute();
+
+            return;
+        }
+
+        CreateLedgerBooking::make(
+            array_merge($data, [
+                'tenant_id' => $loan->tenant_id,
+                'source_type' => morph_alias(static::class),
+                'source_id' => $this->getKey(),
+            ])
+        )
+            ->validate()
+            ->execute();
+    }
+
+    public function deleteLedgerBooking(?LedgerBooking $ledgerBooking = null): void
+    {
+        $ledgerBooking ??= $this->ledgerBooking()->first();
+
+        if (! $ledgerBooking) {
+            return;
+        }
+
+        DeleteLedgerBooking::make(['id' => $ledgerBooking->getKey()])
+            ->validate()
+            ->execute();
     }
 }

--- a/src/Models/Pivots/LoanInstallmentTransaction.php
+++ b/src/Models/Pivots/LoanInstallmentTransaction.php
@@ -2,10 +2,12 @@
 
 namespace FluxErp\Models\Pivots;
 
+use FluxErp\Models\LedgerBooking;
 use FluxErp\Models\LoanInstallment;
 use FluxErp\Models\Transaction;
 use FluxErp\Traits\Model\HasPackageFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 class LoanInstallmentTransaction extends FluxPivot
 {
@@ -19,10 +21,12 @@ class LoanInstallmentTransaction extends FluxPivot
     {
         static::saved(function (LoanInstallmentTransaction $loanInstallmentTransaction): void {
             $loanInstallmentTransaction->recalculate();
+            $loanInstallmentTransaction->syncLedgerBooking();
         });
 
         static::deleted(function (LoanInstallmentTransaction $loanInstallmentTransaction): void {
             $loanInstallmentTransaction->recalculate();
+            $loanInstallmentTransaction->ledgerBooking()->delete();
         });
     }
 
@@ -31,6 +35,11 @@ class LoanInstallmentTransaction extends FluxPivot
         return [
             'is_accepted' => 'boolean',
         ];
+    }
+
+    public function ledgerBooking(): MorphOne
+    {
+        return $this->morphOne(LedgerBooking::class, 'source');
     }
 
     public function loanInstallment(): BelongsTo
@@ -69,5 +78,36 @@ class LoanInstallmentTransaction extends FluxPivot
                 ?->calculateBalance()
                 ->save();
         }
+    }
+
+    public function syncLedgerBooking(): void
+    {
+        $loan = $this->loanInstallment()->first()?->loan;
+        $transaction = $this->transaction()->first();
+        $bankLedgerAccountId = $transaction?->bankConnection?->ledger_account_id;
+        $amount = bcround((string) $this->amount, 2);
+
+        if (! $this->is_accepted
+            || ! $loan?->ledger_account_id
+            || ! $bankLedgerAccountId
+            || $loan->ledger_account_id === $bankLedgerAccountId
+            || bccomp($amount, '0', 2) === 0
+        ) {
+            $this->ledgerBooking()->delete();
+
+            return;
+        }
+
+        $isRepayment = bccomp($amount, '0', 2) === -1;
+
+        $this->ledgerBooking()->updateOrCreate([], [
+            'tenant_id' => $loan->tenant_id,
+            'debit_ledger_account_id' => $isRepayment ? $loan->ledger_account_id : $bankLedgerAccountId,
+            'credit_ledger_account_id' => $isRepayment ? $bankLedgerAccountId : $loan->ledger_account_id,
+            'amount' => ltrim($amount, '-'),
+            'booking_date' => $transaction->booking_date,
+            'booking_text' => $loan->name,
+            'note' => $this->note,
+        ]);
     }
 }

--- a/tests/Feature/Models/LoanInstallmentLedgerBookingTest.php
+++ b/tests/Feature/Models/LoanInstallmentLedgerBookingTest.php
@@ -95,6 +95,23 @@ test('deleting a repayment removes its booking', function (): void {
     expect(LedgerBooking::query()->whereKey($bookingId)->exists())->toBeFalse();
 });
 
+test('changing the amount updates the booking instead of adding one', function (): void {
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => true,
+    ]);
+    $bookingId = $assignment->ledgerBooking()->first()->getKey();
+
+    $assignment->update(['amount' => -3000]);
+
+    expect(LedgerBooking::query()->where('source_id', $assignment->getKey())->count())->toEqual(1)
+        ->and($assignment->ledgerBooking()->first())
+        ->getKey()->toEqual($bookingId)
+        ->amount->toEqual(3000);
+});
+
 test('a chargeback books the debt back', function (): void {
     $chargeback = Transaction::factory()->create([
         'bank_connection_id' => $this->bankConnection->getKey(),

--- a/tests/Feature/Models/LoanInstallmentLedgerBookingTest.php
+++ b/tests/Feature/Models/LoanInstallmentLedgerBookingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use FluxErp\Models\BankConnection;
+use FluxErp\Models\Contact;
+use FluxErp\Models\LedgerAccount;
+use FluxErp\Models\LedgerBooking;
+use FluxErp\Models\Loan;
+use FluxErp\Models\Pivots\LoanInstallmentTransaction;
+use FluxErp\Models\Transaction;
+
+beforeEach(function (): void {
+    $this->loanLedgerAccount = LedgerAccount::factory()->create(['tenant_id' => $this->dbTenant->getKey()]);
+    $this->bankLedgerAccount = LedgerAccount::factory()->create(['tenant_id' => $this->dbTenant->getKey()]);
+
+    $this->loan = Loan::factory()->create([
+        'tenant_id' => $this->dbTenant->getKey(),
+        'contact_id' => Contact::factory()->create()->getKey(),
+        'ledger_account_id' => $this->loanLedgerAccount->getKey(),
+        'amount' => 12000,
+        'number_of_installments' => 2,
+    ]);
+    $this->installment = $this->loan->installments()->create([
+        'sequence' => 1,
+        'due_date' => now()->subDays(2)->toDateString(),
+        'principal_amount' => 6000,
+        'interest_amount' => 60,
+    ]);
+    $this->bankConnection = BankConnection::factory()->create([
+        'ledger_account_id' => $this->bankLedgerAccount->getKey(),
+    ]);
+    $this->transaction = Transaction::factory()->create([
+        'bank_connection_id' => $this->bankConnection->getKey(),
+        'amount' => -6060,
+        'balance' => -6060,
+        'booking_date' => '2026-03-15',
+        'is_ignored' => false,
+    ]);
+});
+
+test('an accepted repayment books against the loan ledger account', function (): void {
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => true,
+    ]);
+
+    $booking = $assignment->ledgerBooking()->first();
+
+    expect($booking)->not->toBeNull()
+        ->and($booking->debit_ledger_account_id)->toEqual($this->loanLedgerAccount->getKey())
+        ->and($booking->credit_ledger_account_id)->toEqual($this->bankLedgerAccount->getKey())
+        ->and($booking->amount)->toEqual(6060)
+        ->and($booking->tenant_id)->toEqual($this->dbTenant->getKey())
+        ->and($booking->booking_date->toDateString())->toEqual('2026-03-15');
+});
+
+test('an unaccepted repayment books nothing', function (): void {
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => false,
+    ]);
+
+    expect($assignment->ledgerBooking()->exists())->toBeFalse();
+});
+
+test('un-accepting a repayment removes its booking', function (): void {
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => true,
+    ]);
+
+    expect($assignment->ledgerBooking()->exists())->toBeTrue();
+
+    $assignment->update(['is_accepted' => false]);
+
+    expect($assignment->ledgerBooking()->exists())->toBeFalse();
+});
+
+test('deleting a repayment removes its booking', function (): void {
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $this->transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => true,
+    ]);
+    $bookingId = $assignment->ledgerBooking()->first()->getKey();
+
+    $assignment->delete();
+
+    expect(LedgerBooking::query()->whereKey($bookingId)->exists())->toBeFalse();
+});
+
+test('a chargeback books the debt back', function (): void {
+    $chargeback = Transaction::factory()->create([
+        'bank_connection_id' => $this->bankConnection->getKey(),
+        'amount' => 6060,
+        'balance' => 6060,
+        'booking_date' => '2026-04-01',
+        'is_ignored' => false,
+    ]);
+
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $chargeback->getKey(),
+        'amount' => 6060,
+        'is_accepted' => true,
+    ]);
+
+    $booking = $assignment->ledgerBooking()->first();
+
+    expect($booking->debit_ledger_account_id)->toEqual($this->bankLedgerAccount->getKey())
+        ->and($booking->credit_ledger_account_id)->toEqual($this->loanLedgerAccount->getKey())
+        ->and($booking->amount)->toEqual(6060);
+});
+
+test('a bank connection without a ledger account books nothing', function (): void {
+    $transaction = Transaction::factory()->create([
+        'bank_connection_id' => BankConnection::factory()->create(['ledger_account_id' => null])->getKey(),
+        'amount' => -6060,
+        'balance' => -6060,
+        'is_ignored' => false,
+    ]);
+
+    $assignment = LoanInstallmentTransaction::create([
+        'loan_installment_id' => $this->installment->getKey(),
+        'transaction_id' => $transaction->getKey(),
+        'amount' => -6060,
+        'is_accepted' => true,
+    ]);
+
+    expect($assignment->ledgerBooking()->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Problem

Assigning a bank transaction to a loan installment only fed the repayment schedule. `LoanInstallmentTransaction::recalculate()` recalculated the loan and the transaction balance, nothing else, so the account in `loan.ledger_account_id` never moved.

The effect on a real ledger: a loan can be fully repaid on its schedule while its liability account still shows the original amount. The account is already attached to the loan and `FinanceOrder` books the payout against it, so only the repayment side was missing.

## Change

An accepted assignment now mirrors itself as a `LedgerBooking` on the same source, debiting the loan account and crediting the ledger account of the bank connection the transaction belongs to — the same pairing a ledger account assignment produces.

- Un-accepting or deleting the assignment removes the booking again.
- A chargeback (positive amount) books the same amount the other way, so the debt returns.
- No booking when the loan or the bank connection has no ledger account, when both would be the same account, or when the amount is zero.

The booking is attached via `morphOne` on `source`, so it stays idempotent when an assignment is edited.

## Tests

`tests/Feature/Models/LoanInstallmentLedgerBookingTest.php` covers all six paths. Verified red before the change and green after; the surrounding loan, ledger booking and transaction suites (99 tests) stay green.

## Summary by Sourcery

Record loan installment repayments and chargebacks directly in the ledger when assignments are accepted, and remove those bookings when assignments are reverted or deleted.

New Features:
- Create a ledger booking for accepted loan installment transaction assignments, linking loan and bank ledger accounts for repayments and chargebacks.

Bug Fixes:
- Ensure loan ledger accounts reflect repayments and chargebacks so liabilities decrease or increase in sync with the repayment schedule.

Enhancements:
- Introduce an idempotent morphOne relation from loan installment transactions to ledger bookings, keeping bookings in sync on save and delete.

Tests:
- Add feature tests covering ledger booking creation, reversal, and edge cases for loan installment transaction assignments.