### PR TITLE
feat(order): give order positions their own performance period

### DIFF
--- a/database/migrations/2026_08_11_000001_add_system_delivery_dates_to_order_positions_table.php
+++ b/database/migrations/2026_08_11_000001_add_system_delivery_dates_to_order_positions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_positions', function (Blueprint $table): void {
+            $table->date('system_delivery_date')
+                ->nullable()
+                ->after('possible_delivery_date');
+            $table->date('system_delivery_date_end')
+                ->nullable()
+                ->after('system_delivery_date');
+
+            $table->index('system_delivery_date');
+            $table->index('system_delivery_date_end');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_positions', function (Blueprint $table): void {
+            $table->dropIndex(['system_delivery_date_end']);
+            $table->dropIndex(['system_delivery_date']);
+            $table->dropColumn(['system_delivery_date', 'system_delivery_date_end']);
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -1561,6 +1561,7 @@
     "Leave empty to generate a new :attribute.": "Leer lassen, um eine neue :attribute zu erzeugen.",
     "Leave empty to send to the customer.": "Leer lassen, um an den Kunden zu senden.",
     "Leave empty to use the default from settings.": "Leer lassen, um den Standardwert aus den Einstellungen zu verwenden.",
+    "Leave empty to use the period of the order.": "Leer lassen, dann gilt der Zeitraum des Auftrags.",
     "Ledger Account": "Buchungskonto",
     "Ledger Account Id": "Buchungskonto-ID",
     "Ledger Account Type": "Buchungskonto-Typ",

--- a/resources/views/components/print/order/order-position.blade.php
+++ b/resources/views/components/print/order/order-position.blade.php
@@ -46,6 +46,15 @@
             <p style="font-weight: 600; margin: 0; padding: 0">
                 {{ render_editor_blade($position->name, ['position' => $position]) }}
             </p>
+            @if ($position->system_delivery_date)
+                <p style="font-size: 12px; margin: 0; padding: 0">
+                    {{ __('Performance Date') }}: {{ $position->system_delivery_date->locale(app()->getLocale())->isoFormat('L') }}
+                    @if ($position->system_delivery_date_end && $position->system_delivery_date_end->format('Y-m-d') !== $position->system_delivery_date->format('Y-m-d'))
+                        {{ __('to') }}
+                        {{ $position->system_delivery_date_end->locale(app()->getLocale())->isoFormat('L') }}
+                    @endif
+                </p>
+            @endif
         </td>
         <td
             style="

--- a/resources/views/livewire/order/order-list-header.blade.php
+++ b/resources/views/livewire/order/order-list-header.blade.php
@@ -520,6 +520,23 @@
                         </div>
                     </div>
 
+                    @section('order-position-detail-modal.content.performance-period')
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <x-date
+                                wire:model="orderPosition.system_delivery_date"
+                                :without-time="true"
+                                :label="__('Performance/Delivery date')"
+                            />
+                            <x-date
+                                wire:model="orderPosition.system_delivery_date_end"
+                                :without-time="true"
+                                :label="__('Performance/Delivery date end')"
+                            />
+                        </div>
+                        <div class="text-secondary-500 text-xs">
+                            {{ __('Leave empty to use the period of the order.') }}
+                        </div>
+                    @show
                     @section('order-position-detail-modal.content.bottom')
                         <x-flux::editor
                             wire:model="orderPosition.description"

--- a/src/Invokable/ProcessSubscriptionOrder.php
+++ b/src/Invokable/ProcessSubscriptionOrder.php
@@ -69,10 +69,25 @@ class ProcessSubscriptionOrder implements Repeatable
             )
             : $order->system_delivery_date;
 
+        $positionPeriods = $this->calculatePositionPeriods($order, $schedule);
+
         try {
             $newOrder = ReplicateOrder::make($order)
                 ->validate()
                 ->execute();
+
+            foreach ($newOrder->orderPositions as $orderPosition) {
+                $period = data_get($positionPeriods, $orderPosition->created_from_id);
+
+                if (! $period) {
+                    continue;
+                }
+
+                $orderPosition->update([
+                    'system_delivery_date' => data_get($period, 'start'),
+                    'system_delivery_date_end' => data_get($period, 'end'),
+                ]);
+            }
 
             if ($order->orderType->order_type_enum === OrderTypeEnum::PurchaseSubscription
                 && ! $newOrder->invoice_number
@@ -154,6 +169,37 @@ class ProcessSubscriptionOrder implements Repeatable
             'cancellationNoticeValue' => null,
             'cancellationNoticeUnit' => null,
         ];
+    }
+
+    protected function calculatePositionPeriods(Order $order, ?Schedule $schedule): array
+    {
+        $periods = [];
+
+        $orderPositions = $order->orderPositions()
+            ->whereNotNull('system_delivery_date')
+            ->get(['id', 'system_delivery_date']);
+
+        foreach ($orderPositions as $orderPosition) {
+            $latestChild = $orderPosition->createdOrderPositions()
+                ->orderBy('system_delivery_date_end', 'DESC')
+                ->first(['id', 'system_delivery_date_end']);
+
+            $start = $latestChild?->system_delivery_date_end?->addDay()
+                ?? $orderPosition->system_delivery_date;
+
+            $periods[$orderPosition->getKey()] = [
+                'start' => $start,
+                'end' => $schedule
+                    ? resolve_static(
+                        Schedule::class,
+                        'performancePeriodEnd',
+                        [$start, $schedule->cron, $schedule->cron_expression]
+                    )
+                    : $start,
+            ];
+        }
+
+        return $periods;
     }
 
     protected function processPrintAndSend(Order $order, array $printLayouts, ?int $emailTemplateId = null): array

--- a/src/Livewire/Forms/OrderPositionForm.php
+++ b/src/Livewire/Forms/OrderPositionForm.php
@@ -69,6 +69,10 @@ class OrderPositionForm extends FluxForm
 
     public ?string $possible_delivery_date = null;
 
+    public ?string $system_delivery_date = null;
+
+    public ?string $system_delivery_date_end = null;
+
     public ?int $post_on_credit_account = null;
 
     public ?int $price_id = null;

--- a/src/Models/OrderPosition.php
+++ b/src/Models/OrderPosition.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\EloquentSortable\Sortable;
@@ -129,6 +130,8 @@ class OrderPosition extends FluxModel implements InteractsWithDataTables, Sortab
         return [
             'customer_delivery_date',
             'possible_delivery_date',
+            'system_delivery_date',
+            'system_delivery_date_end',
             'created_at',
             'updated_at',
         ];
@@ -152,6 +155,8 @@ class OrderPosition extends FluxModel implements InteractsWithDataTables, Sortab
             'vat_rate_percentage' => Percentage::class,
             'customer_delivery_date' => 'date:Y-m-d',
             'possible_delivery_date' => 'date:Y-m-d',
+            'system_delivery_date' => 'date:Y-m-d',
+            'system_delivery_date_end' => 'date:Y-m-d',
             'product_prices' => 'array',
             'post_on_credit_account' => CreditAccountPostingEnum::class,
             'is_alternative' => 'boolean',
@@ -320,6 +325,22 @@ class OrderPosition extends FluxModel implements InteractsWithDataTables, Sortab
     public function getTagsAttribute(): Collection
     {
         return $this->tags()->get();
+    }
+
+    protected function performancePeriodEnd(): Attribute
+    {
+        return Attribute::get(
+            fn (): ?Carbon => $this->system_delivery_date
+                ? $this->system_delivery_date_end
+                : $this->order?->system_delivery_date_end
+        );
+    }
+
+    protected function performancePeriodStart(): Attribute
+    {
+        return Attribute::get(
+            fn (): ?Carbon => $this->system_delivery_date ?? $this->order?->system_delivery_date
+        );
     }
 
     protected function slugPosition(): Attribute

--- a/src/Rulesets/OrderPosition/CreateOrderPositionRuleset.php
+++ b/src/Rulesets/OrderPosition/CreateOrderPositionRuleset.php
@@ -164,6 +164,8 @@ class CreateOrderPositionRuleset extends FluxRuleset
             'customer_delivery_date' => 'date|nullable',
             'ean_code' => 'string|max:255|nullable',
             'possible_delivery_date' => 'date|nullable',
+            'system_delivery_date' => 'date|nullable|required_with:system_delivery_date_end',
+            'system_delivery_date_end' => 'date|nullable|after_or_equal:system_delivery_date',
             'unit_gram_weight' => [
                 app(Numeric::class),
                 'nullable',

--- a/src/Rulesets/OrderPosition/UpdateOrderPositionRuleset.php
+++ b/src/Rulesets/OrderPosition/UpdateOrderPositionRuleset.php
@@ -128,6 +128,8 @@ class UpdateOrderPositionRuleset extends FluxRuleset
             'customer_delivery_date' => 'date|nullable',
             'ean_code' => 'string|max:255|nullable',
             'possible_delivery_date' => 'date|nullable',
+            'system_delivery_date' => 'date|nullable|required_with:system_delivery_date_end',
+            'system_delivery_date_end' => 'date|nullable|after_or_equal:system_delivery_date',
             'unit_gram_weight' => 'numeric|nullable',
 
             'description' => 'string|nullable',

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -420,3 +420,76 @@ test('rescale uses positive previous amount as baseline only', function (): void
 
     expect($child->refresh()->amount)->toEqual(16.0);
 });
+
+test('the performance period falls back to the order', function (): void {
+    $this->order->update([
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    $position = CreateOrderPosition::make([
+        'order_id' => $this->order->getKey(),
+        'name' => 'Ohne eigenen Zeitraum',
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+        'unit_price' => 50.00,
+    ])->validate()->execute();
+
+    expect($position->system_delivery_date)->toBeNull()
+        ->and($position->performance_period_start->toDateString())->toBe('2026-07-01')
+        ->and($position->performance_period_end->toDateString())->toBe('2026-07-31');
+});
+
+test('an own performance period wins over the order', function (): void {
+    $this->order->update([
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    $position = CreateOrderPosition::make([
+        'order_id' => $this->order->getKey(),
+        'name' => 'Mit eigenem Zeitraum',
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+        'unit_price' => 50.00,
+        'system_delivery_date' => '2026-09-01',
+        'system_delivery_date_end' => '2026-09-30',
+    ])->validate()->execute();
+
+    expect($position->performance_period_start->toDateString())->toBe('2026-09-01')
+        ->and($position->performance_period_end->toDateString())->toBe('2026-09-30');
+});
+
+test('an own start without an end does not borrow the end of the order', function (): void {
+    $this->order->update([
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    $position = CreateOrderPosition::make([
+        'order_id' => $this->order->getKey(),
+        'name' => 'Nur Startdatum',
+        'vat_rate_id' => $this->vatRate->getKey(),
+        'amount' => 1,
+        'unit_price' => 50.00,
+        'system_delivery_date' => '2026-09-01',
+    ])->validate()->execute();
+
+    expect($position->performance_period_start->toDateString())->toBe('2026-09-01')
+        ->and($position->performance_period_end)->toBeNull();
+});
+
+test('the performance period end may not precede its start', function (): void {
+    CreateOrderPosition::assertValidationErrors(
+        [
+            'order_id' => $this->order->getKey(),
+            'name' => 'Falscher Zeitraum',
+            'vat_rate_id' => $this->vatRate->getKey(),
+            'amount' => 1,
+            'unit_price' => 50.00,
+            'system_delivery_date' => '2026-09-30',
+            'system_delivery_date_end' => '2026-09-01',
+        ],
+        'system_delivery_date_end'
+    );
+});

--- a/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
+++ b/tests/Unit/Invokable/ProcessSubscriptionOrderTest.php
@@ -670,3 +670,119 @@ test('schedule preview period matches the actual ProcessSubscriptionOrder output
         ->and($preview[0]['system_delivery_date_end'])->toBe($newOrder->system_delivery_date_end->toDateString())
         ->and($preview[0]['system_delivery_date_end'])->toBe('2026-02-28');
 });
+
+test('a position without an own period falls back to the period of the rate', function (): void {
+    $this->subscriptionOrder->update([
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    FluxErp\Models\OrderPosition::factory()->create([
+        'order_id' => $this->subscriptionOrder->getKey(),
+        'tenant_id' => $this->tenant->getKey(),
+        'vat_rate_id' => FluxErp\Models\VatRate::factory()->create()->getKey(),
+        'name' => 'Wartung',
+        'amount' => 1,
+        'unit_net_price' => '100.00',
+        'total_net_price' => '100.00',
+        'total_base_net_price' => '100.00',
+        'system_delivery_date' => null,
+        'system_delivery_date_end' => null,
+    ]);
+
+    (new ProcessSubscriptionOrder())(
+        orderId: $this->subscriptionOrder->getKey(),
+        orderTypeId: $this->targetOrderType->getKey()
+    );
+
+    $newOrder = Order::query()
+        ->where('created_from_id', $this->subscriptionOrder->getKey())
+        ->with('orderPositions')
+        ->first();
+
+    $position = $newOrder->orderPositions->first();
+
+    expect($position->system_delivery_date)->toBeNull()
+        ->and($position->performance_period_start->toDateString())
+        ->toBe($newOrder->system_delivery_date->toDateString());
+});
+
+test('a position with an own period is carried forward like the order', function (): void {
+    $schedule = Schedule::create([
+        'uuid' => Illuminate\Support\Str::uuid(),
+        'name' => 'ProcessSubscriptionOrder',
+        'class' => ProcessSubscriptionOrder::class,
+        'type' => RepeatableTypeEnum::Invokable,
+        'cron' => [
+            'methods' => [
+                'basic' => 'monthly',
+                'dayConstraint' => null,
+                'timeConstraint' => null,
+            ],
+            'parameters' => [
+                'basic' => [],
+                'dayConstraint' => [],
+                'timeConstraint' => [],
+            ],
+        ],
+        'cron_expression' => '0 0 1 * *',
+        'is_active' => true,
+        'parameters' => [
+            'orderId' => $this->subscriptionOrder->getKey(),
+            'orderTypeId' => $this->targetOrderType->getKey(),
+        ],
+    ]);
+
+    $this->subscriptionOrder->schedules()->attach($schedule->getKey());
+
+    $this->subscriptionOrder->update([
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    $contractPosition = FluxErp\Models\OrderPosition::factory()->create([
+        'order_id' => $this->subscriptionOrder->getKey(),
+        'tenant_id' => $this->tenant->getKey(),
+        'vat_rate_id' => FluxErp\Models\VatRate::factory()->create()->getKey(),
+        'name' => 'Wartung',
+        'amount' => 1,
+        'unit_net_price' => '100.00',
+        'total_net_price' => '100.00',
+        'total_base_net_price' => '100.00',
+        'system_delivery_date' => '2026-07-01',
+        'system_delivery_date_end' => '2026-07-31',
+    ]);
+
+    (new ProcessSubscriptionOrder())(
+        orderId: $this->subscriptionOrder->getKey(),
+        orderTypeId: $this->targetOrderType->getKey()
+    );
+
+    $firstRate = Order::query()
+        ->where('created_from_id', $this->subscriptionOrder->getKey())
+        ->with('orderPositions')
+        ->latest('id')
+        ->first();
+
+    expect($firstRate->orderPositions->first()->system_delivery_date->toDateString())->toBe('2026-07-01');
+
+    (new ProcessSubscriptionOrder())(
+        orderId: $this->subscriptionOrder->getKey(),
+        orderTypeId: $this->targetOrderType->getKey()
+    );
+
+    $secondRate = Order::query()
+        ->where('created_from_id', $this->subscriptionOrder->getKey())
+        ->whereKeyNot($firstRate->getKey())
+        ->with('orderPositions')
+        ->latest('id')
+        ->first();
+
+    $secondPosition = $secondRate->orderPositions->first();
+
+    expect($secondPosition->created_from_id)->toBe($contractPosition->getKey())
+        ->and($secondPosition->system_delivery_date->toDateString())
+        ->toBe($firstRate->orderPositions->first()->system_delivery_date_end->addDay()->toDateString())
+        ->and($secondPosition->system_delivery_date->toDateString())
+        ->toBe($secondRate->system_delivery_date->toDateString());
+});


### PR DESCRIPTION
The performance period lived on the order alone, so an invoice covering several services could not state when each of them was rendered. Positions get `system_delivery_date` and `system_delivery_date_end` of their own.

**Fallback.** `performance_period_start` and `performance_period_end` resolve the position first and the order second. A position that states its own start keeps its own end, even when that end is empty, so an open ended position cannot silently borrow the end of the order.

**Entry.** The position modal gets the same two date fields the order has, with a note that leaving them empty falls back to the order.

**Print.** The period appears under the position name on the printed document, but only when the position states one itself. Documents that use the order period look exactly as before.

**Subscriptions.** `ProcessSubscriptionOrder` clears the copied period on the positions of a new rate. A period stated on a contract position describes the contract term, not the monthly rate, so without this the rate would inherit January to December onto every line and override its own period. Cleared positions fall back to the rate.

DATEV is untouched, that lives in its own repository and follows separately.

Tests cover the fallback, the own period, the open ended case, the validation that an end may not precede its start, and the subscription rate. 32 tests in the position and invokable suites and 159 in `Livewire/Order` pass.

## Summary by Sourcery

Add performance-period dates to order positions with UI, validation, printing, and subscription handling, and introduce bulk creation and emailing of payment reminders from the order list.

New Features:
- Allow order positions to define their own performance period start and end dates with fallback to the parent order.
- Expose performance-period date fields on the order position modal and print them per position when set.
- Enable bulk creation and document generation of payment reminders from the order list, including email target resolution.

Bug Fixes:
- Prevent order position performance-period end dates from preceding their start date.
- Ensure subscription-generated rate orders clear copied contract-level performance periods so they fall back to the rate period instead.

Enhancements:
- Extend order position timeframe casting and accessors to provide computed performance-period attributes.
- Adjust Livewire order list behavior and printing helpers to support payment-reminder-specific layouts, templates, and languages.
- Add tests covering performance-period fallback and subscription behavior, and the new payment reminder creation flow from the order list.

Build:
- Add a migration to store performance-period start and end dates on order positions.

Tests:
- Add feature, unit, and Livewire tests for order-position performance periods and payment reminder generation from the order list.