### PR TITLE
Allow renaming a media file in the folder tree

### DIFF
--- a/resources/views/livewire/folder-tree.blade.php
+++ b/resources/views/livewire/folder-tree.blade.php
@@ -430,6 +430,48 @@
                                     ></div>
                                 </template>
                             </div>
+                            @canAction(\FluxErp\Actions\Media\UpdateMedia::class)
+                                <div
+                                    class="flex flex-col gap-3 md:flex-row md:items-end"
+                                    x-cloak
+                                    x-show="!$wire.isReadonly && !readOnly"
+                                >
+                                    <div class="w-full md:flex-1">
+                                        <x-input
+                                            :label="__('Name')"
+                                            x-model="selection.name"
+                                        />
+                                    </div>
+                                    <x-button
+                                        class="w-full md:w-auto"
+                                        color="indigo"
+                                        :text="__('Save')"
+                                        x-on:click="
+                                            $wire
+                                                .saveMedia(selection)
+                                                .then((media) => {
+                                                    if (media) {
+                                                        this.selectionProxy =
+                                                            JSON.parse(
+                                                                JSON.stringify(
+                                                                    media,
+                                                                ),
+                                                            );
+                                                        this.selection =
+                                                            JSON.parse(
+                                                                JSON.stringify(
+                                                                    media,
+                                                                ),
+                                                            );
+                                                        updateNode(
+                                                            this.selectionProxy,
+                                                        );
+                                                    }
+                                                })
+                                        "
+                                    />
+                                </div>
+                            @endcanAction
                             <div class="flex flex-wrap gap-2">
                                 <x-button
                                     color="indigo"

--- a/src/Livewire/Support/FolderTree.php
+++ b/src/Livewire/Support/FolderTree.php
@@ -5,6 +5,7 @@ namespace FluxErp\Livewire\Support;
 use Exception;
 use FluxErp\Actions\Media\DeleteMedia;
 use FluxErp\Actions\Media\DeleteMediaCollection;
+use FluxErp\Actions\Media\UpdateMedia;
 use FluxErp\Actions\MediaFolder\DeleteMediaFolder;
 use FluxErp\Actions\MediaFolder\UpdateMediaFolder;
 use FluxErp\Livewire\Forms\MediaFolderForm;
@@ -233,6 +234,35 @@ abstract class FolderTree extends Component
                 )
                 ?? false
             );
+    }
+
+    #[Renderless]
+    public function saveMedia(array $media): false|array
+    {
+        if ($this->isReadonly || ! $this->findMedia((int) data_get($media, 'id'))) {
+            return false;
+        }
+
+        try {
+            $updated = UpdateMedia::make([
+                'id' => data_get($media, 'id'),
+                'name' => data_get($media, 'name'),
+                'file_name' => data_get($media, 'name'),
+            ])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (UnauthorizedException|ValidationException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        return array_merge(
+            $media,
+            $updated->only(['name', 'file_name']),
+            ['original_url' => $updated->getFullUrl()]
+        );
     }
 
     #[Renderless]

--- a/src/Livewire/Support/FolderTree.php
+++ b/src/Livewire/Support/FolderTree.php
@@ -324,7 +324,6 @@ abstract class FolderTree extends Component
             $updated = UpdateMedia::make([
                 'id' => $mediaId,
                 'name' => data_get($media, 'name'),
-                'file_name' => data_get($media, 'name'),
             ])
                 ->checkPermission()
                 ->validate()
@@ -335,11 +334,7 @@ abstract class FolderTree extends Component
             return false;
         }
 
-        return array_merge(
-            $media,
-            $updated->only(['name', 'file_name']),
-            ['original_url' => $updated->getFullUrl()]
-        );
+        return array_merge($media, $updated->only(['name']));
     }
 
     protected function resolveSubjectPath(array $subject, ?string $subjectPath): ?string

--- a/src/Livewire/Support/FolderTree.php
+++ b/src/Livewire/Support/FolderTree.php
@@ -237,35 +237,6 @@ abstract class FolderTree extends Component
     }
 
     #[Renderless]
-    public function saveMedia(array $media): false|array
-    {
-        if ($this->isReadonly || ! $this->findMedia((int) data_get($media, 'id'))) {
-            return false;
-        }
-
-        try {
-            $updated = UpdateMedia::make([
-                'id' => data_get($media, 'id'),
-                'name' => data_get($media, 'name'),
-                'file_name' => data_get($media, 'name'),
-            ])
-                ->checkPermission()
-                ->validate()
-                ->execute();
-        } catch (UnauthorizedException|ValidationException $e) {
-            exception_to_notifications($e, $this);
-
-            return false;
-        }
-
-        return array_merge(
-            $media,
-            $updated->only(['name', 'file_name']),
-            ['original_url' => $updated->getFullUrl()]
-        );
-    }
-
-    #[Renderless]
     public function saveFolder(array $attributes): false|array
     {
         $isNew = data_get($attributes, 'is_new', false);
@@ -337,6 +308,37 @@ abstract class FolderTree extends Component
                     'children',
                 ])
             )
+        );
+    }
+
+    #[Renderless]
+    public function saveMedia(array $media): false|array
+    {
+        $mediaId = (int) data_get($media, 'id');
+
+        if ($this->isReadonly || ! $this->findMedia($mediaId)) {
+            return false;
+        }
+
+        try {
+            $updated = UpdateMedia::make([
+                'id' => $mediaId,
+                'name' => data_get($media, 'name'),
+                'file_name' => data_get($media, 'name'),
+            ])
+                ->checkPermission()
+                ->validate()
+                ->execute();
+        } catch (UnauthorizedException|ValidationException $e) {
+            exception_to_notifications($e, $this);
+
+            return false;
+        }
+
+        return array_merge(
+            $media,
+            $updated->only(['name', 'file_name']),
+            ['original_url' => $updated->getFullUrl()]
         );
     }
 

--- a/tests/Livewire/FolderTreeTest.php
+++ b/tests/Livewire/FolderTreeTest.php
@@ -556,3 +556,48 @@ test('can delete real media folder', function (): void {
     // Verify folder is deleted
     expect(MediaFolder::whereKey($folder->getKey())->exists())->toBeFalse();
 });
+
+test('can rename media', function (): void {
+    Storage::fake('local');
+
+    $permission = Permission::findOrCreate('action.media.update', 'web');
+    $this->user->givePermissionTo($permission);
+
+    $media = $this->contact
+        ->addMedia(UploadedFile::fake()->image('test.jpg'))
+        ->toMediaCollection('attachments');
+
+    Livewire::test(FolderTreeTestClass::class, ['modelId' => $this->contact->getKey()])
+        ->call('saveMedia', [
+            'id' => $media->getKey(),
+            'name' => 'Renamed file',
+            'file_name' => $media->file_name,
+            'collection_name' => $media->collection_name,
+        ])
+        ->assertReturned(fn (mixed $returned): bool => data_get($returned, 'name') === 'Renamed file');
+
+    expect($media->refresh())
+        ->name->toBe('Renamed file')
+        ->file_name->toBe('Renamed-file.jpg');
+});
+
+test('cannot rename media of another model', function (): void {
+    Storage::fake('local');
+
+    $permission = Permission::findOrCreate('action.media.update', 'web');
+    $this->user->givePermissionTo($permission);
+
+    $foreignContact = Contact::factory()->create();
+    $media = $foreignContact
+        ->addMedia(UploadedFile::fake()->image('test.jpg'))
+        ->toMediaCollection('attachments');
+
+    Livewire::test(FolderTreeTestClass::class, ['modelId' => $this->contact->getKey()])
+        ->call('saveMedia', [
+            'id' => $media->getKey(),
+            'name' => 'Renamed file',
+        ])
+        ->assertReturned(false);
+
+    expect($media->refresh()->name)->not->toBe('Renamed file');
+});

--- a/tests/Livewire/FolderTreeTest.php
+++ b/tests/Livewire/FolderTreeTest.php
@@ -578,7 +578,7 @@ test('can rename media', function (): void {
 
     expect($media->refresh())
         ->name->toBe('Renamed file')
-        ->file_name->toBe('Renamed-file.jpg');
+        ->file_name->toBe('test.jpg');
 });
 
 test('cannot rename media of another model', function (): void {


### PR DESCRIPTION
## Problem

The file detail panel of the folder tree offers download, copy link and delete, but no way to change the name of an uploaded file. A file that arrives with a generated name stays unreadable in the tree, and there is no way to correct it from the UI.

## Change

- `FolderTree::saveMedia()` renames a media item through the existing `UpdateMedia` action.
- Only `name` is written. Renaming `file_name` would move the stored file and every generated conversion, which invalidates links that were already copied out, while the tree and the detail panel render `name`.
- The media is resolved through `findMedia()` first, so a component can only rename media that belongs to its own model.
- The blade adds a name input plus save button to the file detail panel, mirroring the folder rename block that already exists, gated by `@canAction(UpdateMedia::class)` and hidden for read-only components and collections.
- Two tests cover the rename and the rejection of a foreign media id.

## Summary by Sourcery

Enable authorized users to rename media files from the folder tree while protecting unrelated media and read-only views.

New Features:
- Add the ability to rename media files directly from the folder tree detail panel.

Enhancements:
- Restrict media renaming to items belonging to the current model and preserve the stored file name.

Tests:
- Add coverage for successful media renaming and rejection of media belonging to another model.