### PR TITLE
Stop the contract card and the schedule dialog from losing a schedule

### DIFF
--- a/resources/views/components/order/contract-card.blade.php
+++ b/resources/views/components/order/contract-card.blade.php
@@ -5,13 +5,7 @@
             wire:model="schedule.cron.methods.basic"
             required
             select="label:label|value:value"
-            x-on:select="
-                $wire.schedule.cron.parameters.basic =
-                    $event.detail.select.value === 'yearlyOn'
-                        ? [1, 1, '00:00']
-                        : [1, '00:00'];
-                $wire.previewSchedule();
-            "
+            x-on:select="$wire.previewSchedule()"
             :options="[
                 ['value' => 'monthlyOn', 'label' => __('Monthly On')],
                 ['value' => 'quarterlyOn', 'label' => __('Quarterly On')],

--- a/resources/views/components/order/contract-card.blade.php
+++ b/resources/views/components/order/contract-card.blade.php
@@ -13,10 +13,10 @@
                 $wire.previewSchedule();
             "
             :options="[
-                ['value' => 'monthlyOn', 'label' => __('Monthly')],
-                ['value' => 'quarterlyOn', 'label' => __('Quarterly')],
-                ['value' => 'yearlyOn', 'label' => __('Yearly')],
-                ['value' => 'weeklyOn', 'label' => __('Weekly')],
+                ['value' => 'monthlyOn', 'label' => __('Monthly On')],
+                ['value' => 'quarterlyOn', 'label' => __('Quarterly On')],
+                ['value' => 'yearlyOn', 'label' => __('Yearly On')],
+                ['value' => 'weeklyOn', 'label' => __('Weekly On')],
             ]"
         />
         <x-date

--- a/resources/views/components/order/contract-card.blade.php
+++ b/resources/views/components/order/contract-card.blade.php
@@ -3,6 +3,7 @@
         <x-select.styled
             :label="__('Repeat')"
             wire:model="schedule.cron.methods.basic"
+            required
             select="label:label|value:value"
             x-on:select="
                 $wire.schedule.cron.parameters.basic =

--- a/src/Livewire/Order/Order.php
+++ b/src/Livewire/Order/Order.php
@@ -884,6 +884,25 @@ class Order extends Component
         $this->schedule->nextExecutionDates = $this->schedule->getNextExecutionDates();
     }
 
+    public function updatingScheduleCronMethodsBasic(?string $value): void
+    {
+        $defaults = [
+            FrequenciesEnum::WeeklyOn->value => [1, '00:00'],
+            FrequenciesEnum::MonthlyOn->value => [1, '00:00'],
+            FrequenciesEnum::QuarterlyOn->value => [1, '00:00'],
+            FrequenciesEnum::YearlyOn->value => [1, 1, '00:00'],
+        ];
+
+        if (
+            $value === data_get($this->schedule->cron, 'methods.basic')
+            || ! array_key_exists($value, $defaults)
+        ) {
+            return;
+        }
+
+        $this->schedule->cron['parameters']['basic'] = $defaults[$value];
+    }
+
     #[Renderless]
     public function updatedScheduleDueAt(): void
     {

--- a/src/Rulesets/Schedule/UpdateScheduleRuleset.php
+++ b/src/Rulesets/Schedule/UpdateScheduleRuleset.php
@@ -25,8 +25,6 @@ class UpdateScheduleRuleset extends FluxRuleset
             'description' => 'string|nullable',
             'cron' => 'sometimes|required|array',
             'cron.methods' => 'sometimes|required|array',
-            // Without a basic frequency the schedule is silently skipped by the scheduler,
-            // so an update that carries a cron must carry a frequency with it.
             'cron.methods.basic' => [
                 'required_with:cron',
                 Rule::in(FrequenciesEnum::getBasicFrequencies()),

--- a/src/Rulesets/Schedule/UpdateScheduleRuleset.php
+++ b/src/Rulesets/Schedule/UpdateScheduleRuleset.php
@@ -25,8 +25,10 @@ class UpdateScheduleRuleset extends FluxRuleset
             'description' => 'string|nullable',
             'cron' => 'sometimes|required|array',
             'cron.methods' => 'sometimes|required|array',
+            // Without a basic frequency the schedule is silently skipped by the scheduler,
+            // so an update that carries a cron must carry a frequency with it.
             'cron.methods.basic' => [
-                'nullable',
+                'required_with:cron',
                 Rule::in(FrequenciesEnum::getBasicFrequencies()),
             ],
             'cron.methods.dayConstraint' => [

--- a/tests/Feature/Actions/Schedule/ScheduleActionTest.php
+++ b/tests/Feature/Actions/Schedule/ScheduleActionTest.php
@@ -31,3 +31,30 @@ test('a schedule with an unknown repeatable name can still be updated', function
 
     expect(data_get($updated->parameters, 'orderId'))->toBe(2);
 });
+
+test('updating a schedule cannot clear its repetition', function (): void {
+    $schedule = Schedule::query()->create([
+        'name' => 'ProcessSubscriptionOrder',
+        'class' => ProcessSubscriptionOrder::class,
+        'type' => 'invokable',
+        'cron' => [
+            'methods' => ['basic' => 'yearlyOn', 'dayConstraint' => null, 'timeConstraint' => null],
+            'parameters' => ['basic' => [4, 1, '06:00'], 'dayConstraint' => [], 'timeConstraint' => []],
+        ],
+        'parameters' => ['orderId' => 1],
+        'is_active' => true,
+    ]);
+
+    UpdateSchedule::assertValidationErrors(
+        [
+            'id' => $schedule->getKey(),
+            'cron' => [
+                'methods' => ['basic' => null, 'dayConstraint' => null, 'timeConstraint' => null],
+                'parameters' => ['basic' => [], 'dayConstraint' => [], 'timeConstraint' => []],
+            ],
+        ],
+        ['cron.methods.basic']
+    );
+
+    expect(data_get($schedule->refresh()->cron, 'methods.basic'))->toBe('yearlyOn');
+});

--- a/tests/Livewire/Order/OrderTest.php
+++ b/tests/Livewire/Order/OrderTest.php
@@ -761,6 +761,35 @@ test('subscription schedule functionality', function (): void {
     ]);
 });
 
+test('reselecting the same frequency keeps month and day', function (): void {
+    $subscriptionOrderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Subscription,
+    ]);
+
+    $this->order->update(['order_type_id' => $subscriptionOrderType->id]);
+
+    $schedule = Schedule::query()->create([
+        'name' => 'ProcessSubscriptionOrder',
+        'class' => ProcessSubscriptionOrder::class,
+        'type' => 'invokable',
+        'cron' => [
+            'methods' => ['basic' => 'yearlyOn', 'dayConstraint' => null, 'timeConstraint' => null],
+            'parameters' => ['basic' => [1, 24, '06:00'], 'dayConstraint' => [], 'timeConstraint' => []],
+        ],
+        'parameters' => ['orderId' => $this->order->id],
+        'is_active' => true,
+    ]);
+
+    $schedule->orders()->attach($this->order->id);
+
+    Livewire::test(OrderView::class, ['id' => $this->order->id])
+        ->assertSet('schedule.cron.parameters.basic', [1, 24, '06:00'])
+        ->set('schedule.cron.methods.basic', 'yearlyOn')
+        ->assertSet('schedule.cron.parameters.basic', [1, 24, '06:00'])
+        ->set('schedule.cron.methods.basic', 'monthlyOn')
+        ->assertSet('schedule.cron.parameters.basic', [1, '00:00']);
+});
+
 test('cancel subscription immediately deactivates schedule', function (): void {
     $subscriptionOrderType = OrderType::factory()->create([
         'order_type_enum' => OrderTypeEnum::Subscription,


### PR DESCRIPTION
Three findings in the subscription schedule, all reachable from the contract card on a subscription order.

## 1. An update could clear the repetition

`CreateScheduleRuleset` requires `cron.methods.basic`, `UpdateScheduleRuleset` allowed it to be null. Since `ScheduleRunCommand` selects repeatables with `whereNotNull('cron->methods->basic')`, an update that cleared the repetition left the schedule active and due, but permanently invisible to the scheduler.

The visible effect: a subscription order keeps its schedule, shows a next execution date, and never produces a child order. Nothing fails, nothing is logged. On the instance where this surfaced, a yearly subscription created with a start date in the past produced nothing at all, and it only came to light because a person went looking for the missing document.

`cron.methods.basic` is now `required_with:cron`, so an update that carries a cron has to carry a frequency. Updates that do not send `cron` at all (the cancellation path in `Order::cancelSubscription()`, which sends only `id`, `ends_at` and `is_active`) are unaffected.

## 2. The card named the frequencies differently than the dialog

The card offered the `…On` frequencies under the labels of the plain ones, so the same schedule read as "Yearly" in the card and "Yearly On" in the dialog right next to it. `yearly` and `yearlyOn` are separate cases in `FrequenciesEnum` with separate translations, so this was not a synonym.

## 3. Selecting the same frequency again threw the date away

`x-on:select` in the card reset `cron.parameters.basic` on every selection, including a selection that did not change anything. A schedule on 24 January silently became one on 1 January, and the save button next to it wrote that away. Seeding now happens in `updatingScheduleCronMethodsBasic()`, only when the frequency actually changes, and only for the four frequencies the card offers, so the dialog's other frequencies keep their own parameter shapes.

## What the audit log shows

The change log of the affected schedule records one save that set an end date and dropped the repetition in the same write:

```
old   cron.methods.basic  yearlyOn   parameters.basic  [4, 1, "06:00"]   ends_at  null
new   cron.methods.basic  null       parameters.basic  []                ends_at  2027-03-31
```

Twenty seconds later the same user activated the schedule. Nobody set out to remove the repetition, it went missing while the end date was set, and from then on the schedule was active, due, and invisible to the scheduler.

## Coverage

- updating a schedule to a null frequency fails validation and leaves the stored cron untouched
- reselecting the same frequency keeps month and day, switching to another one seeds it

Finding 3 lived in Alpine and is not reachable from the test suite. The test covers the server side replacement, not the removed JS branch.

## Existing rows

The validation closes the door, it does not repair what already walked through it. Rows that already carry a null frequency stay invisible to the scheduler. All reachable instances were checked read only: about 1015 active schedules, none without a frequency. The single damaged row was repaired by hand on the reporting instance. The query, for new instances and for the three that could not be reached:

```sql
SELECT id, name, class, parameters, due_at
FROM schedules
WHERE deleted_at IS NULL
  AND is_active = 1
  AND JSON_EXTRACT(cron, '$.methods.basic') IS NULL;
```

No data migration on purpose: a missing frequency cannot be inferred, monthly, quarterly and yearly are all plausible for the same row, and guessing would put a customer on the wrong billing cycle.

## Still open, out of scope here

`ScheduleRunCommand` skips such rows without a word. The missing feedback when an active, due schedule is passed over is a separate and larger topic.

Related: a schedule whose order was deleted keeps running and is counted as successful, because the invokable returns `false` instead of throwing. On one instance that is 54 of 639 active subscription schedules. Noted, not addressed here.

## Summary by Sourcery

Keep subscription schedules valid and preserve their configured dates when editing frequencies from the contract card.

Bug Fixes:
- Prevent schedule updates from clearing the required repetition frequency and making active schedules invisible to the scheduler.
- Preserve existing schedule dates when the current frequency is selected again, while seeding appropriate defaults only when switching frequencies.
- Correct contract card labels so “On” frequencies match their corresponding dialog labels.

Tests:
- Add coverage for rejecting null schedule frequencies without modifying stored schedules and for preserving or resetting schedule parameters when frequencies are reselected or changed.
