### PR TITLE
Show file previews in the lightbox instead of the detail modal

### DIFF
--- a/resources/views/components/nuxbe-lightbox.blade.php
+++ b/resources/views/components/nuxbe-lightbox.blade.php
@@ -87,7 +87,7 @@
     <a
         x-show="downloadUrl"
         x-bind:href="downloadUrl"
-        x-bind:download="downloadName"
+        download
         x-on:click.stop
         target="_blank"
         rel="noopener"

--- a/resources/views/livewire/order/purchase.blade.php
+++ b/resources/views/livewire/order/purchase.blade.php
@@ -103,7 +103,12 @@
             <x-button
                 color="indigo"
                 :text="__('View')"
-                x-on:click="$nuxbe.openDetailModal($wire.order.invoice.url)"
+                x-on:click="
+                    $nuxbe.openLightbox($wire.order.invoice.url, {
+                        mime: $wire.order.invoice.mime_type,
+                        title: $wire.order.invoice.name,
+                    })
+                "
             />
         </x-card>
     @show

--- a/resources/views/livewire/settings/email-templates.blade.php
+++ b/resources/views/livewire/settings/email-templates.blade.php
@@ -182,7 +182,12 @@
                                 x-cloak
                                 x-show="file.preview_url !== ''"
                                 class="h-full"
-                                x-on:click="$nuxbe.openDetailModal(file.original_url)"
+                                x-on:click="
+                                    $nuxbe.openLightbox(file.original_url, {
+                                        mime: file.mime_type,
+                                        title: file.name,
+                                    })
+                                "
                                 icon="eye"
                             />
                         </div>

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -1090,6 +1090,7 @@ class Order extends Component
             $this->order->invoice = [
                 'url' => $invoice->getUrl(),
                 'mime_type' => $invoice->mime_type,
+                'name' => $invoice->name,
             ];
         }
 

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -182,6 +182,31 @@ test('create documents', function (): void {
     expect($invoice?->getPath())->not->toBeNull();
 });
 
+test('the invoice preview carries what the lightbox needs', function (): void {
+    Storage::fake();
+
+    $this->order->update(['is_locked' => false, 'invoice_number' => null]);
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->call('openCreateDocumentsModal')
+        ->set([
+            'selectedPrintLayouts' => [
+                'download' => ['invoice'],
+            ],
+        ])
+        ->call('createDocuments')
+        ->assertHasNoErrors();
+
+    $invoice = $this->order->invoice();
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->assertSet('order.invoice', [
+            'url' => $invoice->getUrl(),
+            'mime_type' => $invoice->mime_type,
+            'name' => $invoice->name,
+        ]);
+});
+
 test('create documents with delivery lock fails', function (): void {
     $this->order->update(['is_locked' => false, 'invoice_number' => null]);
     $this->contact->update(['has_delivery_lock' => true, 'credit_line' => 1]);


### PR DESCRIPTION
`openDetailModal()` loads a URL into an iframe and appends `no-navigation`, which is built for Flux detail pages. The document of a purchase order and the attachment of an email template are files, not pages, so they now open in the lightbox, which brings handlers for pdf, image, video and audio, escape to close and a download link.

While switching them over, a defect in the lightbox itself surfaced. Its download link was bound to the title it was given, so a caller had to pass a file name where a caption belongs. Every caller that passed a real title handed the browser a download without a file extension. The link now carries a bare `download` attribute and lets the browser take the name from the URL, which ends in the file name. That fixes the four callers that were already using the lightbox: comments, the media upload form, the folder tree and the media list.

The two remaining `openDetailModal()` call sites open internal pages and stay as they are.

## Summary by Sourcery

Switch file previews for invoices and email template attachments to use the lightbox instead of the detail modal, and fix the lightbox download behavior so browsers infer the file name from the URL.

New Features:
- Expose invoice file metadata (URL, MIME type, name) to the frontend for use in the lightbox.
- Open invoice and email template attachment previews in the lightbox with appropriate MIME type and title metadata.

Bug Fixes:
- Update the lightbox download link to use a bare download attribute so downloaded files keep their correct names and extensions across existing lightbox callers.

Tests:
- Add a Livewire test ensuring the invoice preview data includes the URL, MIME type, and name needed by the lightbox.