### PR TITLE
Carry the column labels by sticky or by the floating head, never by both

### DIFF
--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -1,11 +1,19 @@
 /**
- * Keeps a table's column labels in view while the page scrolls.
+ * Keeps a table's column labels in view while the page scrolls, for the tables
+ * that plain sticky cannot serve.
  *
- * Plain sticky cannot do it: a sticky element binds to its nearest scrolling
- * ancestor, and that is the overflow-x wrapper around the table. The wrapper
- * only ever scrolls sideways, so the head would stick to something that never
- * moves vertically. Dropping that overflow would move the table's horizontal
- * scrolling onto the page, taking the toolbar out of view to the right.
+ * Sticky binds to the nearest scrolling ancestor, and a table wide enough to
+ * need horizontal scrolling has one: its wrapper. That wrapper only ever
+ * scrolls sideways, so the head would stick to something that never moves
+ * vertically. Dropping the overflow is no answer either, it would move the
+ * table's horizontal scrolling onto the page and take the toolbar out of view
+ * to the right.
+ *
+ * A table that fits has no such wrapper to bind to, and there sticky holds the
+ * head by itself. Running both would not add up, it would fight: the shift
+ * below puts a transform on the row, a transform makes that row the containing
+ * block of its own sticky cells, and the head ends up somewhere in the middle
+ * of the table. So this only takes over where sticky cannot reach.
  *
  * Nudging the head on every scroll event is no good either: the events arrive
  * after the frame has been painted, so the head visibly trails one frame
@@ -136,6 +144,43 @@ const followsPage = (table) => {
     return true;
 };
 
+/**
+ * Leaves the row where the table put it.
+ *
+ * A travel of zero is not enough to achieve that: the animation still runs and
+ * still writes a transform, an identity matrix. That is a transform all the
+ * same, and it is enough to make the row the containing block of its own sticky
+ * cells, which is exactly what has to be avoided here. So the animation comes
+ * off the row rather than being handed a zero.
+ */
+const stand = (labels) => {
+    labels.style.setProperty('--flux-head-travel', '0px');
+    labels.style.setProperty('animation-name', 'none');
+    labels.style.removeProperty('transform');
+};
+
+/**
+ * Whether anything above the table turns into a scroll port. That is what
+ * decides who carries the head: with a scroll port sticky binds to a box that
+ * never moves vertically and cannot hold, without one it binds to the page and
+ * holds the head on its own.
+ */
+const stickyIsBound = (table) => {
+    for (
+        let node = table.parentElement;
+        node && node !== document.body;
+        node = node.parentElement
+    ) {
+        const style = getComputedStyle(node);
+
+        if (style.overflowX !== 'visible' || style.overflowY !== 'visible') {
+            return true;
+        }
+    }
+
+    return false;
+};
+
 const measure = (table) => {
     const head = table.querySelector('thead');
     const body = table.querySelector('tbody');
@@ -153,8 +198,10 @@ const measure = (table) => {
         return;
     }
 
-    if (!followsPage(table)) {
-        labels.style.setProperty('--flux-head-travel', '0px');
+    // Nothing to do where the table sits in a scroll area of its own, and
+    // nothing to do where sticky already holds the head.
+    if (!followsPage(table) || !stickyIsBound(table)) {
+        stand(labels);
 
         return;
     }
@@ -167,7 +214,7 @@ const measure = (table) => {
     // anyway would only lay the row over the few rows there are, and with a
     // single one it covers the entire table.
     if (bodyRect.bottom - headRect.top <= window.innerHeight - edge) {
-        labels.style.setProperty('--flux-head-travel', '0px');
+        stand(labels);
 
         return;
     }
@@ -184,6 +231,7 @@ const measure = (table) => {
     // whatever comes next.
     const travel = bodyRect.bottom - height - headRect.top;
 
+    labels.style.removeProperty('animation-name');
     labels.style.setProperty('--flux-head-start', `${start}px`);
     labels.style.setProperty('--flux-head-end', `${start + travel}px`);
     labels.style.setProperty('--flux-head-travel', `${travel}px`);

--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -142,9 +142,9 @@ const stand = (labels) => {
     labels.style.removeProperty('transform');
 };
 
-const stickyIsBound = (table) => {
+const stickyIsBound = (labels) => {
     for (
-        let node = table.parentElement;
+        let node = labels.parentElement;
         node && node !== document.body;
         node = node.parentElement
     ) {
@@ -178,7 +178,7 @@ const measure = (table) => {
         return;
     }
 
-    if (!followsPage(table) || !stickyIsBound(table)) {
+    if (!followsPage(table) || !stickyIsBound(labels)) {
         stand(labels);
 
         return;

--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -1,19 +1,11 @@
 /**
- * Keeps a table's column labels in view while the page scrolls, for the tables
- * that plain sticky cannot serve.
+ * Keeps a table's column labels in view while the page scrolls.
  *
- * Sticky binds to the nearest scrolling ancestor, and a table wide enough to
- * need horizontal scrolling has one: its wrapper. That wrapper only ever
- * scrolls sideways, so the head would stick to something that never moves
- * vertically. Dropping the overflow is no answer either, it would move the
- * table's horizontal scrolling onto the page and take the toolbar out of view
- * to the right.
- *
- * A table that fits has no such wrapper to bind to, and there sticky holds the
- * head by itself. Running both would not add up, it would fight: the shift
- * below puts a transform on the row, a transform makes that row the containing
- * block of its own sticky cells, and the head ends up somewhere in the middle
- * of the table. So this only takes over where sticky cannot reach.
+ * Plain sticky cannot do it: a sticky element binds to its nearest scrolling
+ * ancestor, and that is the overflow-x wrapper around the table. The wrapper
+ * only ever scrolls sideways, so the head would stick to something that never
+ * moves vertically. Dropping that overflow would move the table's horizontal
+ * scrolling onto the page, taking the toolbar out of view to the right.
  *
  * Nudging the head on every scroll event is no good either: the events arrive
  * after the frame has been painted, so the head visibly trails one frame
@@ -144,27 +136,12 @@ const followsPage = (table) => {
     return true;
 };
 
-/**
- * Leaves the row where the table put it.
- *
- * A travel of zero is not enough to achieve that: the animation still runs and
- * still writes a transform, an identity matrix. That is a transform all the
- * same, and it is enough to make the row the containing block of its own sticky
- * cells, which is exactly what has to be avoided here. So the animation comes
- * off the row rather than being handed a zero.
- */
 const stand = (labels) => {
     labels.style.setProperty('--flux-head-travel', '0px');
     labels.style.setProperty('animation-name', 'none');
     labels.style.removeProperty('transform');
 };
 
-/**
- * Whether anything above the table turns into a scroll port. That is what
- * decides who carries the head: with a scroll port sticky binds to a box that
- * never moves vertically and cannot hold, without one it binds to the page and
- * holds the head on its own.
- */
 const stickyIsBound = (table) => {
     for (
         let node = table.parentElement;
@@ -173,8 +150,6 @@ const stickyIsBound = (table) => {
     ) {
         const style = getComputedStyle(node);
 
-        // `clip` is the exception: it cuts the overflow away without becoming a
-        // scroll container, so sticky binds straight past it.
         if (
             (style.overflowX !== 'visible' && style.overflowX !== 'clip') ||
             (style.overflowY !== 'visible' && style.overflowY !== 'clip')
@@ -203,8 +178,6 @@ const measure = (table) => {
         return;
     }
 
-    // Nothing to do where the table sits in a scroll area of its own, and
-    // nothing to do where sticky already holds the head.
     if (!followsPage(table) || !stickyIsBound(table)) {
         stand(labels);
 

--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -173,7 +173,12 @@ const stickyIsBound = (table) => {
     ) {
         const style = getComputedStyle(node);
 
-        if (style.overflowX !== 'visible' || style.overflowY !== 'visible') {
+        // `clip` is the exception: it cuts the overflow away without becoming a
+        // scroll container, so sticky binds straight past it.
+        if (
+            (style.overflowX !== 'visible' && style.overflowX !== 'clip') ||
+            (style.overflowY !== 'visible' && style.overflowY !== 'clip')
+        ) {
             return true;
         }
     }

--- a/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
@@ -12,7 +12,11 @@ use FluxErp\Models\PriceList;
 beforeEach(function (): void {
     $contact = Contact::factory()->create();
     $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
-    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true, 'is_hidden' => false]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
     $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
     $priceList = PriceList::factory()->create();
     $currency = Currency::factory()->create();
@@ -29,7 +33,7 @@ beforeEach(function (): void {
     ]);
 });
 
-it('leaves the labels alone where sticky can hold them', function (): void {
+test('leaves the labels alone where sticky can hold them', function (): void {
     $page = waitForDataTable(
         visit(route('orders.orders'))
             ->assertRoute('orders.orders')
@@ -65,7 +69,7 @@ it('leaves the labels alone where sticky can hold them', function (): void {
         ->and($data['rowAnimation'])->toBe('none');
 });
 
-it('keeps carrying the labels of a table too wide to fit', function (): void {
+test('keeps carrying the labels of a table too wide to fit', function (): void {
     $page = waitForDataTable(
         visit(route('orders.orders'))
             ->assertRoute('orders.orders')

--- a/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * The column labels are carried either by plain sticky or by the floating head,
- * never by both. Which one applies depends on whether anything above the table
- * turns into a scroll port, and only a real browser resolves that.
- */
-
 use FluxErp\Enums\OrderTypeEnum;
 use FluxErp\Models\Address;
 use FluxErp\Models\Contact;
@@ -70,9 +64,6 @@ it('leaves the labels alone where sticky can hold them', function (): void {
 
     $data = is_array($result) ? ($result[0] ?? $result) : $result;
 
-    // Where nothing binds sticky, the row must carry no transform at all. An
-    // identity matrix would still make it the containing block of its own
-    // sticky cells and push the labels into the middle of the table.
     if ($data['stickyIsBound'] === false) {
         expect($data['transform'])->toBe('none')
             ->and($data['animationName'])->toBe('none');

--- a/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * The column labels are carried either by plain sticky or by the floating head,
+ * never by both. Which one applies depends on whether anything above the table
+ * turns into a scroll port, and only a real browser resolves that.
+ */
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create(['order_type_enum' => OrderTypeEnum::Order, 'is_active' => true, 'is_hidden' => false]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+    $priceList = PriceList::factory()->create();
+    $currency = Currency::factory()->create();
+
+    Order::factory()->count(30)->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+});
+
+it('leaves the labels alone where sticky can hold them', function (): void {
+    $page = waitForDataTable(
+        visit(route('orders.orders'))
+            ->assertRoute('orders.orders')
+            ->assertNoSmoke()
+    );
+
+    $result = $page->script(<<<'JS'
+        async () => {
+            const table = document.querySelector('[tall-datatable]');
+            const labels = table.querySelector('thead').rows[0];
+
+            let bound = false;
+            for (let node = table.parentElement; node && node !== document.body; node = node.parentElement) {
+                const s = getComputedStyle(node);
+                if (s.overflowX !== 'visible' || s.overflowY !== 'visible') {
+                    bound = true;
+                    break;
+                }
+            }
+
+            window.scrollTo(0, 600);
+            await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+            return {
+                stickyIsBound: bound,
+                transform: getComputedStyle(labels).transform,
+                travel: labels.style.getPropertyValue('--flux-head-travel'),
+                animationName: getComputedStyle(labels).animationName,
+            };
+        }
+    JS);
+
+    $data = is_array($result) ? ($result[0] ?? $result) : $result;
+
+    // Where nothing binds sticky, the row must carry no transform at all. An
+    // identity matrix would still make it the containing block of its own
+    // sticky cells and push the labels into the middle of the table.
+    if ($data['stickyIsBound'] === false) {
+        expect($data['transform'])->toBe('none')
+            ->and($data['animationName'])->toBe('none');
+    } else {
+        expect($data['travel'])->not->toBe('0px');
+    }
+});

--- a/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
@@ -64,3 +64,51 @@ it('leaves the labels alone where sticky can hold them', function (): void {
         ->and($data['rowTransform'])->toBe('none')
         ->and($data['rowAnimation'])->toBe('none');
 });
+
+it('keeps carrying the labels of a table too wide to fit', function (): void {
+    $page = waitForDataTable(
+        visit(route('orders.orders'))
+            ->assertRoute('orders.orders')
+            ->assertNoSmoke()
+    );
+
+    $result = $page->script(<<<'JS'
+        async () => {
+            const root = document.querySelector('[tall-datatable]');
+            const table = root.querySelector('table');
+            const wrapper = table.parentElement;
+            const labels = table.querySelector('thead').rows[0];
+            const settle = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+            wrapper.style.width = '500px';
+            table.style.width = '1600px';
+
+            table.querySelectorAll('tbody tr').forEach((row) => {
+                row.style.height = '120px';
+            });
+
+            const filler = document.createElement('div');
+            filler.style.height = '10px';
+            document.body.appendChild(filler);
+            await settle();
+            await new Promise(r => setTimeout(r, 400));
+
+            const head = table.querySelector('thead').getBoundingClientRect();
+            const body = table.querySelector('tbody').getBoundingClientRect();
+
+            return {
+                tallerThanScreen: (body.bottom - head.top) > window.innerHeight,
+                boundByWrapper: wrapper.scrollWidth > wrapper.clientWidth,
+                wrapperOverflowX: getComputedStyle(wrapper).overflowX,
+                travel: labels.style.getPropertyValue('--flux-head-travel'),
+            };
+        }
+    JS);
+
+    $data = is_array($result) ? ($result[0] ?? $result) : $result;
+
+    expect($data['tallerThanScreen'])->toBeTrue()
+        ->and($data['boundByWrapper'])->toBeTrue()
+        ->and($data['wrapperOverflowX'])->toBe('auto')
+        ->and($data['travel'])->not->toBe('0px');
+});

--- a/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadBoundaryTest.php
@@ -39,35 +39,28 @@ it('leaves the labels alone where sticky can hold them', function (): void {
     $result = $page->script(<<<'JS'
         async () => {
             const table = document.querySelector('[tall-datatable]');
+            const body = table.querySelector('tbody');
             const labels = table.querySelector('thead').rows[0];
-
-            let bound = false;
-            for (let node = table.parentElement; node && node !== document.body; node = node.parentElement) {
-                const s = getComputedStyle(node);
-                if (s.overflowX !== 'visible' || s.overflowY !== 'visible') {
-                    bound = true;
-                    break;
-                }
-            }
+            const cell = [...labels.cells].find(el => getComputedStyle(el).position === 'sticky');
 
             window.scrollTo(0, 600);
             await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
 
+            const rows = body.getBoundingClientRect();
+
             return {
-                stickyIsBound: bound,
-                transform: getComputedStyle(labels).transform,
-                travel: labels.style.getPropertyValue('--flux-head-travel'),
-                animationName: getComputedStyle(labels).animationName,
+                rowsStillVisible: rows.bottom > 0 && rows.top < window.innerHeight,
+                cellTop: Math.round(cell.getBoundingClientRect().top),
+                rowTransform: getComputedStyle(labels).transform,
+                rowAnimation: getComputedStyle(labels).animationName,
             };
         }
     JS);
 
     $data = is_array($result) ? ($result[0] ?? $result) : $result;
 
-    if ($data['stickyIsBound'] === false) {
-        expect($data['transform'])->toBe('none')
-            ->and($data['animationName'])->toBe('none');
-    } else {
-        expect($data['travel'])->not->toBe('0px');
-    }
+    expect($data['rowsStillVisible'])->toBeTrue()
+        ->and($data['cellTop'])->toBeGreaterThanOrEqual(0)
+        ->and($data['rowTransform'])->toBe('none')
+        ->and($data['rowAnimation'])->toBe('none');
 });


### PR DESCRIPTION
The floating head exists because sticky binds to the nearest scrolling ancestor, and a table wide enough to scroll sideways has one: its wrapper. That wrapper never moves vertically, so the labels would stick to nothing.

A table that fits has no such wrapper. Since `tall-datatables` v2.6.9 it does not even get one — the scroll port is only taken while the table is actually wider than its wrapper — and there plain sticky holds the labels by itself.

Both at once do not add up, they fight. The shift puts a `transform` on the label row, a transform makes that row the containing block of its own sticky cells, and the labels end up in the middle of the table. Measured on a customer instance, page scrolled to 1500:

```
row top      56
cell top   1025
```

That is the customer's screenshot: the column labels standing across the data rows.

So the boundary is now explicit. Where nothing above the table turns into a scroll port, the floating head stands down and leaves the labels to sticky. Where a scroll port exists — a table too wide to fit — nothing changes, the floating head stays in charge exactly as before.

Standing down means taking the animation off the row, not handing it a travel of zero. A travel of zero still leaves the animation running and still writes a transform, an identity matrix (`matrix(1, 0, 0, 1, 0, 0)`), and that alone creates the containing block this has to avoid.

A browser test covers it: with nothing binding sticky, the label row must carry no transform and no animation at all. Reverting the change turns it red on exactly that assertion.

## Summary by Sourcery

Ensure column labels are carried by either sticky positioning or the floating header, never both.

Bug Fixes:
- Prevent the floating header from disrupting sticky column labels when no scroll container binds them, eliminating misplaced labels caused by row transforms.
- Preserve floating-header behavior for horizontally overflowing tables.

Enhancements:
- Make the floating-header boundary explicit by disabling its animation and transform when sticky positioning can operate independently.

Tests:
- Add browser coverage for sticky-only tables and horizontally overflowing tables to verify label positioning and floating-header behavior.