### PR TITLE
Pin the seeded test language to English

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -54,9 +54,13 @@ pest()
             'is_default' => true,
         ]);
 
-        $this->defaultLanguage = Language::default() ?? Language::factory()->create([
-            'is_default' => true,
-        ]);
+        $this->defaultLanguage = Language::default() ?? tap(
+            Language::query()->firstOrCreate(
+                ['language_code' => 'en'],
+                Language::factory()->make(['language_code' => 'en'])->toArray()
+            ),
+            fn (Language $language) => $language->update(['is_default' => true])
+        );
 
         VatRate::default() ?? VatRate::factory()->create([
             'is_default' => true,

--- a/tests/Unit/Models/AddressSalutationTest.php
+++ b/tests/Unit/Models/AddressSalutationTest.php
@@ -9,11 +9,14 @@ use FluxErp\Models\Tenant;
 it('uses the address language for the salutation translation', function (): void {
     app()->setLocale('de');
 
-    $english = Language::factory()->create([
-        'language_code' => 'en',
-        'iso_name' => 'en',
-        'name' => 'English',
-    ]);
+    $english = Language::query()->firstOrCreate(
+        ['language_code' => 'en'],
+        Language::factory()->make([
+            'language_code' => 'en',
+            'iso_name' => 'en',
+            'name' => 'English',
+        ])->toArray()
+    );
 
     $tenant = Tenant::factory()->create();
     $contact = Contact::factory()


### PR DESCRIPTION
## Problem

The default language for tests came from the factory, which draws a random faker language code. Every test that formats a number or a date therefore depended on which locale the dice produced.

That is where this failure on an unrelated pull request came from:

```
FAILED  Tests\Feature\Api\OvertimeBalanceBoxWidgetTest > widget api returns …
Expected: ३.००h
To contain: 3
```

The run had seeded a locale with Devanagari digits, so the formatted sum contained no ASCII `3`. Nothing about the widget was wrong.

The same randomness produced the `fr` collision that `LanguageActionTest` used to work around by deleting a language, until that delete hit a foreign key (fixed in #2027).

## Fix

The seeded default language is `en`, created with `firstOrCreate` so a worker that already has that code keeps it.

An abandoned branch from June, `fix/deterministic-test-locale`, pinned it to `de` for the same reason, coming from the browser side: the random code lands in the html lang attribute and drives the JS number formatters. That branch never became a pull request and predates the current test bootstrap. `en` is chosen here because the core ships English keys and only a `de.json`, so an English locale keeps assertions on literal strings honest.

## Verification

`OvertimeBalanceBoxWidgetTest` and `LanguageActionTest` pass, and the whole `Feature` suite runs green in parallel: 1494 passed. The only local failures left are two Imagick cases that need Ghostscript and pass in the CI image.

## Summary by Sourcery

Pin test environments to a stable English language so locale-dependent formatting and language assertions remain reliable.

Bug Fixes:
- Make seeded test language selection deterministic by consistently using English instead of a random locale.
- Prevent English language test setup from creating duplicate language records.