### PR TITLE
Let a granted permission take effect without reloading the workers

### DIFF
--- a/src/FluxServiceProvider.php
+++ b/src/FluxServiceProvider.php
@@ -242,6 +242,7 @@ class FluxServiceProvider extends ServiceProvider
             'ts-ui.components.dialog.1.blur' => 'md',
             'ts-ui.components.modal.1.z-index' => 'z-30',
             'ts-ui.components.slide.1.z-index' => 'z-30',
+            'permission.register_octane_reset_listener' => true,
         ]);
 
         $this->booted(function (): void {

--- a/tests/Unit/OctanePermissionResetTest.php
+++ b/tests/Unit/OctanePermissionResetTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use function Livewire\invade;
+
+test('the permission reset for long running workers is switched on while registering', function (): void {
+    config(['permission.register_octane_reset_listener' => false]);
+
+    $provider = new FluxErp\FluxServiceProvider($this->app);
+    invade($provider)->registerConfig();
+
+    expect(config('permission.register_octane_reset_listener'))->toBeTrue();
+});


### PR DESCRIPTION
Under a long running worker (Octane, FrankenPHP/Swoole/RoadRunner) `PermissionRegistrar` keeps the permissions it loaded on the worker's first request. Granting a permission therefore has no effect until the workers are reloaded, even though the database row and the shared cache are already current. Diagnosed on a live instance: `permission:cache-reset` alone did nothing, `octane:reload` fixed it.

`spatie/laravel-permission` ships a listener for this (`register_octane_reset_listener`, off by default). Enabled, it calls `clearPermissionsCollection()` on `OperationTerminated`, which drops only the copy held in the worker and leaves the shared cache untouched, so the next request reads the current state and there is no extra load on the cache backend beyond the usual lookup.

**Octane stays optional.** `PermissionServiceProvider::registerOctaneListener()` returns early when `config('octane.listeners')` is empty, so an installation without `laravel/octane` never registers a listener and never reads the flag. Nothing changes for those apps.

The flag is set in `registerConfig()` rather than in the `booted()` callback right below it, because the permission package reads it while booting — from `booted()` it would come too late. The test covers exactly that: it resets the flag, runs `registerConfig()` and asserts the value, so moving the line into the boot phase turns it red (verified by removing the line: red, restored: green).

Pint clean.

## Summary by Sourcery

Enable permission cache reset for long-running workers by configuring the permission package to register its Octane reset listener during service registration.

Enhancements:
- Configure the permission package to register its Octane reset listener so granted permissions take effect without reloading long-running workers.

Tests:
- Add a unit test to verify the Octane permission reset listener flag is enabled during the service provider's register phase.