### PR TITLE
feat(accounting): keep a payment run total and reopen orders that leave a run

### DIFF
--- a/database/migrations/2026_08_12_000001_add_total_amount_to_payment_runs_table.php
+++ b/database/migrations/2026_08_12_000001_add_total_amount_to_payment_runs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payment_runs', function (Blueprint $table): void {
+            $table->decimal('total_amount', 40, 10)
+                ->default(0)
+                ->after('payment_run_type_enum');
+        });
+
+        DB::table('payment_runs')->update([
+            'total_amount' => DB::raw(
+                '(select coalesce(sum(`amount`), 0) from `order_payment_run` '
+                . 'where `order_payment_run`.`payment_run_id` = `payment_runs`.`id`)'
+            ),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('payment_runs', function (Blueprint $table): void {
+            $table->dropColumn('total_amount');
+        });
+    }
+};

--- a/src/Livewire/DataTables/PaymentRunList.php
+++ b/src/Livewire/DataTables/PaymentRunList.php
@@ -22,6 +22,7 @@ class PaymentRunList extends BaseDataTable
         'bank_connection.iban',
         'state',
         'payment_run_type_enum',
+        'total_amount',
     ];
 
     public ?string $includeBefore = 'flux::livewire.accounting.payment-run.include-before';
@@ -147,8 +148,7 @@ class PaymentRunList extends BaseDataTable
                     ])
                     ->with(['contactBankConnection:id,iban', 'addressInvoice:id,name'])
                     ->withPivot('amount'),
-            ])
-            ->loadSum('orders AS total_amount', 'order_payment_run.amount');
+            ]);
 
         $this->paymentRunForm->fill($paymentRun);
         $this->paymentRunForm->orders = $paymentRun->orders->toArray();

--- a/src/Models/PaymentRun.php
+++ b/src/Models/PaymentRun.php
@@ -13,6 +13,7 @@ use FluxErp\Traits\Model\HasUuid;
 use FluxErp\Traits\Model\LogsActivity;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\DB;
 
 class PaymentRun extends FluxModel
 {
@@ -38,9 +39,14 @@ class PaymentRun extends FluxModel
 
     public function recalculateTotalAmount(): static
     {
-        $this->total_amount = $this->orders()->sum('order_payment_run.amount');
-
-        $this->saveQuietly();
+        static::query()
+            ->whereKey($this->getKey())
+            ->update([
+                'total_amount' => DB::raw(
+                    '(select coalesce(sum(`amount`), 0) from `order_payment_run` '
+                    . 'where `order_payment_run`.`payment_run_id` = `payment_runs`.`id`)'
+                ),
+            ]);
 
         return $this;
     }

--- a/src/Models/PaymentRun.php
+++ b/src/Models/PaymentRun.php
@@ -2,6 +2,7 @@
 
 namespace FluxErp\Models;
 
+use FluxErp\Casts\Money;
 use FluxErp\Enums\PaymentRunTypeEnum;
 use FluxErp\Enums\SepaMandateTypeEnum;
 use FluxErp\Models\Pivots\OrderPaymentRun;
@@ -25,6 +26,7 @@ class PaymentRun extends FluxModel
             'sepa_mandate_type_enum' => SepaMandateTypeEnum::class,
             'instructed_execution_date' => 'date',
             'is_instant_payment' => 'boolean',
+            'total_amount' => Money::class,
         ];
     }
 
@@ -32,6 +34,15 @@ class PaymentRun extends FluxModel
     public function bankConnection(): BelongsTo
     {
         return $this->belongsTo(BankConnection::class);
+    }
+
+    public function recalculateTotalAmount(): static
+    {
+        $this->total_amount = $this->orders()->sum('order_payment_run.amount');
+
+        $this->saveQuietly();
+
+        return $this;
     }
 
     public function orders(): BelongsToMany

--- a/src/Models/Pivots/OrderPaymentRun.php
+++ b/src/Models/Pivots/OrderPaymentRun.php
@@ -4,11 +4,46 @@ namespace FluxErp\Models\Pivots;
 
 use FluxErp\Models\Order;
 use FluxErp\Models\PaymentRun;
+use FluxErp\States\Order\PaymentState\InOpenPaymentRun;
+use FluxErp\States\Order\PaymentState\InPayment;
+use FluxErp\States\Order\PaymentState\Open;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OrderPaymentRun extends FluxPivot
 {
     protected $table = 'order_payment_run';
+
+    protected static function booted(): void
+    {
+        static::saved(function (OrderPaymentRun $orderPaymentRun): void {
+            $orderPaymentRun->paymentRun?->recalculateTotalAmount();
+        });
+
+        static::deleted(function (OrderPaymentRun $orderPaymentRun): void {
+            $orderPaymentRun->paymentRun?->recalculateTotalAmount();
+
+            $order = $orderPaymentRun->order;
+
+            if (! $order
+                || (
+                    ! $order->payment_state instanceof InOpenPaymentRun
+                    && ! $order->payment_state instanceof InPayment
+                )
+            ) {
+                return;
+            }
+
+            if ($order->paymentRuns()->exists()) {
+                return;
+            }
+
+            if ($order->payment_state->canTransitionTo(Open::class)) {
+                $order->payment_state->transitionTo(Open::class);
+            }
+
+            $order->calculatePaymentState()->save();
+        });
+    }
 
     // Relations
     public function order(): BelongsTo

--- a/tests/Livewire/DataTables/PaymentRunListTest.php
+++ b/tests/Livewire/DataTables/PaymentRunListTest.php
@@ -68,3 +68,66 @@ test('edit is renderless so it does not trigger empty re-render', function (): v
 
     expect($attributes)->not->toBeEmpty('edit() must have #[Renderless] to prevent clearing table data');
 });
+
+test('the list carries the total amount of a payment run', function (): void {
+    $paymentRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create();
+
+    $orderData = [
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => Tenant::default()->getKey(),
+        'language_id' => Language::default()->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'order_type_id' => $orderType->getKey(),
+    ];
+
+    $paymentRun->orders()->attach(Order::factory()->create($orderData)->getKey(), ['amount' => '100.00']);
+    $paymentRun->orders()->attach(Order::factory()->create($orderData)->getKey(), ['amount' => '250.50']);
+
+    expect((float) $paymentRun->refresh()->total_amount)->toBe(350.50);
+});
+
+test('removing an order updates the stored total', function (): void {
+    $paymentRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create();
+
+    $orderData = [
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'tenant_id' => Tenant::default()->getKey(),
+        'language_id' => Language::default()->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'order_type_id' => $orderType->getKey(),
+    ];
+
+    $stays = Order::factory()->create($orderData);
+    $goes = Order::factory()->create($orderData);
+
+    $paymentRun->orders()->attach($stays->getKey(), ['amount' => '100.00']);
+    $paymentRun->orders()->attach($goes->getKey(), ['amount' => '250.50']);
+
+    $paymentRun->orders()->detach($goes->getKey());
+
+    expect((float) $paymentRun->refresh()->total_amount)->toBe(100.0);
+});
+
+test('the total amount is enabled by default', function (): void {
+    expect((new PaymentRunList())->enabledCols)->toContain('total_amount');
+});

--- a/tests/Unit/Models/PaymentRunAssignmentTest.php
+++ b/tests/Unit/Models/PaymentRunAssignmentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentRun;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+use FluxErp\States\Order\PaymentState\InOpenPaymentRun;
+use FluxErp\States\Order\PaymentState\Open;
+use FluxErp\States\Order\PaymentState\Paid;
+
+function createOrderForPaymentRun(object $test, string $paymentState = InOpenPaymentRun::class): Order
+{
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+        'is_invoice_address' => true,
+    ]);
+
+    $order = Order::factory()->create([
+        'order_type_id' => OrderType::factory()->create(['is_active' => true])->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => PaymentType::factory()
+            ->hasAttached($test->dbTenant, relationship: 'tenants')
+            ->create()
+            ->getKey(),
+        'price_list_id' => PriceList::factory()->create()->getKey(),
+        'currency_id' => Currency::factory()->create()->getKey(),
+        'language_id' => $test->defaultLanguage->getKey(),
+        'tenant_id' => $test->dbTenant->getKey(),
+    ]);
+
+    Order::query()->whereKey($order->getKey())->update(['payment_state' => $paymentState::$name]);
+
+    return $order->refresh();
+}
+
+test('removing an order from a payment run reopens it', function (): void {
+    $paymentRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+
+    $order = createOrderForPaymentRun($this);
+    $paymentRun->orders()->attach($order->getKey(), ['amount' => '100.00']);
+
+    $paymentRun->orders()->detach($order->getKey());
+
+    expect($order->refresh()->payment_state)->toBeInstanceOf(Open::class);
+});
+
+test('removing a settled order from a payment run keeps it paid', function (): void {
+    $paymentRun = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+
+    $order = createOrderForPaymentRun($this, Paid::class);
+    $paymentRun->orders()->attach($order->getKey(), ['amount' => '100.00']);
+
+    $paymentRun->orders()->detach($order->getKey());
+
+    expect($order->refresh()->payment_state)->toBeInstanceOf(Paid::class);
+});
+
+test('an order that sits in another open run stays in a payment run state', function (): void {
+    $first = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+    $second = PaymentRun::query()->create([
+        'payment_run_type_enum' => 'money_transfer',
+        'state' => 'open',
+    ]);
+
+    $order = createOrderForPaymentRun($this);
+    $first->orders()->attach($order->getKey(), ['amount' => '100.00']);
+    $second->orders()->attach($order->getKey(), ['amount' => '100.00']);
+
+    $first->orders()->detach($order->getKey());
+
+    expect($order->refresh()->payment_state)->toBeInstanceOf(InOpenPaymentRun::class);
+});


### PR DESCRIPTION
Two things on payment runs.

**The run now carries its total.** `payment_runs.total_amount` is a real column, filled from the pivot and kept up to date by the pivot itself, and it is enabled by default in the list. The migration backfills existing runs from `order_payment_run`. `edit()` no longer needs its `loadSum('orders AS total_amount')`, the column supplies the same value to the form.

**An order that leaves a run gets its state back.** `CreatePaymentRun` moves orders to `InOpenPaymentRun`, but only two paths ever moved them back, so an order could sit in an open payment run that no longer held it. Both jobs now hang off the pivot model, which covers every path: `orders()` is declared `->using(OrderPaymentRun::class)`, and Laravel routes both `attach()` and `detach()` through the custom pivot class, so the models fire real events.

The reset is deliberately narrow:

- it only acts on `InOpenPaymentRun` and `InPayment`, so a settled or partially paid order keeps its state
- it does nothing while the order still sits in another run
- after reopening it runs `calculatePaymentState()`, so an order that was paid in the meantime lands on the correct state instead of plain open

Tests cover the reopen, the settled order that must stay paid, the order that belongs to a second run, the stored total, and that removing an order updates it. 114 tests in `Livewire/Accounting` and `Unit/Models` plus the payment run action tests pass.

## Summary by Sourcery

Track and persist the total amount of each payment run and ensure order payment states are correctly reset when orders are detached from runs.

New Features:
- Add a stored total_amount field on payment runs and expose it in the payment run list UI.

Bug Fixes:
- Ensure orders removed from a payment run revert to the appropriate payment state unless still part of another run.

Enhancements:
- Keep payment run totals in sync by recalculating on pivot changes instead of loading sums ad hoc in the edit view.

Tests:
- Add unit and Livewire tests validating stored payment run totals, their updates on order removal, and correct order payment state transitions when leaving or staying in payment runs.