### PR TITLE
Let categories be dragged into an order and offer them in it

### DIFF
--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use Laravel\Scout\SearchableScope;
+use Spatie\EloquentSortable\Sortable;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 
 class SearchController extends Controller
@@ -94,7 +95,17 @@ class SearchController extends Controller
 
         $this->applyRequestConstraints($query, $request, $model);
 
-        $result = $query->latest()->get();
+        // A model that carries an order of its own is offered in that order,
+        // and only falls back to the newest first when it has none. Without
+        // this a select handed out its options in creation order, which is the
+        // order nobody ever chose.
+        $result = $query
+            ->when(
+                app($model) instanceof Sortable,
+                fn (Builder $query): Builder => $query->ordered()
+            )
+            ->latest()
+            ->get();
 
         if ($request->has('appends')) {
             $result->each(function ($item) use ($request): void {

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -95,13 +95,9 @@ class SearchController extends Controller
 
         $this->applyRequestConstraints($query, $request, $model);
 
-        // A model that carries an order of its own is offered in that order,
-        // and only falls back to the newest first when it has none. Without
-        // this a select handed out its options in creation order, which is the
-        // order nobody ever chose.
         $result = $query
             ->when(
-                app($model) instanceof Sortable,
+                is_a(resolve_static($model, 'class'), Sortable::class, true),
                 fn (Builder $query): Builder => $query->ordered()
             )
             ->latest()

--- a/src/Livewire/DataTables/CategoryList.php
+++ b/src/Livewire/DataTables/CategoryList.php
@@ -35,8 +35,6 @@ class CategoryList extends BaseDataTable
         // then load the tree with recursive children via familyTree()
         $rootIds = $query->pluck($this->modelTable . '.' . $this->modelKeyName);
 
-        // whereKey() drops the order the ids were plucked in, so the tree says
-        // for itself how it is sorted, roots here and children on the relation.
         $categories = resolve_static(Category::class, 'familyTree')
             ->whereKey($rootIds)
             ->ordered()

--- a/src/Livewire/DataTables/CategoryList.php
+++ b/src/Livewire/DataTables/CategoryList.php
@@ -35,8 +35,11 @@ class CategoryList extends BaseDataTable
         // then load the tree with recursive children via familyTree()
         $rootIds = $query->pluck($this->modelTable . '.' . $this->modelKeyName);
 
+        // whereKey() drops the order the ids were plucked in, so the tree says
+        // for itself how it is sorted, roots here and children on the relation.
         $categories = resolve_static(Category::class, 'familyTree')
             ->whereKey($rootIds)
+            ->ordered()
             ->get();
 
         $tree = to_flat_tree($categories->toArray());

--- a/src/Livewire/Settings/Categories.php
+++ b/src/Livewire/Settings/Categories.php
@@ -89,12 +89,6 @@ class Categories extends CategoryList
         JS);
     }
 
-    /**
-     * A row is dragged inside the tree that is on screen, so the whole list is
-     * renumbered in the order it now reads. Roots and children are numbered
-     * from the same run, which keeps a child between its own siblings once the
-     * tree is built again.
-     */
     #[Renderless]
     public function sortRows(int|string $recordId, int $newPosition): void
     {
@@ -106,15 +100,16 @@ class Categories extends CategoryList
             return;
         }
 
-        $ids = array_column($this->data['data'] ?? [], 'id');
-        $currentPosition = array_search($recordId, $ids);
+        $ids = array_map('strval', array_column($this->data['data'] ?? [], 'id'));
+        $recordId = (string) $recordId;
+        $currentPosition = array_search($recordId, $ids, true);
 
         if ($currentPosition === false) {
             return;
         }
 
         array_splice($ids, $currentPosition, 1);
-        array_splice($ids, $newPosition, 0, [$recordId]);
+        array_splice($ids, max(0, min($newPosition, count($ids))), 0, [$recordId]);
 
         resolve_static(Category::class, 'setNewOrder', ['ids' => $ids]);
     }

--- a/src/Livewire/Settings/Categories.php
+++ b/src/Livewire/Settings/Categories.php
@@ -89,6 +89,36 @@ class Categories extends CategoryList
         JS);
     }
 
+    /**
+     * A row is dragged inside the tree that is on screen, so the whole list is
+     * renumbered in the order it now reads. Roots and children are numbered
+     * from the same run, which keeps a child between its own siblings once the
+     * tree is built again.
+     */
+    #[Renderless]
+    public function sortRows(int|string $recordId, int $newPosition): void
+    {
+        try {
+            resolve_static(UpdateCategory::class, 'canPerformAction');
+        } catch (UnauthorizedException $e) {
+            exception_to_notifications($e, $this);
+
+            return;
+        }
+
+        $ids = array_column($this->data['data'] ?? [], 'id');
+        $currentPosition = array_search($recordId, $ids);
+
+        if ($currentPosition === false) {
+            return;
+        }
+
+        array_splice($ids, $currentPosition, 1);
+        array_splice($ids, $newPosition, 0, [$recordId]);
+
+        resolve_static(Category::class, 'setNewOrder', ['ids' => $ids]);
+    }
+
     #[Renderless]
     public function save(): bool
     {
@@ -110,5 +140,10 @@ class Categories extends CategoryList
         return array_merge(parent::getViewData(), [
             'models' => get_models_with_trait(Categorizable::class),
         ]);
+    }
+
+    protected function isSortable(): bool
+    {
+        return true;
     }
 }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -16,6 +16,7 @@ use FluxErp\Traits\Model\SortableTrait;
 use FluxErp\Traits\Scout\Searchable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
@@ -31,8 +32,11 @@ use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
  */
 class Category extends FluxModel implements HasMedia, InteractsWithDataTables, Sortable
 {
-    use Filterable, HasAttributeTranslations, HasPackageFactory, HasParentChildRelations, HasUserModification, HasUuid,
+    use Filterable, HasAttributeTranslations, HasPackageFactory, HasUserModification, HasUuid,
         InteractsWithMedia, LogsActivity, SortableTrait;
+    use HasParentChildRelations {
+        HasParentChildRelations::children as baseChildren;
+    }
     use Searchable {
         Searchable::scoutIndexSettings as baseScoutIndexSettings;
     }
@@ -89,6 +93,16 @@ class Category extends FluxModel implements HasMedia, InteractsWithDataTables, S
     }
 
     // Relations
+    /**
+     * A category is sortable, and that order is what the tree below it is read
+     * in. Without it the children arrived in whatever order the database held
+     * them, so dragging a child into place changed nothing that could be seen.
+     */
+    public function children(): HasMany
+    {
+        return $this->baseChildren()->ordered();
+    }
+
     public function discounts(): BelongsToMany
     {
         return $this->belongsToMany(Discount::class, 'category_price_list')

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -93,11 +93,6 @@ class Category extends FluxModel implements HasMedia, InteractsWithDataTables, S
     }
 
     // Relations
-    /**
-     * A category is sortable, and that order is what the tree below it is read
-     * in. Without it the children arrived in whatever order the database held
-     * them, so dragging a child into place changed nothing that could be seen.
-     */
     public function children(): HasMany
     {
         return $this->baseChildren()->ordered();

--- a/tests/Feature/Http/SortableSearchOrderTest.php
+++ b/tests/Feature/Http/SortableSearchOrderTest.php
@@ -3,8 +3,6 @@
 use FluxErp\Models\Category;
 use FluxErp\Models\Product;
 
-// A select offered its options newest first, so the order a sortable model
-// carries was worth nothing the moment it was offered for picking.
 test('a sortable model is offered in its own order', function (): void {
     $model = morph_alias(Product::class);
 

--- a/tests/Feature/Http/SortableSearchOrderTest.php
+++ b/tests/Feature/Http/SortableSearchOrderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use FluxErp\Models\Category;
+use FluxErp\Models\Product;
+
+// A select offered its options newest first, so the order a sortable model
+// carries was worth nothing the moment it was offered for picking.
+test('a sortable model is offered in its own order', function (): void {
+    $model = morph_alias(Product::class);
+
+    $first = Category::factory()->create(['model_type' => $model]);
+    $second = Category::factory()->create(['model_type' => $model]);
+
+    $second->moveToPosition($first->sort_number);
+
+    $response = $this->post(route('search', Category::class), [
+        'where' => [['model_type', '=', $model]],
+    ]);
+
+    $response->assertOk();
+
+    expect(array_column($response->json(), 'id'))
+        ->toBe([$second->getKey(), $first->getKey()]);
+});
+
+test('an explicit order still wins over the order of the model', function (): void {
+    $model = morph_alias(Product::class);
+
+    $second = Category::factory()->create(['model_type' => $model, 'name' => 'Zylinder']);
+    $first = Category::factory()->create(['model_type' => $model, 'name' => 'Antrieb']);
+
+    $response = $this->post(route('search', Category::class), [
+        'where' => [['model_type', '=', $model]],
+        'orderBy' => 'name',
+    ]);
+
+    $response->assertOk();
+
+    expect(array_column($response->json(), 'id'))
+        ->toBe([$first->getKey(), $second->getKey()]);
+});

--- a/tests/Livewire/Settings/SortCategoriesTest.php
+++ b/tests/Livewire/Settings/SortCategoriesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use FluxErp\Livewire\Settings\Categories;
+use FluxErp\Models\Category;
+use FluxErp\Models\Product;
+use Livewire\Livewire;
+
+function categoryTree(): array
+{
+    $model = morph_alias(Product::class);
+
+    $area = Category::factory()->create([
+        'model_type' => $model,
+        'name' => 'Synthese',
+    ]);
+
+    return [
+        $area,
+        Category::factory()->create([
+            'model_type' => $model,
+            'parent_id' => $area->getKey(),
+            'name' => 'Ausgelaufen',
+        ]),
+        Category::factory()->create([
+            'model_type' => $model,
+            'parent_id' => $area->getKey(),
+            'name' => 'Loesungsmittel leer',
+        ]),
+    ];
+}
+
+/**
+ * @return array<int, int>
+ */
+function renderedOrderOf(Categories $categories, array $tree): array
+{
+    $categories->loadData(true);
+
+    $keys = array_map(fn (Category $category): int => $category->getKey(), $tree);
+
+    return array_values(array_filter(
+        array_column($categories->data['data'], 'id'),
+        fn ($id): bool => in_array($id, $keys)
+    ));
+}
+
+// The children arrived in whatever order the database held them, so the order a
+// category carries was invisible everywhere the tree is read.
+test('the children of a category come back in their own order', function (): void {
+    [$area, $spilled, $solvent] = categoryTree();
+
+    $solvent->moveToPosition($spilled->sort_number);
+
+    expect($area->fresh()->children->pluck('name')->all())
+        ->toBe(['Loesungsmittel leer', 'Ausgelaufen']);
+});
+
+// Dragging a row renumbers the list in the order it now reads, roots and
+// children from the same run, so a child keeps its place among its siblings.
+test('dragging a child to the front puts it before its sibling', function (): void {
+    $tree = categoryTree();
+    [$area, $spilled, $solvent] = $tree;
+
+    $categories = Livewire::test(Categories::class)->instance();
+
+    expect(renderedOrderOf($categories, $tree))
+        ->toBe([$area->getKey(), $spilled->getKey(), $solvent->getKey()]);
+
+    $categories->sortRows($solvent->getKey(), 1);
+
+    expect(renderedOrderOf($categories, $tree))
+        ->toBe([$area->getKey(), $solvent->getKey(), $spilled->getKey()]);
+});
+
+test('a record that is not on the list leaves the order alone', function (): void {
+    $tree = categoryTree();
+    [$area, $spilled, $solvent] = $tree;
+
+    $categories = Livewire::test(Categories::class)->instance();
+    $categories->loadData(true);
+
+    $categories->sortRows($area->getKey() + 10_000, 0);
+
+    expect(renderedOrderOf($categories, $tree))
+        ->toBe([$area->getKey(), $spilled->getKey(), $solvent->getKey()]);
+});

--- a/tests/Livewire/Settings/SortCategoriesTest.php
+++ b/tests/Livewire/Settings/SortCategoriesTest.php
@@ -29,9 +29,6 @@ function categoryTree(): array
     ];
 }
 
-/**
- * @return array<int, int>
- */
 function renderedOrderOf(Categories $categories, array $tree): array
 {
     $categories->loadData(true);
@@ -44,8 +41,6 @@ function renderedOrderOf(Categories $categories, array $tree): array
     ));
 }
 
-// The children arrived in whatever order the database held them, so the order a
-// category carries was invisible everywhere the tree is read.
 test('the children of a category come back in their own order', function (): void {
     [$area, $spilled, $solvent] = categoryTree();
 
@@ -55,8 +50,6 @@ test('the children of a category come back in their own order', function (): voi
         ->toBe(['Loesungsmittel leer', 'Ausgelaufen']);
 });
 
-// Dragging a row renumbers the list in the order it now reads, roots and
-// children from the same run, so a child keeps its place among its siblings.
 test('dragging a child to the front puts it before its sibling', function (): void {
     $tree = categoryTree();
     [$area, $spilled, $solvent] = $tree;


### PR DESCRIPTION
The settings show categories as a tree, but nothing about them carried an order anybody chose: the list read them in whatever order the database returned, and a select offered them newest first. An area and the entries below it therefore sat scattered over the list, and adding one more moved it to the top of every select.

`Category` is `Sortable` and has been for a long time, so the order already had a home in `sort_number`. Three places now use it:

- the settings list is sortable, a row is dragged and the list renumbers itself
- the children of a category come back in their own order
- the search endpoint offers a sortable model in its order

Dragging renumbers the whole rendered list, roots and children from the same run, so a child keeps its place among its siblings once the tree is built again. A record that is not on the rendered list is left alone.

The endpoint keeps the newest first for everything that is not sortable, and an explicit `orderBy` still wins, so nothing that asks for a specific order changes.

## Summary by Sourcery

Introduce consistent use of the Category sort order across settings, tree rendering, and search so that manually defined ordering is respected and can be controlled via drag-and-drop.

New Features:
- Enable manual reordering of categories in the settings tree via drag-and-drop.

Bug Fixes:
- Ensure category children are returned in their defined sort order instead of database insertion order.
- Make search results for sortable models respect their own defined order while preserving explicit orderBy requests.

Enhancements:
- Preserve category sort order when building the category tree for data tables, including both roots and children.

Tests:
- Add Livewire tests covering category drag-and-drop reordering behavior and its impact on the rendered tree.
- Add feature tests verifying sortable search result ordering and precedence of explicit ordering parameters.