### PR TITLE
fix(calendar): keep the event modal in the dom when an event is opened

### DIFF
--- a/src/Livewire/Features/Calendar/Calendar.php
+++ b/src/Livewire/Features/Calendar/Calendar.php
@@ -130,7 +130,6 @@ class Calendar extends Component
 
         if ($trigger === 'event-change' && ! $isEditable) {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             return;
         }
@@ -170,7 +169,6 @@ class Calendar extends Component
 
         if ($trigger === 'event-change') {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             if ($this->event->was_repeatable) {
                 $this->js(<<<'JS'
@@ -200,7 +198,6 @@ class Calendar extends Component
             }
         } elseif ($previousEditComponent === $this->event->edit_component) {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             $this->js(<<<'JS'
                 window.dispatchEvent(new CustomEvent('sync-calendar-event', {

--- a/src/Livewire/Features/Calendar/CalendarEventEdit.php
+++ b/src/Livewire/Features/Calendar/CalendarEventEdit.php
@@ -9,34 +9,11 @@ use Livewire\Component;
 
 class CalendarEventEdit extends Component
 {
-    public static bool $skipNextRender = false;
-
     #[Modelable]
     public CalendarEventForm $event;
-
-    protected ?string $currentEditComponent = null;
 
     public function render(): View
     {
         return view('flux::livewire.features.calendar.calendar-event-edit');
-    }
-
-    public function boot(): void
-    {
-        $this->currentEditComponent = data_get($this->event, 'edit_component');
-
-        if (static::$skipNextRender) {
-            static::$skipNextRender = false;
-            $this->skipRender();
-        }
-    }
-
-    public function updatedEvent(): void
-    {
-        if ($this->currentEditComponent !== data_get($this->event, 'edit_component')) {
-            return;
-        }
-
-        $this->skipRender();
     }
 }

--- a/tests/Livewire/Features/Calendar/CalendarEventModalTest.php
+++ b/tests/Livewire/Features/Calendar/CalendarEventModalTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use FluxErp\Livewire\Features\Calendar\CalendarEventEdit;
+use Livewire\Livewire;
+
+test('an event update still sends the markup that carries the modal', function (): void {
+    $component = Livewire::test(CalendarEventEdit::class)
+        ->set('event.title', 'Termin');
+
+    $html = data_get($component->effects, 'html');
+
+    expect($html)->not->toBeNull()
+        ->and($html)->toContain('edit-event-modal');
+});

--- a/tests/Livewire/Features/Calendar/CalendarEventModalTest.php
+++ b/tests/Livewire/Features/Calendar/CalendarEventModalTest.php
@@ -12,3 +12,15 @@ test('an event update still sends the markup that carries the modal', function (
     expect($html)->not->toBeNull()
         ->and($html)->toContain('edit-event-modal');
 });
+
+test('reopening an event of the same edit component still sends the markup', function (): void {
+    $component = Livewire::test(CalendarEventEdit::class)
+        ->set('event.edit_component', 'features.calendar.calendar-event')
+        ->set('event.title', 'Erster Termin')
+        ->set('event.title', 'Zweiter Termin');
+
+    $html = data_get($component->effects, 'html');
+
+    expect($html)->not->toBeNull()
+        ->and($html)->toContain('edit-event-modal');
+});


### PR DESCRIPTION
## The outage

Reported from production: appointments can no longer be created. Clicking a free slot draws the provisional block, but the dialog never opens. There is no workaround — a reload restores the modal, the next click destroys it again.

## What happens

Clicking a slot throws in the browser:

```
TypeError: Cannot read properties of undefined (reading 'dispatchEvent')
```

It comes from the JS the server returns in `Calendar::editEvent()`, which ends with `$tsui.open.modal('edit-event-modal')`. TallStackUI looks the modal up by id and dispatches on it; the element is gone, so it dispatches on `undefined`.

Measured on the live instance:

| moment | `calendar-event-edit` innerHTML | modal in DOM |
| --- | --- | --- |
| right after page load | 365.794 chars | yes |
| after one click on a free slot | **0** | **no** |

## Why the modal disappears

`CalendarEventEdit` skipped its own render in two places — from `boot()` when the parent had set the static `$skipNextRender`, and from `updatedEvent()` whenever the edit component had not changed. Both were render optimisations for a component whose markup is ~400KB.

The component sits inside `@island(name: 'calendar-event')` and its blade contains `<x-modal id="edit-event-modal">`, which TallStackUI teleports to `<body>`. A skipped render sends no markup at all, the island morph empties the component, and the teleported modal goes with it. The same request then asks that modal to open.

The fix drops the skipping: the component renders, so its modal stays. The static flag and the three assignments feeding it are gone with it.

## Test

A plain Livewire test cannot see this: with `skipRender()` the test harness keeps the previous html, so `assertSee('edit-event-modal')` passes while the browser is broken. The discriminating assertion is whether markup is sent at all — `effects['html']` is null on a skipped render. That is what the new test pins.

Verified in a browser against the patched code as well: the dialog opens on a free slot, closes, and opens again on a second slot, with no console errors.

## Note for the reviewer

`editEvent()` already carries `#[Renderless]`, so the three `$this->skipRender()` calls left inside it look redundant. I did not touch them: this is a hotfix for a live outage, and I have no test proving the attribute covers every path. Worth a separate cleanup.

## Summary by Sourcery

Ensure calendar event modals remain in the DOM so appointment editing works reliably.

Bug Fixes:
- Prevent the calendar event edit modal from being removed from the DOM when events are updated, avoiding runtime errors when opening the dialog.

Enhancements:
- Simplify the calendar event edit component by removing state used to conditionally skip its render and associated coordination with the calendar component.

Tests:
- Add a Livewire test that asserts calendar event updates still send HTML containing the edit-event modal markup.