### PR TITLE
Stop validating the address snapshot against live addresses

### DIFF
--- a/src/Rulesets/Order/CreateOrderRuleset.php
+++ b/src/Rulesets/Order/CreateOrderRuleset.php
@@ -158,7 +158,6 @@ class CreateOrderRuleset extends FluxRuleset
             'address_delivery.id' => [
                 'nullable',
                 'integer',
-                app(ModelExists::class, ['model' => Address::class]),
             ],
 
             'delivery_state' => [

--- a/src/Rulesets/Order/UpdateOrderRuleset.php
+++ b/src/Rulesets/Order/UpdateOrderRuleset.php
@@ -135,6 +135,7 @@ class UpdateOrderRuleset extends FluxRuleset
                 'nullable',
             ],
             'address_delivery.id' => [
+                'nullable',
                 'integer',
             ],
 

--- a/src/Rulesets/Order/UpdateOrderRuleset.php
+++ b/src/Rulesets/Order/UpdateOrderRuleset.php
@@ -136,7 +136,6 @@ class UpdateOrderRuleset extends FluxRuleset
             ],
             'address_delivery.id' => [
                 'integer',
-                app(ModelExists::class, ['model' => Address::class]),
             ],
 
             'state' => [

--- a/tests/Feature/Actions/Order/ReplicateOrderTest.php
+++ b/tests/Feature/Actions/Order/ReplicateOrderTest.php
@@ -1376,3 +1376,42 @@ test('replicates with null agent_id when contact agent was deleted', function (O
     'retoure' => OrderTypeEnum::Retoure,
     'split order' => OrderTypeEnum::SplitOrder,
 ]);
+
+test('replicates an order whose address snapshot points at a deleted address', function (): void {
+    $contact = Contact::factory()->create(['has_delivery_lock' => false, 'credit_line' => null]);
+
+    $address = Address::factory()->create([
+        'contact_id' => $contact->getKey(),
+        'is_main_address' => true,
+    ]);
+
+    $deletedAddress = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $snapshot = ['id' => $deletedAddress->getKey(), 'company' => $deletedAddress->company];
+    $deletedAddress->delete();
+
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+    ]);
+
+    $order = Order::factory()->create([
+        'address_invoice_id' => $address->getKey(),
+        'address_delivery_id' => $address->getKey(),
+        'address_delivery' => $snapshot,
+        'address_invoice' => $snapshot,
+        'contact_id' => $contact->getKey(),
+        'currency_id' => Currency::default()->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+        'order_type_id' => $orderType->getKey(),
+        'payment_type_id' => PaymentType::default()->getKey(),
+        'price_list_id' => PriceList::default()->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+    ]);
+
+    $replicated = ReplicateOrder::make($order)
+        ->validate()
+        ->execute();
+
+    expect($replicated->exists)->toBeTrue()
+        ->and($replicated->getKey())->not->toBe($order->getKey());
+});

--- a/tests/Feature/Actions/Order/ReplicateOrderTest.php
+++ b/tests/Feature/Actions/Order/ReplicateOrderTest.php
@@ -1398,7 +1398,6 @@ test('replicates an order whose address snapshot points at a deleted address', f
         'address_invoice_id' => $address->getKey(),
         'address_delivery_id' => $address->getKey(),
         'address_delivery' => $snapshot,
-        'address_invoice' => $snapshot,
         'contact_id' => $contact->getKey(),
         'currency_id' => Currency::default()->getKey(),
         'language_id' => $this->defaultLanguage->getKey(),


### PR DESCRIPTION
## What went wrong

`orders.address_invoice` and `orders.address_delivery` are snapshots: the address as it read when the document was made, kept so that a later edit to the address cannot rewrite what was printed. Their `id` records where the copy came from. It is not a live foreign key, the live references are `address_invoice_id` and `address_delivery_id` and those are validated separately.

`CreateOrderRuleset` and `UpdateOrderRuleset` validated `address_delivery.id` with `ModelExists` anyway. That tied the frozen copy back to the addresses table, so deleting an address broke every later document that still carried the snapshot.

On one of our instances that stopped a subscription from renewing. The delivery address was deleted on 20 January, `ProcessSubscriptionOrder` then failed on 28 March, 28 April, 28 May, 28 June and 28 July, and five monthly invoices worth 2647.75 EUR were never written. Nothing looked broken from the outside: the schedule kept running, `last_run` advanced, and the reason sat in the activity log as a `ValidationException` that nobody reads.

Every replication path is affected, not just subscriptions: split orders and retoures carry the same snapshot.

## Change

The `ModelExists` rule is gone from `address_delivery.id` in both rulesets. The key stays validated as an integer.

`address_invoice.id` never carried that rule, so this is the same reasoning applied consistently to both snapshot columns.

## Test

`ReplicateOrderTest` gains a case that replicates an order whose snapshot points at a deleted address. It fails on main with "Der gewählte Wert für Lieferadress-ID ist ungültig" and passes with the change.

## Summary by Sourcery

Stop validating delivery address snapshots against the live addresses table so historical orders remain replicable after address deletion.

Bug Fixes:
- Allow order replication to succeed when a delivery address referenced by an address snapshot has since been deleted.

Enhancements:
- Treat delivery address snapshots consistently as non-live historical data while continuing to validate their identifiers as integers.

Tests:
- Add coverage for replicating orders whose delivery address snapshots refer to deleted addresses.