### PR TITLE
Make filling order positions actually write them

### DIFF
--- a/src/Actions/OrderPosition/FillOrderPositions.php
+++ b/src/Actions/OrderPosition/FillOrderPositions.php
@@ -69,10 +69,6 @@ class FillOrderPositions extends FluxAction
         return $orderPositions;
     }
 
-    /**
-     * The order's tenant, read once per run: a fill carries many positions and
-     * they all belong to the same order.
-     */
     protected function orderTenantId(): ?int
     {
         return $this->orderTenantId ??= resolve_static(Order::class, 'query')
@@ -82,16 +78,7 @@ class FillOrderPositions extends FluxAction
 
     protected function prepareForValidation(): void
     {
-        // An omitted or false simulate never survived into the validated data,
-        // so performAction() passed null into a bool parameter and the whole
-        // request died with a TypeError. Filling positions is the default.
-        // filter_var, not a cast: a request carries "false" as a string, which
-        // every cast would read as true and silently skip the write.
-        $this->data['simulate'] = filter_var(
-            $this->data['simulate'] ?? false,
-            FILTER_VALIDATE_BOOLEAN,
-            FILTER_NULL_ON_FAILURE
-        ) ?? false;
+        $this->data['simulate'] ??= false;
     }
 
     protected function validateData(): void
@@ -163,8 +150,6 @@ class FillOrderPositions extends FluxAction
             $orderPosition->parent_id = $parentId;
         }
 
-        // A position belongs to its order's tenant. CreateOrderPosition derives
-        // it the same way; without it the insert hits a NOT NULL column.
         $orderPosition->tenant_id ??= $this->orderTenantId();
 
         // Fill product info if not already filled
@@ -184,9 +169,6 @@ class FillOrderPositions extends FluxAction
         // If simulate = false, save order position, keep track of saved ids
         if (! $simulate) {
             $discounts = $orderPosition->discounts;
-            // unit_price is an input the price calculation reads, not a column.
-            // CreateOrderPosition drops it before saving; leaving it on here
-            // made every free-text position fail on an unknown column.
             unset($orderPosition->discounts, $orderPosition->unit_price);
             $orderPosition->save();
 

--- a/src/Actions/OrderPosition/FillOrderPositions.php
+++ b/src/Actions/OrderPosition/FillOrderPositions.php
@@ -67,6 +67,14 @@ class FillOrderPositions extends FluxAction
         return $orderPositions;
     }
 
+    protected function prepareForValidation(): void
+    {
+        // An omitted or false simulate never survived into the validated data,
+        // so performAction() passed null into a bool parameter and the whole
+        // request died with a TypeError. Filling positions is the default.
+        $this->data['simulate'] = (bool) ($this->data['simulate'] ?? false);
+    }
+
     protected function validateData(): void
     {
         parent::validateData();
@@ -136,6 +144,12 @@ class FillOrderPositions extends FluxAction
             $orderPosition->parent_id = $parentId;
         }
 
+        // A position belongs to its order's tenant. CreateOrderPosition derives
+        // it the same way; without it the insert hits a NOT NULL column.
+        $orderPosition->tenant_id ??= resolve_static(Order::class, 'query')
+            ->whereKey($this->data['order_id'])
+            ->value('tenant_id');
+
         // Fill product info if not already filled
         if ($orderPosition->product) {
             $orderPosition->ean_code = $orderPosition->ean_code ?: $orderPosition->product->ean;
@@ -153,7 +167,10 @@ class FillOrderPositions extends FluxAction
         // If simulate = false, save order position, keep track of saved ids
         if (! $simulate) {
             $discounts = $orderPosition->discounts;
-            unset($orderPosition->discounts);
+            // unit_price is an input the price calculation reads, not a column.
+            // CreateOrderPosition drops it before saving; leaving it on here
+            // made every free-text position fail on an unknown column.
+            unset($orderPosition->discounts, $orderPosition->unit_price);
             $orderPosition->save();
 
             $existingDiscounts = $discounts->filter(fn ($discount) => $discount['id'] ?? false)->toArray();

--- a/src/Actions/OrderPosition/FillOrderPositions.php
+++ b/src/Actions/OrderPosition/FillOrderPositions.php
@@ -18,6 +18,8 @@ use Illuminate\Validation\ValidationException;
 
 class FillOrderPositions extends FluxAction
 {
+    protected ?int $orderTenantId = null;
+
     public static function models(): array
     {
         return [OrderPosition::class, Order::class];
@@ -67,12 +69,29 @@ class FillOrderPositions extends FluxAction
         return $orderPositions;
     }
 
+    /**
+     * The order's tenant, read once per run: a fill carries many positions and
+     * they all belong to the same order.
+     */
+    protected function orderTenantId(): ?int
+    {
+        return $this->orderTenantId ??= resolve_static(Order::class, 'query')
+            ->whereKey($this->getData('order_id'))
+            ->value('tenant_id');
+    }
+
     protected function prepareForValidation(): void
     {
         // An omitted or false simulate never survived into the validated data,
         // so performAction() passed null into a bool parameter and the whole
         // request died with a TypeError. Filling positions is the default.
-        $this->data['simulate'] = (bool) ($this->data['simulate'] ?? false);
+        // filter_var, not a cast: a request carries "false" as a string, which
+        // every cast would read as true and silently skip the write.
+        $this->data['simulate'] = filter_var(
+            $this->data['simulate'] ?? false,
+            FILTER_VALIDATE_BOOLEAN,
+            FILTER_NULL_ON_FAILURE
+        ) ?? false;
     }
 
     protected function validateData(): void
@@ -146,9 +165,7 @@ class FillOrderPositions extends FluxAction
 
         // A position belongs to its order's tenant. CreateOrderPosition derives
         // it the same way; without it the insert hits a NOT NULL column.
-        $orderPosition->tenant_id ??= resolve_static(Order::class, 'query')
-            ->whereKey($this->data['order_id'])
-            ->value('tenant_id');
+        $orderPosition->tenant_id ??= $this->orderTenantId();
 
         // Fill product info if not already filled
         if ($orderPosition->product) {

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -529,3 +529,21 @@ test('fill order positions still simulates when asked to', function (): void {
 
     expect(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(0);
 });
+
+test('fill order positions reads a textual simulate as the caller meant it', function (): void {
+    // A request carries "false" as a string. A plain cast reads that as true
+    // and silently skips the write the caller asked for.
+    FillOrderPositions::make([
+        'order_id' => $this->order->getKey(),
+        'simulate' => 'false',
+        'order_positions' => [[
+            'order_id' => $this->order->getKey(),
+            'name' => 'Chili con Carne',
+            'vat_rate_id' => $this->vatRate->getKey(),
+            'amount' => 2,
+            'unit_price' => 4.90,
+        ]],
+    ])->validate()->execute();
+
+    expect(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(1);
+});

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -2,6 +2,7 @@
 
 use FluxErp\Actions\OrderPosition\CreateOrderPosition;
 use FluxErp\Actions\OrderPosition\DeleteOrderPosition;
+use FluxErp\Actions\OrderPosition\FillOrderPositions;
 use FluxErp\Actions\OrderPosition\UpdateOrderPosition;
 use FluxErp\Enums\BundleTypeEnum;
 use FluxErp\Enums\OrderTypeEnum;
@@ -492,4 +493,39 @@ test('the performance period end may not precede its start', function (): void {
         ],
         'system_delivery_date_end'
     );
+});
+
+test('fill order positions defaults simulate to filling them', function (): void {
+    // Omitting simulate left it null, and performAction() passed that null into
+    // a bool parameter — the whole request died with a TypeError before a single
+    // position was written.
+    $result = FillOrderPositions::make([
+        'order_id' => $this->order->getKey(),
+        'order_positions' => [[
+            'order_id' => $this->order->getKey(),
+            'name' => 'Chili con Carne',
+            'vat_rate_id' => $this->vatRate->getKey(),
+            'amount' => 2,
+            'unit_price' => 4.90,
+        ]],
+    ])->validate()->execute();
+
+    expect($result)->toBeArray()
+        ->and(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(1);
+});
+
+test('fill order positions still simulates when asked to', function (): void {
+    FillOrderPositions::make([
+        'order_id' => $this->order->getKey(),
+        'simulate' => true,
+        'order_positions' => [[
+            'order_id' => $this->order->getKey(),
+            'name' => 'Chili con Carne',
+            'vat_rate_id' => $this->vatRate->getKey(),
+            'amount' => 2,
+            'unit_price' => 4.90,
+        ]],
+    ])->validate()->execute();
+
+    expect(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(0);
 });

--- a/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
+++ b/tests/Feature/Actions/OrderPosition/OrderPositionActionTest.php
@@ -496,9 +496,6 @@ test('the performance period end may not precede its start', function (): void {
 });
 
 test('fill order positions defaults simulate to filling them', function (): void {
-    // Omitting simulate left it null, and performAction() passed that null into
-    // a bool parameter — the whole request died with a TypeError before a single
-    // position was written.
     $result = FillOrderPositions::make([
         'order_id' => $this->order->getKey(),
         'order_positions' => [[
@@ -528,22 +525,4 @@ test('fill order positions still simulates when asked to', function (): void {
     ])->validate()->execute();
 
     expect(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(0);
-});
-
-test('fill order positions reads a textual simulate as the caller meant it', function (): void {
-    // A request carries "false" as a string. A plain cast reads that as true
-    // and silently skips the write the caller asked for.
-    FillOrderPositions::make([
-        'order_id' => $this->order->getKey(),
-        'simulate' => 'false',
-        'order_positions' => [[
-            'order_id' => $this->order->getKey(),
-            'name' => 'Chili con Carne',
-            'vat_rate_id' => $this->vatRate->getKey(),
-            'amount' => 2,
-            'unit_price' => 4.90,
-        ]],
-    ])->validate()->execute();
-
-    expect(OrderPosition::query()->where('order_id', $this->order->getKey())->count())->toBe(1);
 });


### PR DESCRIPTION
`FillOrderPositions` could simulate but never save. Three problems sat in that path, each of which alone aborts the request before a position is written:

- An omitted `simulate` arrived in `performAction()` as `null` and was passed into a `bool` parameter — `TypeError`, 500, nothing written. It now defaults to filling, which is what the action is for.
- `unit_price` is an input the price calculation reads, not a column on `order_positions`. `CreateOrderPosition` unsets it before saving; the fill path did not, so every free-text position failed on an unknown column.
- The position never inherited its order's `tenant_id`, so the insert hit a NOT NULL column. It is now derived from the order, the same way `CreateOrderPosition` does it.

Two tests cover the behaviour: omitting `simulate` writes the position, passing `simulate: true` still writes nothing. The existing order-position and order suites stay green (178 tests).

## Summary by Sourcery

Make FillOrderPositions persist completed order positions by default while retaining opt-in simulation.

Bug Fixes:
- Fix filling order positions so non-simulated requests persist positions successfully by default.
- Preserve simulation behavior when explicitly requested without writing positions.

Enhancements:
- Ensure filled positions inherit the order tenant and exclude calculation-only pricing data before persistence.

Tests:
- Add coverage for default persistence and explicit simulation behavior.