### PR TITLE
Fall back to the base language for translations

### DIFF
--- a/src/Http/Middleware/Localization.php
+++ b/src/Http/Middleware/Localization.php
@@ -38,15 +38,15 @@ class Localization
                 ->first(fn (string $lang) => $availableLocales->contains($lang));
         }
 
-        app()->setLocale(
-            $locale
+        $locale = $locale
             ?? resolve_static(Language::class, 'default')?->language_code
-            ?? config('app.locale')
-        );
+            ?? config('app.locale');
 
-        Number::useLocale(app()->getLocale());
-        Carbon::setLocale(app()->getLocale());
-        BaseCarbon::setLocale(app()->getLocale());
+        app()->setLocale(strstr($locale, '_', true) ?: $locale);
+
+        Number::useLocale($locale);
+        Carbon::setLocale($locale);
+        BaseCarbon::setLocale($locale);
 
         return $next($request);
     }

--- a/tests/Feature/Http/Middleware/LocalizationTest.php
+++ b/tests/Feature/Http/Middleware/LocalizationTest.php
@@ -126,3 +126,17 @@ test('passes request to next middleware', function (): void {
     expect($called)->toBeTrue();
     expect($response->getContent())->toBe('ok');
 });
+
+test('strips the region for translations but keeps it for formatting', function (): void {
+    $language = languageWithCode('en_US');
+
+    $this->user->update(['language_id' => $language->getKey()]);
+    $this->user->load('language');
+
+    $request = Request::create('/test', 'GET');
+
+    app(Localization::class)->handle($request, function (): void {});
+
+    expect(app()->getLocale())->toBe('en')
+        ->and(Carbon::getLocale())->toBe('en_US');
+});


### PR DESCRIPTION
## Problem

A user whose language is `en_US` sees raw translation keys as field labels. Measured in the shared local instance:

| locale | `__('nuxbe-mailgun::dns.sending_domain')` |
|---|---|
| `de` | Sende-Domain |
| `en` | Sending domain |
| `en_US` | `nuxbe-mailgun::dns.sending_domain` |

`app.fallback_locale` is `en`, and it does not save this case: the key stays untranslated.

The middleware passed the user's language code to `app()->setLocale()` unchanged, so the translator looked for `en_US`. Packages ship `de.json` and `en.json`, never `en_US.json`. This affects every package with translations, flux-core included, as soon as a user has a language with a region part — and `en_US` exists in the language table of that instance, so it is not a constructed case.

Found by the session working on nuxbe-mailgun, reproduced here.

## Fix

The locale is stripped to its base language **for translations only**:

```php
app()->setLocale(strstr($locale, '_', true) ?: $locale);

Number::useLocale($locale);
Carbon::setLocale($locale);
BaseCarbon::setLocale($locale);
```

The accept-language branch already matched on the base language; the user's own language code did not go through the same treatment.

Number and date formatting keep the full locale, because that is exactly where the region matters. Stripping it everywhere would have traded a broken label for a wrong date format — an `en_US` user would suddenly get British formats.

## Tests

`tests/Feature/Http/Middleware/LocalizationTest.php` gains one case, red before the fix: a user with `en_US` ends up with `en` for translations and `en_US` for formatting. The eight existing cases still pass, and the whole `tests/Feature/Http` suite is green (52 tests).

## Summary by Sourcery

Use base language locales for translations while preserving regional locales for number and date formatting.

Bug Fixes:
- Fall back to the base language for translations when a user's locale includes a regional suffix, preventing raw translation keys for locales such as en_US.

Enhancements:
- Preserve the full regional locale for number and date formatting so region-specific formats remain available.

Tests:
- Add coverage confirming regional locales use the base language for translations while retaining the full locale for formatting.