### PR TITLE
Keep the address list standing when the last address goes

### DIFF
--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -144,10 +144,7 @@ class Addresses extends Component
             fn ($address) => $address['id'] !== $this->addressId
         ));
 
-        $address = resolve_static(Address::class, 'query')
-            ->whereKey($this->addresses[0]['id'])
-            ->first();
-        $this->select($address);
+        $this->selectFirstAddress();
 
         $this->edit = false;
     }
@@ -302,19 +299,7 @@ class Addresses extends Component
     public function reloadAddress(): void
     {
         if (! $this->address->id) {
-            // Whichever address is first takes over the detail pane once the
-            // shown one is deleted. Deleting the contact deletes them all
-            // though, and then there is no first one and nothing left to take
-            // over: reading it demanded a row that is gone, and the selection
-            // demanded an address where the query had already found none.
-            $replacement = resolve_static(Address::class, 'query')
-                ->whereKey(data_get($this->addresses, '0.id'))
-                ->with('contactOptions')
-                ->first();
-
-            if ($replacement) {
-                $this->select($replacement);
-            }
+            $this->selectFirstAddress();
 
             return;
         }
@@ -389,5 +374,24 @@ class Addresses extends Component
         $this->address->fill($address);
 
         $this->addressId = $this->address->id;
+    }
+
+    /**
+     * Whichever address is first takes over the detail pane once the shown one
+     * is gone. There is not always one: deleting the contact deletes all of its
+     * addresses, and the broadcast for each of them still arrives. Reading the
+     * first of none demanded a row that is gone, and where a stale entry was
+     * still listed the selection demanded an address the query had not found.
+     */
+    private function selectFirstAddress(): void
+    {
+        $address = resolve_static(Address::class, 'query')
+            ->whereKey(data_get($this->addresses, '0.id'))
+            ->with('contactOptions')
+            ->first();
+
+        if ($address) {
+            $this->select($address);
+        }
     }
 }

--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -376,16 +376,14 @@ class Addresses extends Component
         $this->addressId = $this->address->id;
     }
 
-    private function selectFirstAddress(): void
+    protected function selectFirstAddress(): void
     {
         $address = resolve_static(Address::class, 'query')
-            ->whereKey(data_get($this->addresses, '0.id'))
+            ->whereKey(data_get(array_first($this->addresses ?? []), 'id'))
             ->with('contactOptions')
             ->first();
 
-        // Deleting the contact takes all of its addresses with it, so there is
-        // nothing left here to show.
-        if (! $address) {
+        if (is_null($address)) {
             $this->redirectRoute('contacts.contacts', navigate: true);
 
             return;

--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -302,12 +302,19 @@ class Addresses extends Component
     public function reloadAddress(): void
     {
         if (! $this->address->id) {
-            $this->select(
-                resolve_static(Address::class, 'query')
-                    ->whereKey($this->addresses[0]['id'])
-                    ->with('contactOptions')
-                    ->first()
-            );
+            // Whichever address is first takes over the detail pane once the
+            // shown one is deleted. Deleting the contact deletes them all
+            // though, and then there is no first one and nothing left to take
+            // over: reading it demanded a row that is gone, and the selection
+            // demanded an address where the query had already found none.
+            $replacement = resolve_static(Address::class, 'query')
+                ->whereKey(data_get($this->addresses, '0.id'))
+                ->with('contactOptions')
+                ->first();
+
+            if ($replacement) {
+                $this->select($replacement);
+            }
 
             return;
         }

--- a/src/Livewire/Contact/Addresses.php
+++ b/src/Livewire/Contact/Addresses.php
@@ -376,13 +376,6 @@ class Addresses extends Component
         $this->addressId = $this->address->id;
     }
 
-    /**
-     * Whichever address is first takes over the detail pane once the shown one
-     * is gone. There is not always one: deleting the contact deletes all of its
-     * addresses, and the broadcast for each of them still arrives. Reading the
-     * first of none demanded a row that is gone, and where a stale entry was
-     * still listed the selection demanded an address the query had not found.
-     */
     private function selectFirstAddress(): void
     {
         $address = resolve_static(Address::class, 'query')
@@ -390,8 +383,14 @@ class Addresses extends Component
             ->with('contactOptions')
             ->first();
 
-        if ($address) {
-            $this->select($address);
+        // Deleting the contact takes all of its addresses with it, so there is
+        // nothing left here to show.
+        if (! $address) {
+            $this->redirectRoute('contacts.contacts', navigate: true);
+
+            return;
         }
+
+        $this->select($address);
     }
 }

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -140,11 +140,9 @@ test('can lift an address into a new contact', function (): void {
         ->and($secondary->is_main_address)->toBeTrue();
 });
 
-// Whichever address is first takes over the detail pane once the shown one is
-// deleted. Deleting the contact deletes them all though, and the broadcast for
-// each one still arrives: there is no first address left to take over, and both
-// reading it and selecting it ended the request.
-test('survives the deletion of the last address', function (): void {
+// Deleting the contact deletes all of its addresses, and the broadcast for each
+// one still arrives. Nothing is left to show, so the list is where to go.
+test('goes back to the contacts when the last address is gone', function (): void {
     $address = Address::query()->whereKey($this->addressForm->id)->first();
 
     $component = Livewire::actingAs($this->user)
@@ -155,16 +153,16 @@ test('survives the deletion of the last address', function (): void {
     $component
         ->call('addressDeleted', ['model' => ['id' => $this->addressForm->id]])
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertRedirect(route('contacts.contacts'));
 });
 
-// Deleting from the detail pane takes the same route to the next address, so
-// deleting the only one there is lands in the same place.
-test('survives deleting the only address from the pane', function (): void {
+test('goes back to the contacts when the only address is deleted from the pane', function (): void {
     Livewire::actingAs($this->user)
         ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
         ->set('addressId', $this->addressForm->id)
         ->call('delete')
         ->assertOk()
-        ->assertHasNoErrors();
+        ->assertHasNoErrors()
+        ->assertRedirect(route('contacts.contacts'));
 });

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -140,8 +140,6 @@ test('can lift an address into a new contact', function (): void {
         ->and($secondary->is_main_address)->toBeTrue();
 });
 
-// Deleting the contact deletes all of its addresses, and the broadcast for each
-// one still arrives. Nothing is left to show, so the list is where to go.
 test('goes back to the contacts when the last address is gone', function (): void {
     $address = Address::query()->whereKey($this->addressForm->id)->first();
 

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -157,3 +157,14 @@ test('survives the deletion of the last address', function (): void {
         ->assertOk()
         ->assertHasNoErrors();
 });
+
+// Deleting from the detail pane takes the same route to the next address, so
+// deleting the only one there is lands in the same place.
+test('survives deleting the only address from the pane', function (): void {
+    Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm])
+        ->set('addressId', $this->addressForm->id)
+        ->call('delete')
+        ->assertOk()
+        ->assertHasNoErrors();
+});

--- a/tests/Livewire/Contact/AddressesTest.php
+++ b/tests/Livewire/Contact/AddressesTest.php
@@ -139,3 +139,21 @@ test('can lift an address into a new contact', function (): void {
     expect($secondary->refresh()->contact_id)->not->toBe($this->contactForm->id)
         ->and($secondary->is_main_address)->toBeTrue();
 });
+
+// Whichever address is first takes over the detail pane once the shown one is
+// deleted. Deleting the contact deletes them all though, and the broadcast for
+// each one still arrives: there is no first address left to take over, and both
+// reading it and selecting it ended the request.
+test('survives the deletion of the last address', function (): void {
+    $address = Address::query()->whereKey($this->addressForm->id)->first();
+
+    $component = Livewire::actingAs($this->user)
+        ->test(Addresses::class, ['contact' => $this->contactForm, 'address' => $this->addressForm]);
+
+    $address->forceDelete();
+
+    $component
+        ->call('addressDeleted', ['model' => ['id' => $this->addressForm->id]])
+        ->assertOk()
+        ->assertHasNoErrors();
+});


### PR DESCRIPTION
Two errors from the same three lines, seen on a customer system, 36 occurrences combined:

| error | message | occurrences |
|---|---|---|
| [8740924](https://flareapp.io/errors/8740924/latest) | `Undefined array key 0` in `reloadAddress` | 24 |
| [8880145](https://flareapp.io/errors/8880145/latest) | `Addresses::select(): Argument #1 ($address) must be of type Address, null given` | 12 |

## Cause

`addressDeleted()` reloads the list and, when the deleted address was the one on display, picks whichever address is now first to take over the detail pane:

```php
->whereKey($this->addresses[0]['id'])
```

Deleting the **contact** deletes all of its addresses, and the broadcast for each one still arrives. By then there is no first address left: the array is empty, so reading index zero raises the undefined key, and where a stale row was still listed the query finds nothing and `select(Address $address)` gets null.

`delete()` repeated the same three lines and carried the same fault, unreported so far: deleting the only address from the detail pane ends the request in exactly the same way.

## What changes

Both go through one place that looks the replacement up without assuming it exists.

When there is none, it redirects to the contact list. That is the honest end state rather than a guard that leaves a detail pane standing for a contact that no longer exists, and it is where `Contact::contactDeleted()` already sends the user on the very same event. Until now that redirect never arrived: this component threw first and took the whole Livewire request down with it.

## Tests

Two cases, both seen failing with `Undefined array key 0` before the change:

* the broadcast for the displayed address after it has really been deleted
* deleting the only address from the pane

Full `Contact\AddressesTest` green, 11 passed.

Note on the red Browser Tests: the runner could not resolve `cdn.playwright.dev` while installing browsers. Unrelated to this change.