### PR TITLE
Stop the order position factory from rolling a gross position

### DIFF
--- a/database/factories/OrderPositionFactory.php
+++ b/database/factories/OrderPositionFactory.php
@@ -34,7 +34,7 @@ class OrderPositionFactory extends Factory
 
             'is_alternative' => fake()->boolean(15),
             'is_free_text' => fake()->boolean(15),
-            'is_net' => fake()->boolean(90),
+            'is_net' => true,
         ];
     }
 }


### PR DESCRIPTION
`OrderPositionFactory` set `is_net` from `fake()->boolean(90)`, so one position in ten came out gross.

A test that pins `unit_net_price` alone then leaves the gross price empty. Replicating such a position fails validation in `CreateOrderPosition`:

    The Unit Price field is required when none of Product ID / Price List ID / Price ID are present.

That is the intermittent `Tests\Unit\Invokable\ProcessSubscriptionOrderTest` failure in CI, roughly one run in five. Reproduced by pinning `is_net` to `false`, which yields the identical message.

Tests that need a gross position already set `is_net` themselves, in nine places.

Verified locally: Unit suite 466 passed, `tests/Livewire/Order` plus `tests/Feature/Actions/Order` plus `ContractRemainingBalanceTest` 192 passed.

## Summary by Sourcery

Bug Fixes:
- Make order position factories consistently create net positions by default, preventing intermittent validation failures when only a net unit price is configured.