### PR TITLE
Keep the held back reminders warning on screen

### DIFF
--- a/src/Livewire/Accounting/PaymentReminderRun.php
+++ b/src/Livewire/Accounting/PaymentReminderRun.php
@@ -413,6 +413,7 @@ class PaymentReminderRun extends Component
                     )
                     ->implode(' ')
             )
+            ->persistent()
             ->send();
     }
 

--- a/tests/Livewire/Accounting/PaymentReminderRunTest.php
+++ b/tests/Livewire/Accounting/PaymentReminderRunTest.php
@@ -413,7 +413,8 @@ test('orders that cannot be sent stay in the list instead of looking sent', func
         ->assertSet('groups', fn (array $groups) => count($groups) === 1)
         ->call('sendSelected')
         ->assertSet('groups', fn (array $groups) => count($groups) === 1)
-        ->assertSet('sentOrderIds', []);
+        ->assertSet('sentOrderIds', [])
+        ->assertDispatched('ts-ui:toast', type: 'warning', persistent: true);
 
     Queue::assertNotPushed(SendPaymentReminderJob::class);
 });


### PR DESCRIPTION
## Problem

A payment reminder run where nothing could be sent is indistinguishable from one where everything went out.

`handleSendResult()` reports the held back invoices as a toast, which fades out on its own. Right after it, `loadData()` runs and reselects every row by default. Since nothing was marked as sent, the user is left looking at the same list, fully ticked, with no trace of why. The natural reading is that the send did nothing at all, or worse, that it worked.

Seen in the field on a run where every reminder level was missing its email template: every invoice was held back, the warning came and went, and the run looked like a no-op.

## Change

The warning is persistent. It names the invoices that were held back and the reason, and it is the one outcome of a run the user has to act on, so it stays until dismissed. Nothing else about the run changes.

## Tests

The existing "orders that cannot be sent stay in the list instead of looking sent" case now also asserts the dispatched toast is a persistent warning. Verified to fail without the change and pass with it.

## Summary by Sourcery

Tests:
- Extend the payment reminder run test to assert that the held-back warning toast is dispatched as a persistent warning message.