### PR TITLE
Carry the labels of a short table while the page scrolls

### DIFF
--- a/resources/js/components/data-table-floating-head.js
+++ b/resources/js/components/data-table-floating-head.js
@@ -166,7 +166,13 @@ const measure = (table) => {
     // nothing that could scroll underneath its labels. Letting them travel
     // anyway would only lay the row over the few rows there are, and with a
     // single one it covers the entire table.
-    if (bodyRect.bottom - headRect.top <= window.innerHeight - edge) {
+    const pageTravel =
+        document.documentElement.scrollHeight - window.innerHeight;
+
+    if (
+        pageTravel <= 0 &&
+        bodyRect.bottom - headRect.top <= window.innerHeight - edge
+    ) {
         labels.style.setProperty('--flux-head-travel', '0px');
 
         return;

--- a/tests/Browser/Features/DataTable/FloatingHeadOnScrollingPageTest.php
+++ b/tests/Browser/Features/DataTable/FloatingHeadOnScrollingPageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use FluxErp\Enums\OrderTypeEnum;
+use FluxErp\Models\Address;
+use FluxErp\Models\Contact;
+use FluxErp\Models\Currency;
+use FluxErp\Models\Order;
+use FluxErp\Models\OrderType;
+use FluxErp\Models\PaymentType;
+use FluxErp\Models\PriceList;
+
+beforeEach(function (): void {
+    $contact = Contact::factory()->create();
+    $address = Address::factory()->create(['contact_id' => $contact->getKey()]);
+    $orderType = OrderType::factory()->create([
+        'order_type_enum' => OrderTypeEnum::Order,
+        'is_active' => true,
+        'is_hidden' => false,
+    ]);
+    $paymentType = PaymentType::factory()->hasAttached($this->dbTenant, relationship: 'tenants')->create();
+    $priceList = PriceList::factory()->create();
+    $currency = Currency::factory()->create();
+
+    Order::factory()->count(5)->create([
+        'order_type_id' => $orderType->getKey(),
+        'address_invoice_id' => $address->getKey(),
+        'contact_id' => $contact->getKey(),
+        'payment_type_id' => $paymentType->getKey(),
+        'price_list_id' => $priceList->getKey(),
+        'tenant_id' => $this->dbTenant->getKey(),
+        'currency_id' => $currency->getKey(),
+        'language_id' => $this->defaultLanguage->getKey(),
+    ]);
+});
+
+test('carries the labels of a short table while the page scrolls', function (): void {
+    $page = waitForDataTable(
+        visit(route('orders.orders'))
+            ->assertRoute('orders.orders')
+            ->assertNoSmoke()
+    );
+
+    $result = $page->script(<<<'JS'
+        async () => {
+            const root = document.querySelector('[tall-datatable]');
+            const table = root.querySelector('table');
+            const wrapper = table.parentElement;
+            const labels = table.querySelector('thead').rows[0];
+            const settle = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+            wrapper.style.width = '500px';
+            table.style.width = '1600px';
+
+            const filler = document.createElement('div');
+            filler.style.height = '2500px';
+            document.body.appendChild(filler);
+            await settle();
+            await new Promise(r => setTimeout(r, 400));
+
+            const head = table.querySelector('thead').getBoundingClientRect();
+            const body = table.querySelector('tbody').getBoundingClientRect();
+
+            return {
+                boundByWrapper: wrapper.scrollWidth > wrapper.clientWidth,
+                fitsOnScreen: (body.bottom - head.top) <= window.innerHeight,
+                pageScrolls: document.documentElement.scrollHeight > window.innerHeight,
+                travel: labels.style.getPropertyValue('--flux-head-travel'),
+            };
+        }
+    JS);
+
+    $data = is_array($result) ? ($result[0] ?? $result) : $result;
+
+    expect($data['boundByWrapper'])->toBeTrue()
+        ->and($data['fitsOnScreen'])->toBeTrue()
+        ->and($data['pageScrolls'])->toBeTrue()
+        ->and($data['travel'])->not->toBe('0px');
+});


### PR DESCRIPTION
`measure()` asks whether the table fits between the bar and the lower edge of the screen, and then lets the labels stand. That reasoning holds only while the page stays put.

It is readable from the code alone: nothing in that branch asks whether the page can scroll. Put anything below the table — a dashboard, a second panel, a comment section — and the table travels through the screen whether it fits or not. Its labels leave the top with rows still below them, and since `travel` is `0px`, nothing carries them.

So the shortcut now also asks whether the page has anywhere to scroll. A page that cannot scroll keeps the old behaviour exactly: the labels stay where the table put them, which is what the comment above that branch describes.

The browser test widens the table past its wrapper — otherwise the wrapper takes no scroll port and the case does not arise — keeps it short enough to fit on screen, and puts a filler below so the page scrolls. `travel` then has to be something other than `0px`. Reverting the guard turns it red, so it discriminates rather than merely passing.

**Note on how this was verified.** An earlier version of this description quoted numbers measured through a remotely driven Chrome tab. Such a tab is `document.visibilityState === "hidden"` and does not render, and without a frame neither a `ResizeObserver` nor a scroll driven animation runs — those numbers described the un-rendered state and are gone from this description. The reasoning above stands on the code, and the test result stands on a Pest browser run with a real renderer, confirmed by its red counter-check.

## Summary by Sourcery

Keep floating table labels attached while scrolling pages that extend beyond the viewport.

Bug Fixes:
- Keep floating table labels moving with the table when a short table is displayed on a vertically scrollable page.

Tests:
- Add browser coverage verifying that labels travel for a horizontally overflowing, short table on a page with additional vertical content.