### PR TITLE
Keep a product's properties when an update omits them

### DIFF
--- a/src/Actions/Product/UpdateProduct.php
+++ b/src/Actions/Product/UpdateProduct.php
@@ -37,8 +37,6 @@ class UpdateProduct extends FluxAction
         $productCrossSellings = Arr::pull($this->data, 'product_cross_sellings');
         $tenants = Arr::pull($this->data, 'tenants');
 
-        // No default here. With one, an update that never mentions the properties would sync an
-        // empty array and silently detach every property the product has.
         $productProperties = is_null($properties = Arr::pull($this->data, 'product_properties'))
             ? null
             : Arr::mapWithKeys(

--- a/src/Actions/Product/UpdateProduct.php
+++ b/src/Actions/Product/UpdateProduct.php
@@ -37,10 +37,14 @@ class UpdateProduct extends FluxAction
         $productCrossSellings = Arr::pull($this->data, 'product_cross_sellings');
         $tenants = Arr::pull($this->data, 'tenants');
 
-        $productProperties = Arr::mapWithKeys(
-            Arr::pull($this->data, 'product_properties', []),
-            fn ($item, $key) => [$item['id'] => ['value' => $item['value']]]
-        );
+        // No default here. With one, an update that never mentions the properties would sync an
+        // empty array and silently detach every property the product has.
+        $productProperties = is_null($properties = Arr::pull($this->data, 'product_properties'))
+            ? null
+            : Arr::mapWithKeys(
+                $properties,
+                fn ($item, $key) => [$item['id'] => ['value' => $item['value']]]
+            );
         $bundleProducts = Arr::pull($this->data, 'bundle_products', false);
         $prices = Arr::pull($this->data, 'prices', false);
         $suppliers = Arr::pull($this->data, 'suppliers');

--- a/tests/Feature/Actions/Product/ProductActionTest.php
+++ b/tests/Feature/Actions/Product/ProductActionTest.php
@@ -4,6 +4,7 @@ use FluxErp\Actions\Product\CreateProduct;
 use FluxErp\Actions\Product\DeleteProduct;
 use FluxErp\Actions\Product\UpdateProduct;
 use FluxErp\Models\Product;
+use FluxErp\Models\ProductProperty;
 use FluxErp\Models\VatRate;
 
 test('create product with defaults', function (): void {
@@ -70,4 +71,31 @@ test('create product rejects a purchase-only vat rate', function (): void {
         'name' => 'Test Widget',
         'vat_rate_id' => $purchaseOnlyVatRate->getKey(),
     ], 'vat_rate_id');
+});
+
+test('update product keeps its properties when none are passed', function (): void {
+    $product = Product::factory()->create();
+    $property = ProductProperty::factory()->create();
+    $product->productProperties()->attach($property->getKey(), ['value' => 'kept']);
+
+    UpdateProduct::make([
+        'id' => $product->getKey(),
+        'name' => 'Updated Widget',
+    ])->validate()->execute();
+
+    expect($product->productProperties()->pluck('id')->all())->toBe([$property->getKey()]);
+});
+
+test('update product syncs its properties when they are passed', function (): void {
+    $product = Product::factory()->create();
+    $stale = ProductProperty::factory()->create();
+    $wanted = ProductProperty::factory()->create();
+    $product->productProperties()->attach($stale->getKey(), ['value' => 'gone']);
+
+    UpdateProduct::make([
+        'id' => $product->getKey(),
+        'product_properties' => [['id' => $wanted->getKey(), 'value' => 'set']],
+    ])->validate()->execute();
+
+    expect($product->productProperties()->pluck('id')->all())->toBe([$wanted->getKey()]);
 });


### PR DESCRIPTION
## Problem

`UpdateProduct` pulled `product_properties` with an empty-array default:

```php
$productProperties = Arr::mapWithKeys(
    Arr::pull($this->data, 'product_properties', []),
    ...
);
...
if (! is_null($productProperties)) {
    $product->productProperties()->sync($productProperties);
}
```

The value is therefore never `null`, the guard always passes, and an update that never mentions properties runs `sync([])` — detaching every property the product has. `product_options`, `suppliers` and `tags` all pull without a default and are correctly skipped when absent; this one was the exception.

The damage is silent and easy to miss: an importer that updates a product from an external source passes the fields it knows about and wipes the properties maintained in flux.

## Change

Pull without a default and keep `null` meaning "not part of this update".

Removing every property through the UI still detaches, because `ProductForm` always carries the array and sends an explicit `[]`.

## Tests

`tests/Feature/Actions/Product/ProductActionTest.php`:
- an update that omits the properties keeps them
- an update that passes properties still syncs them (stale ones go)

The first test fails on main.

## Summary by Sourcery

Ensure product updates preserve existing properties when the update payload omits them while still syncing explicitly provided properties.

Bug Fixes:
- Prevent product updates from unintentionally detaching all properties when no product_properties field is included.

Tests:
- Add feature tests covering property preservation when omitted from updates and proper syncing when properties are explicitly provided.