### PR TITLE
Let a package put its own badges on an address

### DIFF
--- a/resources/views/livewire/contact/addresses.blade.php
+++ b/resources/views/livewire/contact/addresses.blade.php
@@ -105,6 +105,14 @@
                                                     color="amber"
                                                     :text="__('Invoice Address')"
                                                 />
+                                                <template
+                                                    x-for="badge in addressItem.badges ?? []"
+                                                    x-bind:key="badge"
+                                                >
+                                                    <x-badge color="gray" light>
+                                                        <span x-text="badge"></span>
+                                                    </x-badge>
+                                                </template>
                                             @show
                                         </div>
                                     </div>

--- a/resources/views/livewire/contact/addresses.blade.php
+++ b/resources/views/livewire/contact/addresses.blade.php
@@ -106,11 +106,17 @@
                                                     :text="__('Invoice Address')"
                                                 />
                                                 <template
-                                                    x-for="badge in addressItem.badges ?? []"
+                                                    x-for="
+                                                        badge in
+                                                            addressItem.badges ??
+                                                        []
+                                                    "
                                                     x-bind:key="badge"
                                                 >
                                                     <x-badge color="gray" light>
-                                                        <span x-text="badge"></span>
+                                                        <span
+                                                            x-text="badge"
+                                                        ></span>
                                                     </x-badge>
                                                 </template>
                                             @show


### PR DESCRIPTION
The address list in the contact view renders three fixed badges: main address, delivery address, invoice address. Anything else a package knows about an address had nowhere to go, short of overriding the view, which a customer project usually already does for its own badge.

The list now also renders every entry of `addressItem.badges`, a plain array of strings on the address entries the component loads. A Livewire component hook can append to it without touching the view:

```php
$addresses[$i]['badges'] = array_merge(data_get($address, 'badges', []), $names);
```

Strings, not objects, on purpose. A colour would have to be a Tailwind class decided at build time, so a package cannot pass one anyway; the badges render in a neutral grey next to the built in ones.

## Summary by Sourcery

Display package-defined badges in the contact address list without requiring view overrides.

New Features:
- Allow address entries to display package-provided custom badges alongside the built-in address badges.

Enhancements:
- Render custom address badges as neutral grey labels with safe handling for entries that do not define any badges.