### PR TITLE
Stop leaking the calendar edit skip flag between requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/reverb": "^1.11",
         "laravel/sanctum": "^4.3",
         "laravel/scout": "^11.4",
-        "livewire/livewire": "^4.3.3",
+        "livewire/livewire": "^4.4",
         "meilisearch/meilisearch-php": "^1.16",
         "nesbot/carbon": "^3.13",
         "php-http/discovery": "^1.20",

--- a/src/Livewire/Features/Calendar/Calendar.php
+++ b/src/Livewire/Features/Calendar/Calendar.php
@@ -130,7 +130,6 @@ class Calendar extends Component
 
         if ($trigger === 'event-change' && ! $isEditable) {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             return;
         }
@@ -170,7 +169,6 @@ class Calendar extends Component
 
         if ($trigger === 'event-change') {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             if ($this->event->was_repeatable) {
                 $this->js(<<<'JS'
@@ -200,7 +198,6 @@ class Calendar extends Component
             }
         } elseif ($previousEditComponent === $this->event->edit_component) {
             $this->skipRender();
-            CalendarEventEdit::$skipNextRender = true;
 
             $this->js(<<<'JS'
                 window.dispatchEvent(new CustomEvent('sync-calendar-event', {

--- a/src/Livewire/Features/Calendar/CalendarEventEdit.php
+++ b/src/Livewire/Features/Calendar/CalendarEventEdit.php
@@ -9,8 +9,6 @@ use Livewire\Component;
 
 class CalendarEventEdit extends Component
 {
-    public static bool $skipNextRender = false;
-
     #[Modelable]
     public CalendarEventForm $event;
 
@@ -24,11 +22,6 @@ class CalendarEventEdit extends Component
     public function boot(): void
     {
         $this->currentEditComponent = data_get($this->event, 'edit_component');
-
-        if (static::$skipNextRender) {
-            static::$skipNextRender = false;
-            $this->skipRender();
-        }
     }
 
     public function updatedEvent(): void

--- a/tests/Livewire/Features/Calendar/CalendarEventEditTest.php
+++ b/tests/Livewire/Features/Calendar/CalendarEventEditTest.php
@@ -1,9 +1,20 @@
 <?php
 
+use FluxErp\Livewire\Features\Calendar\Calendar;
 use FluxErp\Livewire\Features\Calendar\CalendarEventEdit;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
     Livewire::test(CalendarEventEdit::class)
         ->assertOk();
+});
+
+test('renders after the calendar skipped a non editable event change', function (): void {
+    Livewire::test(Calendar::class)
+        ->call('editEvent', ['extendedProps' => ['is_editable' => false]], 'event-change')
+        ->assertOk();
+
+    Livewire::test(CalendarEventEdit::class)
+        ->assertOk()
+        ->assertSee('edit-event-modal');
 });


### PR DESCRIPTION
## Problem

Creating an appointment stopped working on an Octane instance: clicking a free slot no longer opened the event modal, and once a worker was affected it stayed broken for everyone hitting it until the next restart. That is why it looked intermittent and why a redeploy appeared to help.

`CalendarEventEdit` carried a `public static bool $skipNextRender`. `Calendar::editEvent()` set it on three paths, expecting the child component to boot in the same request and reset it in `boot()`.

Livewire 4.4.0 fixed a store-key mismatch in `SupportIslands`:

```php
- if ($this->storeGet('skipIslandsRender', false)) return;   // written on the component, read on the hook
+ if ($this->component->shouldSkipIslandsRender()) return;    // both on the component
```

Before 4.4.0 the guard never took effect, so the island always rendered, the child always booted, and the flag was always consumed. Now `#[Renderless]` genuinely suppresses island rendering, the child does not boot, and the static keeps its value. Under FPM the process dies and nothing shows; under Octane it survives in the worker and the next request that does boot `CalendarEventEdit` calls `skipRender()`, so the modal markup is never sent.

## Fix

The flag has no job left — `#[Renderless]` already skips the island render — so it is removed along with its three assignments. Nothing else in `src/Livewire` uses a static this way (`Dashboard::$defaultWidgets` is boot-time configuration, not per-request state).

The constraint moves to `^4.4`, since the behaviour this code now relies on only exists there.

## Verification

The new test models the worker: statics survive between requests inside one test process just as they do inside an Octane worker. It fails on the current code at `assertSee('edit-event-modal')` and passes with the fix.

Browser-checked against real Livewire 4.4.0 (calendar slot click, order positions create and edit through the island refresh, project task list edit), each also with a `@extends` view override and a container-rebound `Calendar` subclass in place.

## Summary by Sourcery

Remove stale calendar edit skip flag now handled by Livewire and ensure calendar event editing continues to render correctly on supported Livewire versions.

Bug Fixes:
- Prevent calendar event edit modals from remaining hidden across requests due to a static skip-render flag persisting between requests, especially under Octane.

Enhancements:
- Rely on Livewire's render skipping instead of a custom static flag for calendar event editing behavior.

Build:
- Bump Livewire dependency constraint from ^4.3.3 to ^4.4 to depend on the fixed render skipping behavior.

Tests:
- Add a regression test ensuring the calendar event edit component still renders its modal after the calendar skips rendering a non-editable event change.