### PR TITLE
Fix flaky language fixtures in HasAttributeTranslationsTest

### DIFF
--- a/tests/Unit/Traits/HasAttributeTranslationsTest.php
+++ b/tests/Unit/Traits/HasAttributeTranslationsTest.php
@@ -27,7 +27,8 @@ test('model can be localized', function (): void {
 });
 
 test('retrieved hook localizes model based on app locale when session is empty', function (): void {
-    $language = Language::factory()->create(['language_code' => 'fr']);
+    $language = Language::query()->where('language_code', 'fr')->first()
+        ?? Language::factory()->create(['language_code' => 'fr']);
 
     $product = Product::factory()->create(['name' => 'English Name']);
 
@@ -46,7 +47,8 @@ test('retrieved hook localizes model based on app locale when session is empty',
 });
 
 test('localize falls back to app locale when no language id given and session is empty', function (): void {
-    $language = Language::factory()->create(['language_code' => 'de']);
+    $language = Language::query()->where('language_code', 'de')->first()
+        ?? Language::factory()->create(['language_code' => 'de']);
 
     $product = Product::factory()->create(['name' => 'English Name']);
 


### PR DESCRIPTION
- The Pest base setup creates the default language with a random faker language code; forcing `de`/`fr` via a factory override bypasses the factory's uniqueness loop and randomly hits `languages_language_code_unique` in CI.
- Reuses the existing guard pattern from the printing tests: `Language::query()->where(...)->first() ?? Language::factory()->create(...)`.

## Summary by Sourcery

Stabilize attribute translation tests by avoiding unique language code conflicts when creating test languages.

Bug Fixes:
- Prevent intermittent failures caused by violating the unique language_code constraint when creating test Language records.

Tests:
- Reuse existing guard pattern to re-use or create Language records for specific language codes in HasAttributeTranslations tests.