### PR TITLE
Let the comment and queue monitor broadcast carry only their key

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -14,6 +14,7 @@ use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Arr;
 use Spatie\MediaLibrary\HasMedia;
 
 class Comment extends FluxModel implements HasMedia, IsSubscribable
@@ -90,7 +91,7 @@ class Comment extends FluxModel implements HasMedia, IsSubscribable
 
     public function broadcastWith(): array
     {
-        $data = $this->toArray();
+        $data = Arr::except($this->toArray(), ['comment']);
         $data['user'] = $this->user;
 
         return ['model' => $data];

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -14,7 +14,6 @@ use FluxErp\Traits\Model\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Arr;
 use Spatie\MediaLibrary\HasMedia;
 
 class Comment extends FluxModel implements HasMedia, IsSubscribable
@@ -87,14 +86,6 @@ class Comment extends FluxModel implements HasMedia, IsSubscribable
     public function broadcastChannel(): string
     {
         return $this->model_type . '.' . $this->model_id;
-    }
-
-    public function broadcastWith(): array
-    {
-        $data = Arr::except($this->toArray(), ['comment']);
-        $data['user'] = $this->user;
-
-        return ['model' => $data];
     }
 
     // Attributes

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Context;
 use Throwable;
@@ -105,16 +104,6 @@ class QueueMonitor extends FluxModel
     }
 
     // Public methods
-    public function broadcastWith(): array
-    {
-        return [
-            'model' => Arr::except(
-                $this->withoutRelations()->toArray(),
-                ['exception', 'exception_message', 'data', 'accept', 'reject']
-            ),
-        ];
-    }
-
     public function canBeRetried(): bool
     {
         return ! $this->retried

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -107,8 +107,12 @@ class QueueMonitor extends FluxModel
     // Public methods
     public function broadcastWith(): array
     {
-        // This ensures the payload doesnt get too large
-        return ['model' => Arr::except($this->withoutRelations()->toArray(), ['exception'])];
+        return [
+            'model' => Arr::except(
+                $this->withoutRelations()->toArray(),
+                ['exception', 'exception_message', 'data', 'accept', 'reject']
+            ),
+        ];
     }
 
     public function canBeRetried(): bool

--- a/tests/Unit/BroadcastPayloadSizeTest.php
+++ b/tests/Unit/BroadcastPayloadSizeTest.php
@@ -4,21 +4,17 @@ use FluxErp\Models\Comment;
 use FluxErp\Models\Contact;
 use FluxErp\Models\QueueMonitor;
 
-test('the queue monitor broadcast leaves out the unbounded columns', function (): void {
+test('the queue monitor broadcast carries nothing but its key', function (): void {
     $monitor = QueueMonitor::factory()->create([
         'data' => ['payload' => str_repeat('x', 20000)],
         'exception' => str_repeat('y', 20000),
         'exception_message' => str_repeat('z', 20000),
     ]);
 
-    $payload = $monitor->broadcastWith()['model'];
-
-    expect($payload)->not->toHaveKeys(['exception', 'exception_message', 'data', 'accept', 'reject'])
-        ->and($payload)->toHaveKeys(['id', 'name', 'state'])
-        ->and(strlen(json_encode($payload)))->toBeLessThan(10240);
+    expect($monitor->broadcastWith())->toBe(['model' => ['id' => $monitor->getKey()]]);
 });
 
-test('the comment broadcast leaves out the comment body', function (): void {
+test('the comment broadcast carries nothing but its key', function (): void {
     $contact = Contact::factory()->create();
 
     $comment = Comment::factory()->create([
@@ -27,9 +23,5 @@ test('the comment broadcast leaves out the comment body', function (): void {
         'comment' => str_repeat('x', 20000),
     ]);
 
-    $payload = $comment->broadcastWith()['model'];
-
-    expect($payload)->not->toHaveKey('comment')
-        ->and($payload)->toHaveKey('id')
-        ->and(strlen(json_encode($payload)))->toBeLessThan(10240);
+    expect($comment->broadcastWith())->toBe(['model' => ['id' => $comment->getKey()]]);
 });

--- a/tests/Unit/BroadcastPayloadSizeTest.php
+++ b/tests/Unit/BroadcastPayloadSizeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use FluxErp\Models\Comment;
+use FluxErp\Models\Contact;
+use FluxErp\Models\QueueMonitor;
+
+test('the queue monitor broadcast leaves out the unbounded columns', function (): void {
+    $monitor = QueueMonitor::factory()->create([
+        'data' => ['payload' => str_repeat('x', 20000)],
+        'exception' => str_repeat('y', 20000),
+        'exception_message' => str_repeat('z', 20000),
+    ]);
+
+    $payload = $monitor->broadcastWith()['model'];
+
+    expect($payload)->not->toHaveKeys(['exception', 'exception_message', 'data', 'accept', 'reject'])
+        ->and($payload)->toHaveKeys(['id', 'name', 'state'])
+        ->and(strlen(json_encode($payload)))->toBeLessThan(10240);
+});
+
+test('the comment broadcast leaves out the comment body', function (): void {
+    $contact = Contact::factory()->create();
+
+    $comment = Comment::factory()->create([
+        'model_type' => morph_alias(Contact::class),
+        'model_id' => $contact->getKey(),
+        'comment' => str_repeat('x', 20000),
+    ]);
+
+    $payload = $comment->broadcastWith()['model'];
+
+    expect($payload)->not->toHaveKey('comment')
+        ->and($payload)->toHaveKey('id')
+        ->and(strlen(json_encode($payload)))->toBeLessThan(10240);
+});


### PR DESCRIPTION
`Comment` and `QueueMonitor` were the only two models in the package overriding `broadcastWith()`. Every other model broadcasts nothing but its key, through `$broadcastOnlyKey`, which has been the default since the trait was reworked in `4caddd592` (December 2025).

Both overrides predate that mechanism — `Comment` since the first commit in March 2023, `QueueMonitor` since the queue monitoring feature in May 2024, where the intent is written in the code it carried: *This ensures the payload doesnt get too large*. So the full payload is age, not intent.

Trimming single columns would only move the ceiling: a comment body, an exception, a serialized job payload all grow without bound, and the next unbounded column reintroduces the problem. Dropping the overrides removes the ceiling instead and makes the two models consistent with the rest.

## Nothing in the package reads those payloads

- `resources/js/components/comments.js` listens for `.CommentCreated`, `.CommentUpdated` and `.CommentDeleted` and calls `loadComments()` — it discards the payload and reloads from the server
- no view and no Livewire component listens for queue monitor events at all

## Verification

    tests/Unit/BroadcastPayloadSizeTest.php   2 passed
    Unit suite                                468 passed
    every comment suite                        41 passed

## Summary by Sourcery

Keep unbounded model fields out of broadcast payloads to prevent oversized broadcast failures.

Bug Fixes:
- Prevent comment and queue-monitor broadcasts from including unbounded content that can exceed provider payload limits.

Enhancements:
- Restore the default key-only broadcast payload for comments and queue monitors while preserving the existing broadcast contract.
- Add regression tests covering large comment, job payload, and exception fields.

Tests:
- Add unit tests verifying comment and queue-monitor broadcasts contain only the model key even when large fields are populated.