### PR TITLE
fix(calendar): reopen the event modal when its markup was dropped

### DIFF
--- a/src/Livewire/Features/Calendar/Calendar.php
+++ b/src/Livewire/Features/Calendar/Calendar.php
@@ -206,7 +206,23 @@ class Calendar extends Component
                 window.dispatchEvent(new CustomEvent('sync-calendar-event', {
                     detail: JSON.parse(JSON.stringify($wire.event))
                 }));
-                $tsui.open.modal('edit-event-modal');
+                setTimeout(() => {
+                    const openEditEventModal = () => $tsui.open.modal('edit-event-modal');
+
+                    if (document.getElementById('edit-event-modal')) {
+                        openEditEventModal();
+
+                        return;
+                    }
+
+                    const editComponent = window.Livewire.all().find(
+                        (component) => component.name.endsWith('calendar.calendar-event-edit')
+                    );
+
+                    editComponent
+                        ? editComponent.$wire.$refresh().then(() => setTimeout(openEditEventModal, 80))
+                        : openEditEventModal();
+                }, 250);
             JS);
         } else {
             $this->js(<<<'JS'


### PR DESCRIPTION
## The outage

Reported from a customer instance: appointments cannot be created. Clicking a free slot draws the provisional block, the dialog never opens, and the browser throws `TypeError: Cannot read properties of undefined (reading 'dispatchEvent')` — `$tsui.open.modal('edit-event-modal')` dispatching on a modal that is no longer in the DOM. There is no workaround; a reload restores the modal and the next click removes it again.

## What was measured

On the affected instance, before the click the `calendar-event-edit` component carries ~365KB of markup and `#edit-event-modal` exists. After one click the component is a **different instance** — new Livewire id, empty markup — and the modal is gone with it, because TallStackUI teleports it to `<body>`. The update response contains no html for either component, so the emptying is not something the server sent.

A `$refresh()` on the replaced component brings everything back (365KB, modal present). The component renders correctly; only the update path leaves it empty.

## The change

The JS the server already emits to open the modal now checks whether the modal is actually there. If it is, it opens as before. If it is not, it refreshes the edit component first and opens once the markup is back.

This is a targeted remedy, not a root-cause fix: why the island hands back a fresh, empty child on that instance is not established. What is established is that this makes the dialog open reliably where it previously never did.

## Verification

Server-side tests cannot see this — the failure is a DOM replacement after the response. Verified in the browser on the affected customer's dev instance, which reproduces the bug identically to production: dialog opens on a free slot with the correct times, closes, and opens again on a second slot with the new times. Confirmed twice in a row.

## Things worth knowing that came out of the investigation

- **Octane keeps classes in memory.** `php artisan optimize:clear` does not pick up changed PHP; only `php artisan octane:reload` does. Several earlier attempts at this bug appeared to fail purely because the workers were still running the old code.
- The customer's own `Calendar` subclass, their `CalendarEventForm` and their overridden blade views were each ruled out by disabling them one at a time; the deployed core files are byte-identical to main.

## Summary by Sourcery

Bug Fixes:
- Prevent calendar event editing from failing with a JS error when the edit-event modal has been removed from the DOM by refreshing the edit component and reopening the modal.