### PR TITLE
Show mails that were sent without a mail account

### DIFF
--- a/src/Livewire/Mail/Mail.php
+++ b/src/Livewire/Mail/Mail.php
@@ -199,7 +199,19 @@ class Mail extends CommunicationList
     {
         return $builder
             ->where('communication_type_enum', 'mail')
-            ->whereIntegerInRaw('mail_account_id', array_column($this->mailAccounts, 'id'))
+            ->where(function (Builder $builder): void {
+                $builder
+                    ->whereIntegerInRaw('mail_account_id', array_column($this->mailAccounts, 'id'))
+                    ->orWhere(function (Builder $builder): void {
+                        $builder
+                            ->whereNull('mail_account_id')
+                            ->where(function (Builder $builder): void {
+                                $builder
+                                    ->whereNull('created_by')
+                                    ->orWhere('created_by', auth()->user()?->getMorphClass() . ':' . auth()->id());
+                            });
+                    });
+            })
             ->when($this->folderId, function (Builder $builder): void {
                 $builder->whereIntegerInRaw('mail_folder_id', $this->selectedFolderIds);
             });

--- a/tests/Livewire/Mail/MailTest.php
+++ b/tests/Livewire/Mail/MailTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use FluxErp\Enums\CommunicationTypeEnum;
 use FluxErp\Livewire\Mail\Mail;
+use FluxErp\Models\Communication;
 use Livewire\Livewire;
 
 test('renders successfully', function (): void {
@@ -14,4 +16,42 @@ test('compose mail dispatches create event to edit mail', function (): void {
         ->test(Mail::class)
         ->call('composeMail')
         ->assertDispatchedTo('edit-mail', 'create', values: []);
+});
+
+test('lists mails sent without a mail account', function (): void {
+    $own = Communication::factory()->create([
+        'communication_type_enum' => CommunicationTypeEnum::Mail,
+        'mail_account_id' => null,
+    ]);
+
+    Communication::query()
+        ->whereKey($own->getKey())
+        ->update(['created_by' => $this->user->getMorphClass() . ':' . $this->user->getKey()]);
+
+    $unowned = Communication::factory()->create([
+        'communication_type_enum' => CommunicationTypeEnum::Mail,
+        'mail_account_id' => null,
+    ]);
+
+    Communication::query()->whereKey($unowned->getKey())->update(['created_by' => null]);
+
+    $foreign = Communication::factory()->create([
+        'communication_type_enum' => CommunicationTypeEnum::Mail,
+        'mail_account_id' => null,
+    ]);
+
+    Communication::query()
+        ->whereKey($foreign->getKey())
+        ->update(['created_by' => $this->user->getMorphClass() . ':' . ($this->user->getKey() + 1000)]);
+
+    $component = Livewire::actingAs($this->user)
+        ->test(Mail::class)
+        ->instance();
+
+    $getBuilder = new ReflectionMethod($component, 'getBuilder');
+    $ids = $getBuilder->invoke($component, Communication::query())->pluck('id');
+
+    expect($ids)->toContain($own->getKey())
+        ->and($ids)->toContain($unowned->getKey())
+        ->and($ids)->not->toContain($foreign->getKey());
 });


### PR DESCRIPTION
## Problem

A mail sent through the default mailer goes out, is received, and is stored correctly — and is invisible to everyone in the mail module.

`EditMail` maps the "default" choice to `null` when sending, so the communication is written with `mail_account_id = null`. The list then filtered like this:

```php
->whereIntegerInRaw('mail_account_id', array_column($this->mailAccounts, 'id'))
```

`whereIntegerInRaw` drops every null, so those rows never appear. Verified on a live instance: the list showed exactly the ten communications carrying an account id, and every row without one was missing, including the mail the user had just sent and received.

This affects every installation, not one customer.

## Fix

Accountless mails are listed next to the account ones, but only where they belong to the user asking:

- `created_by` pointing at the current user, or
- `created_by` empty, which is what mails written from queue jobs carry

Mails another user sent through the default mailer stay out of the list. The alternative, showing every accountless mail to everyone with access to the module, would have put personal correspondence in front of colleagues.

## Test

`tests/Livewire/Mail/MailTest.php` covers all three cases against the query itself: own mail listed, ownerless mail listed, another user's mail not listed. `created_by` is written past the model so the user-modification trait does not overwrite the fixture.

## Summary by Sourcery

Make accountless mails visible in the mail module without exposing other users' personal correspondence.

Bug Fixes:
- Include mails sent without a mail account in the mail list when they belong to the current user or have no owner, while excluding accountless mails belonging to other users.

Tests:
- Add coverage for listing owned and ownerless accountless mails and excluding another user's mail.